### PR TITLE
Fix C++11 clang builds in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ before-install:
   - uname -a
   - $CC --version
   - $CXX --version
+  - $CXX -v
+
 install:
 # /usr/bin/gcc is 4.6 always, but gcc-X.Y is available.
 - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
@@ -20,6 +22,8 @@ install:
 - echo ${PATH}
 - echo ${CXX}
 - ${CXX} --version
+- $CXX -v
+- apt-cache search clang
 addons:
   apt:
     sources:
@@ -27,11 +31,11 @@ addons:
     packages:
     - gcc-4.9
     - g++-4.9
-    - clang-3.6
+    - clang
     - valgrind
 os:
   - linux
-  - osx
+#  - osx
 language: cpp
 compiler:
   - gcc
@@ -42,8 +46,8 @@ env:
 #    - LIBSTDC_VERSION=5
     - CLANG_VERSION=3.6
   matrix:
-    - GTEST_TARGET=googletest SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=debug   VERBOSE_MAKE=true VERBOSE
-    - GTEST_TARGET=googlemock SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=debug   VERBOSE_MAKE=true VERBOSE
+#    - GTEST_TARGET=googletest SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=debug   VERBOSE_MAKE=true VERBOSE
+#    - GTEST_TARGET=googlemock SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=debug   VERBOSE_MAKE=true VERBOSE
     - GTEST_TARGET=googlemock SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=debug CXX_FLAGS=-std=c++11  VERBOSE_MAKE=true VERBOSE
 #    - GTEST_TARGET=googletest SHARED_LIB=ON  STATIC_LIB=ON CMAKE_PKG=ON  BUILD_TYPE=release VERBOSE_MAKE=false
 #    - GTEST_TARGET=googlemock SHARED_LIB=ON  STATIC_LIB=ON CMAKE_PKG=ON  BUILD_TYPE=release VERBOSE_MAKE=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ compiler:
   - clang
 script: ./travis.sh
 env:
+  global:
+#    - LIBSTDC_VERSION=5
+    - CLANG_VERSION=3.6
   matrix:
     - GTEST_TARGET=googletest SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=debug   VERBOSE_MAKE=true VERBOSE
     - GTEST_TARGET=googlemock SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=debug   VERBOSE_MAKE=true VERBOSE

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 # /usr/bin/gcc is 4.6 always, but gcc-X.Y is available.
 - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
 # /usr/bin/clang is 3.4, lets override with modern one.
-- if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.7" CC="clang-3.7"; fi
+- if [ "$CXX" = "clang++" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then export CXX="clang++-3.7" CC="clang-3.7"; fi
 - echo ${PATH}
 - echo ${CXX}
 - ${CXX} --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ install:
 # /usr/bin/clang is our version already, and clang-X.Y does not exist.
 #- if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.7" CC="clang-3.7"; fi
 - echo ${PATH}
-- ls /usr/local
-- ls /usr/local/bin
-- export PATH=/usr/local/bin:/usr/bin:${PATH}
 - echo ${CXX}
 - ${CXX} --version
 addons:
@@ -30,7 +27,7 @@ addons:
     packages:
     - gcc-4.9
     - g++-4.9
-    - clang
+    - clang-3.6
     - valgrind
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ install:
 - ${CXX} -v
 addons:
   apt:
+    # List of whitelisted in travis packages for ubuntu-precise can be found here:
+    #   https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
+    # List of whitelisted in travis apt-sources:
+    #   https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
     sources:
     - ubuntu-toolchain-r-test
     - llvm-toolchain-precise-3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,12 @@
 # http://about.travis-ci.org/docs/user/build-configuration/
 # This file can be validated on:
 # http://lint.travis-ci.org/
-# See also
-# http://stackoverflow.com/questions/22111549/travis-ci-with-clang-3-4-and-c11/30925448#30925448
-# to allow C++11, though we are not yet building with -std=c++11
 
 install:
 # /usr/bin/gcc is 4.6 always, but gcc-X.Y is available.
 - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
-# /usr/bin/clang is our version already, and clang-X.Y does not exist.
-#- if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.7" CC="clang-3.7"; fi
+# /usr/bin/clang is 3.4, lets override with modern one.
+- if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.7" CC="clang-3.7"; fi
 - echo ${PATH}
 - echo ${CXX}
 - ${CXX} --version
@@ -19,11 +16,11 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
-    - llvm-toolchain-precise-3.6
+    - llvm-toolchain-precise-3.7
     packages:
     - gcc-4.9
     - g++-4.9
-    - clang-3.6
+    - clang-3.7
     - valgrind
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,6 @@
 # http://stackoverflow.com/questions/22111549/travis-ci-with-clang-3-4-and-c11/30925448#30925448
 # to allow C++11, though we are not yet building with -std=c++11
 
-before-install:
-  # Debug information
-  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then lsb_release -a; fi
-  - uname -a
-  - $CC --version
-  - $CXX --version
-  - $CXX -v
-
 install:
 # /usr/bin/gcc is 4.6 always, but gcc-X.Y is available.
 - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
@@ -22,32 +14,29 @@ install:
 - echo ${PATH}
 - echo ${CXX}
 - ${CXX} --version
-- $CXX -v
-- apt-cache search clang
+- ${CXX} -v
 addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
+    - llvm-toolchain-precise-3.6
     packages:
     - gcc-4.9
     - g++-4.9
-    - clang
+    - clang-3.6
     - valgrind
 os:
   - linux
-#  - osx
+  - osx
 language: cpp
 compiler:
   - gcc
   - clang
 script: ./travis.sh
 env:
-  global:
-#    - LIBSTDC_VERSION=5
-    - CLANG_VERSION=3.6
   matrix:
-#    - GTEST_TARGET=googletest SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=debug   VERBOSE_MAKE=true VERBOSE
-#    - GTEST_TARGET=googlemock SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=debug   VERBOSE_MAKE=true VERBOSE
+    - GTEST_TARGET=googletest SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=debug   VERBOSE_MAKE=true VERBOSE
+    - GTEST_TARGET=googlemock SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=debug   VERBOSE_MAKE=true VERBOSE
     - GTEST_TARGET=googlemock SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=debug CXX_FLAGS=-std=c++11  VERBOSE_MAKE=true VERBOSE
 #    - GTEST_TARGET=googletest SHARED_LIB=ON  STATIC_LIB=ON CMAKE_PKG=ON  BUILD_TYPE=release VERBOSE_MAKE=false
 #    - GTEST_TARGET=googlemock SHARED_LIB=ON  STATIC_LIB=ON CMAKE_PKG=ON  BUILD_TYPE=release VERBOSE_MAKE=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@
 # http://stackoverflow.com/questions/22111549/travis-ci-with-clang-3-4-and-c11/30925448#30925448
 # to allow C++11, though we are not yet building with -std=c++11
 
+before-install:
+  # Debug information
+  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then lsb_release -a; fi
+  - uname -a
+  - $CC --version
+  - $CXX --version
 install:
 # /usr/bin/gcc is 4.6 always, but gcc-X.Y is available.
 - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi


### PR DESCRIPTION
Existing Travis configuration installs clang 3.0, which seems not being able to locate gcc 4.9.
Using white-listed clang 3.7 package instead.