### PR TITLE
googlemock: change guess of googletest's relative location from ../gtest to ../googletest

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -15,7 +15,7 @@ option(gmock_build_tests "Build all of Google Mock's own tests." OFF)
 if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/gtest/CMakeLists.txt")
   set(gtest_dir gtest)
 else()
-  set(gtest_dir ../gtest)
+  set(gtest_dir ../googletest)
 endif()
 
 # Defines pre_project_set_up_hermetic_build() and set_up_hermetic_build().


### PR DESCRIPTION
Pretty trivial miss from the merging of the two tree.

Thanks.