### PR TITLE
Allow explicit bool operators to work with ASSERT_TRUE variants

### DIFF
--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1186,7 +1186,7 @@ class NativeArray {
 #define GTEST_TEST_BOOLEAN_(expression, text, actual, expected, fail) \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
   if (const ::testing::AssertionResult gtest_ar_ = \
-      ::testing::AssertionResult(expression)) \
+      ::testing::AssertionResult(bool(expression))) \
     ; \
   else \
     fail(::testing::internal::GetBoolAssertionFailureMessage(\


### PR DESCRIPTION
Inserting an explicit cast to bool allows the explicit bool operator
to function just as it would in an if statement.