### PR TITLE
Added (ASSERT|EXPECT)_THROW_MSG macros

### DIFF
--- a/googletest/include/gtest/gtest-message.h
+++ b/googletest/include/gtest/gtest-message.h
@@ -102,6 +102,8 @@ class GTEST_API_ Message {
     *ss_ << str;
   }
 
+  operator bool() const { return true; }
+
 #if GTEST_OS_SYMBIAN
   // Streams a value (either a pointer or not) to this object.
   template <typename T>

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1839,7 +1839,7 @@ class TestWithParam : public Test, public WithParamInterface<T> {
 //
 //    * {ASSERT|EXPECT}_THROW(statement, expected_exception):
 //         Tests that the statement throws the expected exception.
-//    * {ASSERT|EXPECT}_THROW_WHAT(statement, expected_exception, regex):
+//    * {ASSERT|EXPECT}_THROW_MSG(statement, expected_exception, regex):
 //         Tests that the statement throws the expected exception with a
 //         matching message.
 //    * {ASSERT|EXPECT}_NO_THROW(statement):
@@ -1849,8 +1849,8 @@ class TestWithParam : public Test, public WithParamInterface<T> {
 
 #define EXPECT_THROW(statement, expected_exception) \
   GTEST_TEST_THROW_(statement, expected_exception, GTEST_NONFATAL_FAILURE_)
-#define EXPECT_THROW_WHAT(statement, expected_exception, regex) \
-  GTEST_TEST_THROW_WHAT_(statement, expected_exception, regex, \
+#define EXPECT_THROW_MSG(statement, expected_exception, regex) \
+  GTEST_TEST_THROW_MSG_(statement, expected_exception, regex, \
                          GTEST_NONFATAL_FAILURE_)
 #define EXPECT_NO_THROW(statement) \
   GTEST_TEST_NO_THROW_(statement, GTEST_NONFATAL_FAILURE_)
@@ -1858,8 +1858,8 @@ class TestWithParam : public Test, public WithParamInterface<T> {
   GTEST_TEST_ANY_THROW_(statement, GTEST_NONFATAL_FAILURE_)
 #define ASSERT_THROW(statement, expected_exception) \
   GTEST_TEST_THROW_(statement, expected_exception, GTEST_FATAL_FAILURE_)
-#define ASSERT_THROW_WHAT(statement, expected_exception, regex) \
-  GTEST_TEST_THROW_WHAT_(statement, expected_exception, regex, \
+#define ASSERT_THROW_MSG(statement, expected_exception, regex) \
+  GTEST_TEST_THROW_MSG_(statement, expected_exception, regex, \
                          GTEST_FATAL_FAILURE_)
 #define ASSERT_NO_THROW(statement) \
   GTEST_TEST_NO_THROW_(statement, GTEST_FATAL_FAILURE_)

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1839,6 +1839,9 @@ class TestWithParam : public Test, public WithParamInterface<T> {
 //
 //    * {ASSERT|EXPECT}_THROW(statement, expected_exception):
 //         Tests that the statement throws the expected exception.
+//    * {ASSERT|EXPECT}_THROW_WHAT(statement, expected_exception, regex):
+//         Tests that the statement throws the expected exception with a
+//         matching message.
 //    * {ASSERT|EXPECT}_NO_THROW(statement):
 //         Tests that the statement doesn't throw any exception.
 //    * {ASSERT|EXPECT}_ANY_THROW(statement):
@@ -1846,12 +1849,18 @@ class TestWithParam : public Test, public WithParamInterface<T> {
 
 #define EXPECT_THROW(statement, expected_exception) \
   GTEST_TEST_THROW_(statement, expected_exception, GTEST_NONFATAL_FAILURE_)
+#define EXPECT_THROW_WHAT(statement, expected_exception, regex) \
+  GTEST_TEST_THROW_WHAT_(statement, expected_exception, regex, \
+                         GTEST_NONFATAL_FAILURE_)
 #define EXPECT_NO_THROW(statement) \
   GTEST_TEST_NO_THROW_(statement, GTEST_NONFATAL_FAILURE_)
 #define EXPECT_ANY_THROW(statement) \
   GTEST_TEST_ANY_THROW_(statement, GTEST_NONFATAL_FAILURE_)
 #define ASSERT_THROW(statement, expected_exception) \
   GTEST_TEST_THROW_(statement, expected_exception, GTEST_FATAL_FAILURE_)
+#define ASSERT_THROW_WHAT(statement, expected_exception, regex) \
+  GTEST_TEST_THROW_WHAT_(statement, expected_exception, regex, \
+                         GTEST_FATAL_FAILURE_)
 #define ASSERT_NO_THROW(statement) \
   GTEST_TEST_NO_THROW_(statement, GTEST_FATAL_FAILURE_)
 #define ASSERT_ANY_THROW(statement) \

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1147,6 +1147,46 @@ class NativeArray {
     GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__): \
       fail(gtest_msg.value)
 
+#define GTEST_TEST_THROW_WHAT_(statement, expected_exception, regex, fail) \
+  GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
+  if (::testing::internal::ConstCharPtr gtest_msg = "") { \
+    bool gtest_caught_expected = false; \
+    try { \
+      GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement); \
+    } \
+    catch (expected_exception const& e) { \
+      const ::testing::internal::RE& gtest_regex = (regex); \
+      const bool matched = ::testing::internal::RE::PartialMatch(::testing::PrintToString(e), gtest_regex); \
+      if (matched) { \
+        gtest_caught_expected = true; \
+      } else { \
+        Message buffer; \
+        buffer << "Result: threw correct exception type " << "#expected_exception" \
+               << ". Expected " << gtest_regex.pattern() << "\n" \
+               << "Actual msg: " << ::testing::PrintToString(e); \
+        std::cout << "asdfasdfasdfasdfasdfasdf: " << buffer.GetString() << std::endl; \
+        gtest_msg.value = \
+            "Result: " #statement " threw correct exception type " #expected_exception \
+            " with wrong message. Expected: " #regex "."; \
+        goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
+      } \
+    } \
+    catch (...) { \
+      gtest_msg.value = \
+          "Expected: " #statement " throws an exception of type " \
+          #expected_exception ".\n  Actual: it throws a different type."; \
+      goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
+    } \
+    if (!gtest_caught_expected) { \
+      gtest_msg.value = \
+          "Expected: " #statement " throws an exception of type " \
+          #expected_exception ".\n  Actual: it throws nothing."; \
+      goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
+    } \
+  } else \
+    GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__): \
+      fail(gtest_msg.value)
+
 #define GTEST_TEST_NO_THROW_(statement, fail) \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
   if (::testing::internal::AlwaysTrue()) { \

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1149,7 +1149,7 @@ class NativeArray {
 
 #define GTEST_TEST_THROW_MSG_(statement, expected_exception, regex, fail) \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
-  if (::testing::internal::ConstCharPtr gtest_msg = "") { \
+  if (::testing::Message buffer = ::testing::Message()) { \
     bool gtest_caught_expected = false; \
     try { \
       GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement); \
@@ -1161,32 +1161,26 @@ class NativeArray {
       if (matched) { \
         gtest_caught_expected = true; \
       } else { \
-        Message buffer; \
-        buffer << "Result: threw correct exception type " << "#expected_exception" \
-               << ". Expected " << gtest_regex.pattern() << "\n" \
-               << "Actual msg: " << ::testing::PrintToString(e); \
-        std::cout << "asdfasdfasdfasdfasdfasdf: " << buffer.GetString() << std::endl; \
-        gtest_msg.value = \
-            "Result: " #statement " threw correct exception type " #expected_exception \
-            " with wrong message. Expected: " #regex "."; \
+        buffer << "Result: " #statement " threw correct exception type " \
+                  #expected_exception " with wrong message. " \
+               << "Expected: " << gtest_regex.pattern() << ".\n " \
+               << "Actual: " << err_string << "."; \
         goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
       } \
     } \
     catch (...) { \
-      gtest_msg.value = \
-          "Expected: " #statement " throws an exception of type " \
-          #expected_exception ".\n  Actual: it throws a different type."; \
+      buffer << "Expected: " #statement " throws an exception of type " \
+          #expected_exception ".\n Actual: it throws a different type."; \
       goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
     } \
     if (!gtest_caught_expected) { \
-      gtest_msg.value = \
-          "Expected: " #statement " throws an exception of type " \
-          #expected_exception ".\n  Actual: it throws nothing."; \
+      buffer << "Expected: " #statement " throws an exception of type " \
+          #expected_exception ".\n Actual: it throws nothing."; \
       goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
     } \
   } else \
     GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__): \
-      fail(gtest_msg.value)
+      fail(buffer.GetString().c_str()) \
 
 #define GTEST_TEST_NO_THROW_(statement, fail) \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_ \

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1147,7 +1147,7 @@ class NativeArray {
     GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__): \
       fail(gtest_msg.value)
 
-#define GTEST_TEST_THROW_WHAT_(statement, expected_exception, regex, fail) \
+#define GTEST_TEST_THROW_MSG_(statement, expected_exception, regex, fail) \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
   if (::testing::internal::ConstCharPtr gtest_msg = "") { \
     bool gtest_caught_expected = false; \
@@ -1156,7 +1156,8 @@ class NativeArray {
     } \
     catch (expected_exception const& e) { \
       const ::testing::internal::RE& gtest_regex = (regex); \
-      const bool matched = ::testing::internal::RE::PartialMatch(::testing::PrintToString(e), gtest_regex); \
+      const std::string err_string = ::testing::PrintToString(e); \
+      const bool matched = ::testing::internal::RE::PartialMatch(err_string, gtest_regex); \
       if (matched) { \
         gtest_caught_expected = true; \
       } else { \

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -3322,7 +3322,7 @@ TEST_F(SingleEvaluationTest, ExceptionTests) {
   EXPECT_EQ(1, a_);
 
   // successful EXPECT_THROW
-  EXPECT_THROW_WHAT({  // NOLINT
+  EXPECT_THROW_MSG({  // NOLINT
     a_++;
     ThrowAnInteger();
   }, int, "1");
@@ -3790,27 +3790,27 @@ TEST(AssertionTest, ASSERT_THROW) {
       "  Actual: it throws nothing.");
 }
 
-// Tests ASSERT_THROW_WHAT.
-TEST(AssertionTest, ASSERT_THROW_WHAT) {
-  ASSERT_THROW_WHAT(ThrowAString(), const char *, "std::string");
+// Tests ASSERT_THROW_MSG.
+TEST(AssertionTest, ASSERT_THROW_MSG) {
+  ASSERT_THROW_MSG(ThrowAString(), const char *, "std::string");
 
 # ifndef __BORLANDC__
 
   // ICE's in C++Builder 2007 and 2009.
   EXPECT_FATAL_FAILURE(
-      ASSERT_THROW_WHAT(ThrowAString(), bool, "std::string"),
+      ASSERT_THROW_MSG(ThrowAString(), bool, "std::string"),
       "Expected: ThrowAString() throws an exception of type bool.\n"
       "  Actual: it throws a different type.");
 
   // Need to figure out how to get the message that was actually thrown into this
   EXPECT_FATAL_FAILURE(
-      ASSERT_THROW_WHAT(ThrowAString(), const char *, "std::array"),
+      ASSERT_THROW_MSG(ThrowAString(), const char *, "std::array"),
       "Result: ThrowAString() threw correct exception "
       "type const char * with wrong message. Expected: \"std::array\".");
 # endif
 
   EXPECT_FATAL_FAILURE(
-      ASSERT_THROW_WHAT(ThrowNothing(), bool, "std::string"),
+      ASSERT_THROW_MSG(ThrowNothing(), bool, "std::string"),
       "Expected: ThrowNothing() throws an exception of type bool.\n"
       "  Actual: it throws nothing.");
 }
@@ -4123,7 +4123,7 @@ TEST(ExpectThrowTest, DoesNotGenerateUnreachableCodeWarning) {
   int n = 0;
 
   EXPECT_THROW(throw 1, int);
-  EXPECT_THROW_WHAT(throw 1, int, "1");
+  EXPECT_THROW_MSG(throw 1, int, "1");
   EXPECT_NONFATAL_FAILURE(EXPECT_THROW(n++, int), "");
   EXPECT_NONFATAL_FAILURE(EXPECT_THROW(throw 1, const char*), "");
   EXPECT_NO_THROW(n++);
@@ -4142,10 +4142,10 @@ TEST(AssertionSyntaxTest, ExceptionAssertionsBehavesLikeSingleStatement) {
     ;  // NOLINT
 
   if (AlwaysFalse())
-    EXPECT_THROW_WHAT(ThrowNothing(), bool, "false");
+    EXPECT_THROW_MSG(ThrowNothing(), bool, "false");
 
   if (AlwaysTrue())
-    EXPECT_THROW_WHAT(ThrowAnInteger(), int, "1");
+    EXPECT_THROW_MSG(ThrowAnInteger(), int, "1");
   else
     ;  // NOLINT
 
@@ -4222,10 +4222,10 @@ TEST(AssertionSyntaxTest, WorksWithSwitch) {
 // type qualifier.
 TEST(AssertionSyntaxTest, WorksWithConst) {
     ASSERT_THROW(ThrowAString(), const char*);
-    ASSERT_THROW_WHAT(ThrowAString(), const char*, "std::string");
+    ASSERT_THROW_MSG(ThrowAString(), const char*, "std::string");
 
     EXPECT_THROW(ThrowAString(), const char*);
-    EXPECT_THROW_WHAT(ThrowAString(), const char*, "std::string");
+    EXPECT_THROW_MSG(ThrowAString(), const char*, "std::string");
 }
 
 #endif  // GTEST_HAS_EXCEPTIONS
@@ -4560,19 +4560,19 @@ TEST(ExpectTest, EXPECT_THROW) {
       "  Actual: it throws nothing.");
 }
 
-// Tests EXPECT_THROW_WHAT.
-TEST(ExpectTest, EXPECT_THROW_WHAT) {
-  EXPECT_THROW_WHAT(ThrowAString(), const char *, "std::string");
-  EXPECT_NONFATAL_FAILURE(EXPECT_THROW_WHAT(ThrowAString(), bool, "std::string"),
+// Tests EXPECT_THROW_MSG.
+TEST(ExpectTest, EXPECT_THROW_MSG) {
+  EXPECT_THROW_MSG(ThrowAString(), const char *, "std::string");
+  EXPECT_NONFATAL_FAILURE(EXPECT_THROW_MSG(ThrowAString(), bool, "std::string"),
                           "Expected: ThrowAString() throws an exception of "
                           "type bool.\n  Actual: it throws a different type.");
 
   // Need to figure out how to get the message that was actually thrown into this
-  EXPECT_NONFATAL_FAILURE(EXPECT_THROW_WHAT(ThrowAString(), const char *, "std::array"),
+  EXPECT_NONFATAL_FAILURE(EXPECT_THROW_MSG(ThrowAString(), const char *, "std::array"),
                           "Result: ThrowAString() threw correct exception "
                           "type const char * with wrong message. Expected: \"std::array\".");
   EXPECT_NONFATAL_FAILURE(
-      EXPECT_THROW_WHAT(ThrowNothing(), bool, "1"),
+      EXPECT_THROW_MSG(ThrowNothing(), bool, "1"),
       "Expected: ThrowNothing() throws an exception of type bool.\n"
       "  Actual: it throws nothing.");
 }

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -3799,20 +3799,20 @@ TEST(AssertionTest, ASSERT_THROW_MSG) {
   // ICE's in C++Builder 2007 and 2009.
   EXPECT_FATAL_FAILURE(
       ASSERT_THROW_MSG(ThrowAString(), bool, "std::string"),
-      "Expected: ThrowAString() throws an exception of type bool.\n"
-      "  Actual: it throws a different type.");
+      "Expected: ThrowAString() throws an exception of type bool.\n "
+      "Actual: it throws a different type.");
 
-  // Need to figure out how to get the message that was actually thrown into this
   EXPECT_FATAL_FAILURE(
       ASSERT_THROW_MSG(ThrowAString(), const char *, "std::array"),
       "Result: ThrowAString() threw correct exception "
-      "type const char * with wrong message. Expected: \"std::array\".");
+      "type const char * with wrong message. Expected: std::array.\n "
+      "Actual: \"std::string\".");
 # endif
 
   EXPECT_FATAL_FAILURE(
       ASSERT_THROW_MSG(ThrowNothing(), bool, "std::string"),
-      "Expected: ThrowNothing() throws an exception of type bool.\n"
-      "  Actual: it throws nothing.");
+      "Expected: ThrowNothing() throws an exception of type bool.\n "
+      "Actual: it throws nothing.");
 }
 
 // Tests ASSERT_NO_THROW.
@@ -4564,17 +4564,17 @@ TEST(ExpectTest, EXPECT_THROW) {
 TEST(ExpectTest, EXPECT_THROW_MSG) {
   EXPECT_THROW_MSG(ThrowAString(), const char *, "std::string");
   EXPECT_NONFATAL_FAILURE(EXPECT_THROW_MSG(ThrowAString(), bool, "std::string"),
-                          "Expected: ThrowAString() throws an exception of "
-                          "type bool.\n  Actual: it throws a different type.");
+                          "Expected: ThrowAString() throws an exception of type bool.\n "
+                          "Actual: it throws a different type.");
 
-  // Need to figure out how to get the message that was actually thrown into this
   EXPECT_NONFATAL_FAILURE(EXPECT_THROW_MSG(ThrowAString(), const char *, "std::array"),
                           "Result: ThrowAString() threw correct exception "
-                          "type const char * with wrong message. Expected: \"std::array\".");
+                          "type const char * with wrong message. Expected: std::array.\n "
+                          "Actual: \"std::string\".");
   EXPECT_NONFATAL_FAILURE(
       EXPECT_THROW_MSG(ThrowNothing(), bool, "1"),
-      "Expected: ThrowNothing() throws an exception of type bool.\n"
-      "  Actual: it throws nothing.");
+      "Expected: ThrowNothing() throws an exception of type bool.\n "
+      "Actual: it throws nothing.");
 }
 
 // Tests EXPECT_NO_THROW.

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -76,6 +76,8 @@ TEST(CommandLineFlagsTest, CanBeAccessedInCodeOnceGTestHIsIncluded) {
 #include "src/gtest-internal-inl.h"
 #undef GTEST_IMPLEMENTATION_
 
+#include "gtest/gtest-printers.h"
+
 namespace testing {
 namespace internal {
 
@@ -3319,38 +3321,45 @@ TEST_F(SingleEvaluationTest, ExceptionTests) {
   }, int);
   EXPECT_EQ(1, a_);
 
+  // successful EXPECT_THROW
+  EXPECT_THROW_WHAT({  // NOLINT
+    a_++;
+    ThrowAnInteger();
+  }, int, "1");
+  EXPECT_EQ(2, a_);
+
   // failed EXPECT_THROW, throws different
   EXPECT_NONFATAL_FAILURE(EXPECT_THROW({  // NOLINT
     a_++;
     ThrowAnInteger();
   }, bool), "throws a different type");
-  EXPECT_EQ(2, a_);
+  EXPECT_EQ(3, a_);
 
   // failed EXPECT_THROW, throws nothing
   EXPECT_NONFATAL_FAILURE(EXPECT_THROW(a_++, bool), "throws nothing");
-  EXPECT_EQ(3, a_);
+  EXPECT_EQ(4, a_);
 
   // successful EXPECT_NO_THROW
   EXPECT_NO_THROW(a_++);
-  EXPECT_EQ(4, a_);
+  EXPECT_EQ(5, a_);
 
   // failed EXPECT_NO_THROW
   EXPECT_NONFATAL_FAILURE(EXPECT_NO_THROW({  // NOLINT
     a_++;
     ThrowAnInteger();
   }), "it throws");
-  EXPECT_EQ(5, a_);
+  EXPECT_EQ(6, a_);
 
   // successful EXPECT_ANY_THROW
   EXPECT_ANY_THROW({  // NOLINT
     a_++;
     ThrowAnInteger();
   });
-  EXPECT_EQ(6, a_);
+  EXPECT_EQ(7, a_);
 
   // failed EXPECT_ANY_THROW
   EXPECT_NONFATAL_FAILURE(EXPECT_ANY_THROW(a_++), "it doesn't");
-  EXPECT_EQ(7, a_);
+  EXPECT_EQ(8, a_);
 }
 
 #endif  // GTEST_HAS_EXCEPTIONS
@@ -3756,6 +3765,10 @@ TEST(AssertionTest, ASSERT_GT) {
 
 #if GTEST_HAS_EXCEPTIONS
 
+void ThrowAString() {
+    throw "std::string";
+}
+
 void ThrowNothing() {}
 
 // Tests ASSERT_THROW.
@@ -3773,6 +3786,31 @@ TEST(AssertionTest, ASSERT_THROW) {
 
   EXPECT_FATAL_FAILURE(
       ASSERT_THROW(ThrowNothing(), bool),
+      "Expected: ThrowNothing() throws an exception of type bool.\n"
+      "  Actual: it throws nothing.");
+}
+
+// Tests ASSERT_THROW_WHAT.
+TEST(AssertionTest, ASSERT_THROW_WHAT) {
+  ASSERT_THROW_WHAT(ThrowAString(), const char *, "std::string");
+
+# ifndef __BORLANDC__
+
+  // ICE's in C++Builder 2007 and 2009.
+  EXPECT_FATAL_FAILURE(
+      ASSERT_THROW_WHAT(ThrowAString(), bool, "std::string"),
+      "Expected: ThrowAString() throws an exception of type bool.\n"
+      "  Actual: it throws a different type.");
+
+  // Need to figure out how to get the message that was actually thrown into this
+  EXPECT_FATAL_FAILURE(
+      ASSERT_THROW_WHAT(ThrowAString(), const char *, "std::array"),
+      "Result: ThrowAString() threw correct exception "
+      "type const char * with wrong message. Expected: \"std::array\".");
+# endif
+
+  EXPECT_FATAL_FAILURE(
+      ASSERT_THROW_WHAT(ThrowNothing(), bool, "std::string"),
       "Expected: ThrowNothing() throws an exception of type bool.\n"
       "  Actual: it throws nothing.");
 }
@@ -4085,6 +4123,7 @@ TEST(ExpectThrowTest, DoesNotGenerateUnreachableCodeWarning) {
   int n = 0;
 
   EXPECT_THROW(throw 1, int);
+  EXPECT_THROW_WHAT(throw 1, int, "1");
   EXPECT_NONFATAL_FAILURE(EXPECT_THROW(n++, int), "");
   EXPECT_NONFATAL_FAILURE(EXPECT_THROW(throw 1, const char*), "");
   EXPECT_NO_THROW(n++);
@@ -4099,6 +4138,14 @@ TEST(AssertionSyntaxTest, ExceptionAssertionsBehavesLikeSingleStatement) {
 
   if (AlwaysTrue())
     EXPECT_THROW(ThrowAnInteger(), int);
+  else
+    ;  // NOLINT
+
+  if (AlwaysFalse())
+    EXPECT_THROW_WHAT(ThrowNothing(), bool, "false");
+
+  if (AlwaysTrue())
+    EXPECT_THROW_WHAT(ThrowAnInteger(), int, "1");
   else
     ;  // NOLINT
 
@@ -4171,16 +4218,14 @@ TEST(AssertionSyntaxTest, WorksWithSwitch) {
 
 #if GTEST_HAS_EXCEPTIONS
 
-void ThrowAString() {
-    throw "std::string";
-}
-
 // Test that the exception assertion macros compile and work with const
 // type qualifier.
 TEST(AssertionSyntaxTest, WorksWithConst) {
     ASSERT_THROW(ThrowAString(), const char*);
+    ASSERT_THROW_WHAT(ThrowAString(), const char*, "std::string");
 
     EXPECT_THROW(ThrowAString(), const char*);
+    EXPECT_THROW_WHAT(ThrowAString(), const char*, "std::string");
 }
 
 #endif  // GTEST_HAS_EXCEPTIONS
@@ -4511,6 +4556,23 @@ TEST(ExpectTest, EXPECT_THROW) {
                           "type bool.\n  Actual: it throws a different type.");
   EXPECT_NONFATAL_FAILURE(
       EXPECT_THROW(ThrowNothing(), bool),
+      "Expected: ThrowNothing() throws an exception of type bool.\n"
+      "  Actual: it throws nothing.");
+}
+
+// Tests EXPECT_THROW_WHAT.
+TEST(ExpectTest, EXPECT_THROW_WHAT) {
+  EXPECT_THROW_WHAT(ThrowAString(), const char *, "std::string");
+  EXPECT_NONFATAL_FAILURE(EXPECT_THROW_WHAT(ThrowAString(), bool, "std::string"),
+                          "Expected: ThrowAString() throws an exception of "
+                          "type bool.\n  Actual: it throws a different type.");
+
+  // Need to figure out how to get the message that was actually thrown into this
+  EXPECT_NONFATAL_FAILURE(EXPECT_THROW_WHAT(ThrowAString(), const char *, "std::array"),
+                          "Result: ThrowAString() threw correct exception "
+                          "type const char * with wrong message. Expected: \"std::array\".");
+  EXPECT_NONFATAL_FAILURE(
+      EXPECT_THROW_WHAT(ThrowNothing(), bool, "1"),
       "Expected: ThrowNothing() throws an exception of type bool.\n"
       "  Actual: it throws nothing.");
 }


### PR DESCRIPTION
This allows checking both the type of the exception that was thrown and what the message in that exception was.

Attempted to use regex and PrintToString as suggested by vladlosev in #285.
