### PR TITLE
Skip variadic implementation of matchers if using GCC<4.7

### DIFF
--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -1600,6 +1600,7 @@ struct MatcherList<2, Matcher1, Matcher2> {
   }
 };
 
+#if GTEST_HAS_VARIADIC_TEMPLATES
 // VariadicMatcher is used for the variadic implementation of
 // AllOf(m_1, m_2, ...) and AnyOf(m_1, m_2, ...).
 // CombiningMatcher<T> is used to recursively combine the provided matchers
@@ -1630,6 +1631,7 @@ class VariadicMatcher {
 template <typename... Args>
 using AllOfMatcher = VariadicMatcher<BothOfMatcherImpl, Args...>;
 
+#endif  // GTEST_HAS_VARIADIC_TEMPLATES
 #endif  // GTEST_LANG_CXX11
 
 // Used for implementing the AllOf(m_1, ..., m_n) matcher, which
@@ -1719,12 +1721,12 @@ class EitherOfMatcherImpl : public MatcherInterface<T> {
   GTEST_DISALLOW_ASSIGN_(EitherOfMatcherImpl);
 };
 
-#if GTEST_LANG_CXX11
+#if GTEST_HAS_VARIADIC_TEMPLATES
 // AnyOfMatcher is used for the variadic implementation of AnyOf(m_1, m_2, ...).
 template <typename... Args>
 using AnyOfMatcher = VariadicMatcher<EitherOfMatcherImpl, Args...>;
 
-#endif  // GTEST_LANG_CXX11
+#endif  // GTEST_HAS_VARIADIC_TEMPLATES
 
 // Used for implementing the AnyOf(m_1, ..., m_n) matcher, which
 // matches a value that matches at least one of the matchers m_1, ...,
@@ -4356,7 +4358,7 @@ inline bool ExplainMatchResult(
   return SafeMatcherCast<const T&>(matcher).MatchAndExplain(value, listener);
 }
 
-#if GTEST_LANG_CXX11
+#if GTEST_HAS_VARIADIC_TEMPLATES
 // Define variadic matcher versions. They are overloaded in
 // gmock-generated-matchers.h for the cases supported by pre C++11 compilers.
 template <typename... Args>
@@ -4369,7 +4371,7 @@ inline internal::AnyOfMatcher<Args...> AnyOf(const Args&... matchers) {
   return internal::AnyOfMatcher<Args...>(matchers...);
 }
 
-#endif  // GTEST_LANG_CXX11
+#endif  // GTEST_HAS_VARIADIC_TEMPLATES
 
 // AllArgs(m) is a synonym of m.  This is useful in
 //

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -2094,7 +2094,7 @@ TEST(AllOfTest, MatchesWhenAllMatch) {
                          Ne(9), Ne(10)));
 }
 
-#if GTEST_LANG_CXX11
+#if GTEST_HAS_VARIADIC_TEMPLATES
 // Tests the variadic version of the AllOfMatcher.
 TEST(AllOfTest, VariadicMatchesWhenAllMatch) {
   // Make sure AllOf is defined in the right namespace and does not depend on
@@ -2114,7 +2114,7 @@ TEST(AllOfTest, VariadicMatchesWhenAllMatch) {
                          Ne(50)));
 }
 
-#endif  // GTEST_LANG_CXX11
+#endif  // GTEST_HAS_VARIADIC_TEMPLATES
 
 // Tests that AllOf(m1, ..., mn) describes itself properly.
 TEST(AllOfTest, CanDescribeSelf) {
@@ -2289,7 +2289,7 @@ TEST(AnyOfTest, MatchesWhenAnyMatches) {
   AnyOfMatches(10, AnyOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
 }
 
-#if GTEST_LANG_CXX11
+#if GTEST_HAS_VARIADIC_TEMPLATES
 // Tests the variadic version of the AnyOfMatcher.
 TEST(AnyOfTest, VariadicMatchesWhenAnyMatches) {
   // Also make sure AnyOf is defined in the right namespace and does not depend
@@ -2305,7 +2305,7 @@ TEST(AnyOfTest, VariadicMatchesWhenAnyMatches) {
                          41, 42, 43, 44, 45, 46, 47, 48, 49, 50));
 }
 
-#endif  // GTEST_LANG_CXX11
+#endif  // GTEST_HAS_VARIADIC_TEMPLATES
 
 // Tests that AnyOf(m1, ..., mn) describes itself properly.
 TEST(AnyOfTest, CanDescribeSelf) {

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -387,6 +387,19 @@
 # endif
 #endif
 
+// Skip variadic implementation of matchers if using GCC < 4.7 due to
+// Bug 35722 -[C++0x] Variadic templates expansion into non-variadic class template
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=35722
+#if !defined(GTEST_HAS_VARIADIC_TEMPLATES)
+# if !GTEST_LANG_CXX11 || \
+    (defined(__GNUC__) && \
+        (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 7)))
+#   define GTEST_HAS_VARIADIC_TEMPLATES 0
+#  else
+#   define GTEST_HAS_VARIADIC_TEMPLATES 1
+#  endif
+#endif
+
 // Brings in definitions for functions used in the testing::internal::posix
 // namespace (read, write, close, chdir, isatty, stat). We do not currently
 // use them on Windows Mobile.


### PR DESCRIPTION
This is due to a bug in older GCC versions:
Bug 35722 -[C++0x] Variadic templates expansion into non-variadic class template
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=35722

As discussed on:
https://groups.google.com/d/msg/googlemock/XvPDUENM5JM/7zjkEa1Q8XgJ
