### PR TITLE
Add an environment variable to control the location of temporary files

### DIFF
--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -953,7 +953,15 @@ class CapturedStream {
     // use /sdcard.
     char name_template[] = "/sdcard/gtest_captured_stream.XXXXXX";
 #  else
-    char name_template[] = "/tmp/captured_stream.XXXXXX";
+    char name_template[256];
+    char *test_tmpdir = getenv("GTEST_TMP_DIR");
+    if (test_tmpdir != NULL && test_tmpdir[0] != '\0') {
+      snprintf(name_template, sizeof(name_template),
+               "%s/captured_stream.XXXXXX", test_tmpdir);
+    } else {
+      const char *default_template = "/tmp/captured_stream.XXXXXX";
+      strcpy(name_template, default_template);
+    }
 #  endif  // GTEST_OS_LINUX_ANDROID
     const int captured_fd = mkstemp(name_template);
     filename_ = name_template;


### PR DESCRIPTION
Bazel says in their test environment documentation
(http://bazel.io/docs/test-encyclopedia.html) that tests should not
write to /tmp. However, googletest unconditionally writes files there.
This fixes that by having googletest use the GTEST_TMP_DIR
environment variable instead, which Bazel will soon set automatically
when running tests.

I've previously submitted this [on the mailing list](https://groups.google.com/forum/#!topic/googletestframework/_yvYL1KoFbk), but it seems like the more common path for submissions is pull requests.
