### PR TITLE
Link to API documentation directly from root README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ join us!
 **Google Mock** is an extension to Google Test for writing and using C++ mock
 classes.  See the separate [Google Mock documentation](googlemock/README.md).
 
-More detailed documentation for googletest (including build instructions) are
-in its interior [googletest/README.md](googletest/README.md) file.
+More detailed documentation for setting up googletest (including build
+instructions) are in its interior [googletest/README.md](googletest/README.md)
+file.
+
+Documentation for writing tests using Google Test can be found at
+[googletest/docs/Documentation.md](googletest/docs/Documentation.md).
 
 ## Features ##
 


### PR DESCRIPTION
It was kind of difficult to find user-level API documentation after the move. This commit Includes a link to the documentation directly near the beginning of the root README.md.
