### PR TITLE
Added missing CMake install rules for GMock

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -94,6 +94,14 @@ cxx_library(gmock_main
 
 ########################################################################
 #
+# Install rules
+install(TARGETS gmock gmock_main
+  DESTINATION lib)
+install(DIRECTORY ${gmock_SOURCE_DIR}/include/gmock
+  DESTINATION include)
+
+########################################################################
+#
 # Google Mock's own tests.
 #
 # You can skip this section if you aren't interested in testing


### PR DESCRIPTION
Install rules where missing in the GMock CMakeLists.txt file. The result was that, when building GMock using CMake, the library was not being installed in the system.