### PR TITLE
FIX add missing blank line between text and table

### DIFF
--- a/googletest/docs/Primer.md
+++ b/googletest/docs/Primer.md
@@ -108,6 +108,7 @@ streamed to an assertion, it will be translated to UTF-8 when printed.
 ## Basic Assertions ##
 
 These assertions do basic true/false condition testing.
+
 | **Fatal assertion** | **Nonfatal assertion** | **Verifies** |
 |:--------------------|:-----------------------|:-------------|
 | `ASSERT_TRUE(`_condition_`)`;  | `EXPECT_TRUE(`_condition_`)`;   | _condition_ is true |


### PR DESCRIPTION
The markdown interpreter don't interpret the table otherwise.