### PR TITLE
gmock unit tests: avoid make_tuple for lvalueref tuples.

### DIFF
--- a/googlemock/test/gmock-generated-actions_test.cc
+++ b/googlemock/test/gmock-generated-actions_test.cc
@@ -376,7 +376,8 @@ class SubstractAction : public ActionInterface<int(int, int)> {  // NOLINT
 TEST(WithArgsTest, NonInvokeAction) {
   Action<int(const string&, int, int)> a =  // NOLINT
       WithArgs<2, 1>(MakeAction(new SubstractAction));
-  EXPECT_EQ(8, a.Perform(make_tuple(string("hi"), 2, 10)));
+  string s("hello");
+  EXPECT_EQ(8, a.Perform(tuple<const string&, int, int>(s, 2, 10)));
 }
 
 // Tests using WithArgs to pass all original arguments in the original order.
@@ -753,7 +754,7 @@ TEST(ActionPMacroTest, CanReferenceArgumentAndParameterTypes) {
 TEST(ActionPMacroTest, WorksInCompatibleMockFunction) {
   Action<std::string(const std::string& s)> a1 = Plus("tail");
   const std::string re = "re";
-  EXPECT_EQ("retail", a1.Perform(make_tuple(re)));
+  EXPECT_EQ("retail", a1.Perform(tuple<const std::string&>(re)));
 }
 
 // Tests that we can use ACTION*() to define actions overloaded on the
@@ -795,7 +796,7 @@ TEST(ActionPnMacroTest, WorksFor3Parameters) {
 
   Action<std::string(const std::string& s)> a2 = Plus("tail", "-", ">");
   const std::string re = "re";
-  EXPECT_EQ("retail->", a2.Perform(make_tuple(re)));
+  EXPECT_EQ("retail->", a2.Perform(tuple<const std::string&>(re)));
 }
 
 ACTION_P4(Plus, p0, p1, p2, p3) { return arg0 + p0 + p1 + p2 + p3; }

--- a/googlemock/test/gmock-more-actions_test.cc
+++ b/googlemock/test/gmock-more-actions_test.cc
@@ -327,7 +327,9 @@ TEST(InvokeTest, FunctionThatTakes10Arguments) {
 TEST(InvokeTest, FunctionWithUnusedParameters) {
   Action<int(int, int, double, const string&)> a1 =
       Invoke(SumOfFirst2);
-  EXPECT_EQ(12, a1.Perform(make_tuple(10, 2, 5.6, string("hi"))));
+  string s("hi");
+  EXPECT_EQ(12, a1.Perform(
+    tuple<int, int, double, const string&>(10, 2, 5.6, s)));
 
   Action<int(int, int, bool, int*)> a2 =
       Invoke(SumOfFirst2);
@@ -379,7 +381,8 @@ TEST(InvokeMethodTest, Binary) {
   Foo foo;
   Action<string(const string&, char)> a = Invoke(&foo, &Foo::Binary);
   string s("Hell");
-  EXPECT_EQ("Hello", a.Perform(make_tuple(s, 'o')));
+  EXPECT_EQ("Hello", a.Perform(
+      tuple<const string&, char>(s, 'o')));
 }
 
 // Tests using Invoke() with a ternary method.


### PR DESCRIPTION
Googlemock has some tuples containing lvalue refs in its unit tests. These tuples are created with make_tuple, which is given temporaries. The make_tuple is in a function argument list.

A possibly overzealous static_assert in libc++'s std::tuple ctor
is firing in our 'Perform(make_tuple("hi"))' calls, so
we can't use its make_tuple here. Instead we will use
explicitly-constructed tuples constructed from non-temporary strings.

Workaround for llvm bug:
    https://llvm.org/bugs/show_bug.cgi?id=20855

An alternative to https://github.com/google/googletest/pull/580 .