### PR TITLE
Allow specifying file/line for SCOPED_TRACE

### DIFF
--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -2116,9 +2116,14 @@ GTEST_API_ AssertionResult DoubleLE(const char* expr1, const char* expr2,
 // of the dummy variable name, thus allowing multiple SCOPED_TRACE()s
 // to appear in the same block - as long as they are on different
 // lines.
-#define SCOPED_TRACE(message) \
+#define SCOPED_TRACE(...) GTEST_VA_SELECT_(SCOPED_TRACE, __VA_ARGS__) 
+#define SCOPED_TRACE_1(message) \
   ::testing::internal::ScopedTrace GTEST_CONCAT_TOKEN_(gtest_trace_, __LINE__)(\
     __FILE__, __LINE__, ::testing::Message() << (message))
+#define SCOPED_TRACE_3(file, line, message) \
+  ::testing::internal::ScopedTrace GTEST_CONCAT_TOKEN_(gtest_trace_, line)(\
+    file, line, ::testing::Message() << (message))
+
 
 // Compile-time assertion for type equality.
 // StaticAssertTypeEq<type1, type2>() compiles iff type1 and type2 are

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -76,6 +76,10 @@
 #define GTEST_CONCAT_TOKEN_(foo, bar) GTEST_CONCAT_TOKEN_IMPL_(foo, bar)
 #define GTEST_CONCAT_TOKEN_IMPL_(foo, bar) foo ## bar
 
+#define GTEST_VA_SIZE_(...) GTEST_VA_SIZE_IMPL_(__VA_ARGS__, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+#define GTEST_VA_SIZE_IMPL_(_1, _2, _3, _4, _5, _6, _7, _8, _9, SIZE, ...) SIZE
+#define GTEST_VA_SELECT_(name, ...) GTEST_CONCAT_TOKEN_(name ## _, GTEST_VA_SIZE_(__VA_ARGS__))(__VA_ARGS__)
+
 class ProtocolMessage;
 namespace proto2 { class Message; }
 


### PR DESCRIPTION
Example use:

```c++
void custom_assert(const Foo& actual, int expected_1, expected_2, expected_3) {
  ASSERT_EQ(expected_1, actual.thing_1());
  // ...
}

#define CUSTOM_ASSERT(actual, expected_1, expected_2, expected_3, message) \
  do { \
    SCOPED_TRACE_(message, __FILE__, __LINE__); \
    custom_assert(actual, expected_1, expected_2, expected_3); \
  } while(0)
```

Grouping re-used assertions into a subroutine, while still keeping the stack trace clean