### PR TITLE
Fix warnings encountered in MSVC build of gtest/gmock tests

### DIFF
--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -2708,21 +2708,16 @@ class FloatingPointTest : public testing::Test {
         zero_bits_(Floating(0).bits()),
         one_bits_(Floating(1).bits()),
         infinity_bits_(Floating(Floating::Infinity()).bits()),
-        close_to_positive_zero_(Floating::ReinterpretBits(
-            static_cast<Bits>(zero_bits_ + max_ulps_/2))),
-        close_to_negative_zero_(-Floating::ReinterpretBits(
-            static_cast<Bits>(zero_bits_ + max_ulps_ - max_ulps_/2))),
-        further_from_negative_zero_(-Floating::ReinterpretBits(
-            static_cast<Bits>(zero_bits_ + max_ulps_ + 1 - max_ulps_/2))),
-        close_to_one_(Floating::ReinterpretBits(
-            static_cast<Bits>(one_bits_ + max_ulps_))),
-        further_from_one_(Floating::ReinterpretBits(
-            static_cast<Bits>(one_bits_ + max_ulps_ + 1))),
+        close_to_positive_zero_(ReinterpretBits(zero_bits_ + max_ulps_/2)),
+        close_to_negative_zero_(ReinterpretBits(
+            zero_bits_ + max_ulps_ - max_ulps_/2)),
+        further_from_negative_zero_(-ReinterpretBits(
+            zero_bits_ + max_ulps_ + 1 - max_ulps_/2)),
+        close_to_one_(ReinterpretBits(one_bits_ + max_ulps_)),
+        further_from_one_(ReinterpretBits(one_bits_ + max_ulps_ + 1)),
         infinity_(Floating::Infinity()),
-        close_to_infinity_(Floating::ReinterpretBits(
-            static_cast<Bits>(infinity_bits_ - max_ulps_))),
-        further_from_infinity_(Floating::ReinterpretBits(
-            static_cast<Bits>(infinity_bits_ - max_ulps_ - 1))),
+        close_to_infinity_(ReinterpretBits(infinity_bits_ - max_ulps_)),
+        further_from_infinity_(ReinterpretBits(infinity_bits_ - max_ulps_ - 1)),
         max_(Floating::Max()),
         nan1_(Floating::ReinterpretBits(Floating::kExponentBitMask | 1)),
         nan2_(Floating::ReinterpretBits(Floating::kExponentBitMask | 200)) {
@@ -2806,6 +2801,12 @@ class FloatingPointTest : public testing::Test {
   // Some NaNs.
   const RawType nan1_;
   const RawType nan2_;
+
+ private:
+  template <typename T>
+  static RawType ReinterpretBits(T value) {
+    return Floating::ReinterpretBits(static_cast<Bits>(value));
+  }
 };
 
 // Tests floating-point matchers with fixed epsilons.

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -2708,19 +2708,21 @@ class FloatingPointTest : public testing::Test {
         zero_bits_(Floating(0).bits()),
         one_bits_(Floating(1).bits()),
         infinity_bits_(Floating(Floating::Infinity()).bits()),
-        close_to_positive_zero_(
-            Floating::ReinterpretBits(zero_bits_ + max_ulps_/2)),
-        close_to_negative_zero_(
-            -Floating::ReinterpretBits(zero_bits_ + max_ulps_ - max_ulps_/2)),
+        close_to_positive_zero_(Floating::ReinterpretBits(
+            static_cast<Bits>(zero_bits_ + max_ulps_/2))),
+        close_to_negative_zero_(-Floating::ReinterpretBits(
+            static_cast<Bits>(zero_bits_ + max_ulps_ - max_ulps_/2))),
         further_from_negative_zero_(-Floating::ReinterpretBits(
-            zero_bits_ + max_ulps_ + 1 - max_ulps_/2)),
-        close_to_one_(Floating::ReinterpretBits(one_bits_ + max_ulps_)),
-        further_from_one_(Floating::ReinterpretBits(one_bits_ + max_ulps_ + 1)),
+            static_cast<Bits>(zero_bits_ + max_ulps_ + 1 - max_ulps_/2))),
+        close_to_one_(Floating::ReinterpretBits(
+            static_cast<Bits>(one_bits_ + max_ulps_))),
+        further_from_one_(Floating::ReinterpretBits(
+            static_cast<Bits>(one_bits_ + max_ulps_ + 1))),
         infinity_(Floating::Infinity()),
-        close_to_infinity_(
-            Floating::ReinterpretBits(infinity_bits_ - max_ulps_)),
-        further_from_infinity_(
-            Floating::ReinterpretBits(infinity_bits_ - max_ulps_ - 1)),
+        close_to_infinity_(Floating::ReinterpretBits(
+            static_cast<Bits>(infinity_bits_ - max_ulps_))),
+        further_from_infinity_(Floating::ReinterpretBits(
+            static_cast<Bits>(infinity_bits_ - max_ulps_ - 1))),
         max_(Floating::Max()),
         nan1_(Floating::ReinterpretBits(Floating::kExponentBitMask | 1)),
         nan2_(Floating::ReinterpretBits(Floating::kExponentBitMask | 200)) {
@@ -2778,7 +2780,7 @@ class FloatingPointTest : public testing::Test {
 
   // Pre-calculated numbers to be used by the tests.
 
-  const unsigned int max_ulps_;
+  const size_t max_ulps_;
 
   const Bits zero_bits_;  // The bits that represent 0.0.
   const Bits one_bits_;  // The bits that represent 1.0.

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -2778,7 +2778,7 @@ class FloatingPointTest : public testing::Test {
 
   // Pre-calculated numbers to be used by the tests.
 
-  const size_t max_ulps_;
+  const unsigned int max_ulps_;
 
   const Bits zero_bits_;  // The bits that represent 0.0.
   const Bits one_bits_;  // The bits that represent 1.0.

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -2708,19 +2708,18 @@ class FloatingPointTest : public testing::Test {
         zero_bits_(Floating(0).bits()),
         one_bits_(Floating(1).bits()),
         infinity_bits_(Floating(Floating::Infinity()).bits()),
-        close_to_positive_zero_(ReinterpretBits(zero_bits_ + max_ulps_/2)),
-        close_to_negative_zero_(ReinterpretBits(
-            zero_bits_ + max_ulps_ - max_ulps_/2)),
-        further_from_negative_zero_(-ReinterpretBits(
+        close_to_positive_zero_(AsBits(zero_bits_ + max_ulps_/2)),
+        close_to_negative_zero_(AsBits(zero_bits_ + max_ulps_ - max_ulps_/2)),
+        further_from_negative_zero_(-AsBits(
             zero_bits_ + max_ulps_ + 1 - max_ulps_/2)),
-        close_to_one_(ReinterpretBits(one_bits_ + max_ulps_)),
-        further_from_one_(ReinterpretBits(one_bits_ + max_ulps_ + 1)),
+        close_to_one_(AsBits(one_bits_ + max_ulps_)),
+        further_from_one_(AsBits(one_bits_ + max_ulps_ + 1)),
         infinity_(Floating::Infinity()),
-        close_to_infinity_(ReinterpretBits(infinity_bits_ - max_ulps_)),
-        further_from_infinity_(ReinterpretBits(infinity_bits_ - max_ulps_ - 1)),
+        close_to_infinity_(AsBits(infinity_bits_ - max_ulps_)),
+        further_from_infinity_(AsBits(infinity_bits_ - max_ulps_ - 1)),
         max_(Floating::Max()),
-        nan1_(Floating::ReinterpretBits(Floating::kExponentBitMask | 1)),
-        nan2_(Floating::ReinterpretBits(Floating::kExponentBitMask | 200)) {
+        nan1_(AsBits(Floating::kExponentBitMask | 1)),
+        nan2_(AsBits(Floating::kExponentBitMask | 200)) {
   }
 
   void TestSize() {
@@ -2804,7 +2803,7 @@ class FloatingPointTest : public testing::Test {
 
  private:
   template <typename T>
-  static RawType ReinterpretBits(T value) {
+  static RawType AsBits(T value) {
     return Floating::ReinterpretBits(static_cast<Bits>(value));
   }
 };

--- a/googletest/test/gtest-port_test.cc
+++ b/googletest/test/gtest-port_test.cc
@@ -75,8 +75,8 @@ TEST(IsXDigitTest, WorksForNarrowAscii) {
 }
 
 TEST(IsXDigitTest, ReturnsFalseForNarrowNonAscii) {
-  EXPECT_FALSE(IsXDigit(static_cast<char>(0x80)));
-  EXPECT_FALSE(IsXDigit(static_cast<char>('0' | 0x80)));
+  EXPECT_FALSE(IsXDigit(static_cast<char>(0x80u)));
+  EXPECT_FALSE(IsXDigit(static_cast<char>('0' | 0x80u)));
 }
 
 TEST(IsXDigitTest, WorksForWideAscii) {

--- a/googletest/test/gtest-port_test.cc
+++ b/googletest/test/gtest-port_test.cc
@@ -75,8 +75,8 @@ TEST(IsXDigitTest, WorksForNarrowAscii) {
 }
 
 TEST(IsXDigitTest, ReturnsFalseForNarrowNonAscii) {
-  EXPECT_FALSE(IsXDigit(static_cast<char>(0x80u)));
-  EXPECT_FALSE(IsXDigit(static_cast<char>('0' | 0x80u)));
+  EXPECT_FALSE(IsXDigit('\x80'));
+  EXPECT_FALSE(IsXDigit(static_cast<char>('0' | '\x80')));
 }
 
 TEST(IsXDigitTest, WorksForWideAscii) {


### PR DESCRIPTION
This fixes these warnings:

…\gtest\googletest\test\gtest-port_test.cc(78) : error C2220: warning treated as error - no 'object' file generated
…\gtest\googletest\test\gtest-port_test.cc(78) : warning C4309: 'static_cast' : truncation of constant value
…\gtest\googletest\test\gtest-port_test.cc(79) : warning C4309: 'static_cast' : truncation of constant value

…\gtest\googlemock\test\gmock-matchers_test.cc(2712) : error C2220: warning treated as error - no 'object' file generated
        …\gtest\googlemock\test\gmock-matchers_test.cc(2706) : while compiling class template member function 'testing::gmock_matchers_test::FloatingPointTest<float>::FloatingPointTest(void)'
        …\gtest\googlemock\test\gmock-matchers_test.cc(2896) : see reference to function template instantiation 'testing::gmock_matchers_test::FloatingPointTest<float>::FloatingPointTest(void)' being compiled
        …\gtest\googlemock\test\gmock-matchers_test.cc(2896) : see reference to class template instantiation 'testing::gmock_matchers_test::FloatingPointTest<float>' being compiled
…\gtest\googlemock\test\gmock-matchers_test.cc(2712) : warning C4267: 'argument' : conversion from 'size_t' to 'const unsigned int', possible loss of data
…\gtest\googlemock\test\gmock-matchers_test.cc(2714) : warning C4267: 'argument' : conversion from 'size_t' to 'const unsigned int', possible loss of data
…\gtest\googlemock\test\gmock-matchers_test.cc(2716) : warning C4267: 'argument' : conversion from 'size_t' to 'const unsigned int', possible loss of data
…\gtest\googlemock\test\gmock-matchers_test.cc(2717) : warning C4267: 'argument' : conversion from 'size_t' to 'const unsigned int', possible loss of data
…\gtest\googlemock\test\gmock-matchers_test.cc(2718) : warning C4267: 'argument' : conversion from 'size_t' to 'const unsigned int', possible loss of data
…\gtest\googlemock\test\gmock-matchers_test.cc(2721) : warning C4267: 'argument' : conversion from 'size_t' to 'const unsigned int', possible loss of data
…\gtest\googlemock\test\gmock-matchers_test.cc(2723) : warning C4267: 'argument' : conversion from 'size_t' to 'const unsigned int', possible loss of data