### PR TITLE
global mocks outliving registry, don't access destructed registry

### DIFF
--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -215,6 +215,10 @@ class GTEST_API_ UntypedFunctionMockerBase {
       const void* untyped_args)
           GTEST_LOCK_EXCLUDED_(g_gmock_mutex);
 
+  void set_registry_destructed() {
+    registry_destructed = true;
+  }
+
  protected:
   typedef std::vector<const void*> UntypedOnCallSpecs;
 
@@ -239,6 +243,8 @@ class GTEST_API_ UntypedFunctionMockerBase {
 
   // All expectations for this function mocker.
   UntypedExpectations untyped_expectations_;
+
+  bool registry_destructed;
 };  // class UntypedFunctionMockerBase
 
 // Untyped base class for OnCallSpec<F>.
@@ -1468,7 +1474,8 @@ class FunctionMockerBase : public UntypedFunctionMockerBase {
         GTEST_LOCK_EXCLUDED_(g_gmock_mutex) {
     MutexLock l(&g_gmock_mutex);
     VerifyAndClearExpectationsLocked();
-    Mock::UnregisterLocked(this);
+    if (!registry_destructed)
+      Mock::UnregisterLocked(this);
     ClearDefaultActionsLocked();
   }
 

--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -215,8 +215,8 @@ class GTEST_API_ UntypedFunctionMockerBase {
       const void* untyped_args)
           GTEST_LOCK_EXCLUDED_(g_gmock_mutex);
 
-  void set_registry_destructed() {
-    registry_destructed = true;
+  void SetRegistryDestructed() {
+    registry_destructed_ = true;
   }
 
  protected:
@@ -244,7 +244,7 @@ class GTEST_API_ UntypedFunctionMockerBase {
   // All expectations for this function mocker.
   UntypedExpectations untyped_expectations_;
 
-  bool registry_destructed;
+  bool registry_destructed_;
 };  // class UntypedFunctionMockerBase
 
 // Untyped base class for OnCallSpec<F>.
@@ -383,12 +383,12 @@ class GTEST_API_ Mock {
   static void AllowLeak(const void* mock_obj)
       GTEST_LOCK_EXCLUDED_(internal::g_gmock_mutex);
 
-  // Tells Google Mock about global static mocks, so that they are
-  // not falsely detected as leaks, if they outlive the
-  // global g_mock_object_registry
-  // (this is if a global static mock's destructor is called AFTER
+  // Tells Google Mock about mocks with static storage duration,
+  // so that they are not falsely detected as leaks, if they
+  // outlive the static g_mock_object_registry
+  // (this is if a static mock's destructor is called AFTER
   //  g_mock_object_registry's destructor)
-  inline static void MarkGlobalStatic(const void* mock_obj) {
+  static void MarkStatic(const void* mock_obj) {
      AllowLeak(mock_obj);
   }
 
@@ -1483,7 +1483,7 @@ class FunctionMockerBase : public UntypedFunctionMockerBase {
         GTEST_LOCK_EXCLUDED_(g_gmock_mutex) {
     MutexLock l(&g_gmock_mutex);
     VerifyAndClearExpectationsLocked();
-    if (!registry_destructed)
+    if (!registry_destructed_)
       Mock::UnregisterLocked(this);
     ClearDefaultActionsLocked();
   }

--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -79,8 +79,6 @@
 
 namespace testing {
 
-class MockObjectRegistry; // forward declaration
-
 // An abstract handle of an expectation.
 class Expectation;
 
@@ -242,7 +240,7 @@ class GTEST_API_ UntypedFunctionMockerBase {
   // All expectations for this function mocker.
   UntypedExpectations untyped_expectations_;
 
-  MockObjectRegistry *&g_mock_object_registry_p;
+  bool &g_mock_object_registry_valid_;
 };  // class UntypedFunctionMockerBase
 
 // Untyped base class for OnCallSpec<F>.
@@ -1472,7 +1470,7 @@ class FunctionMockerBase : public UntypedFunctionMockerBase {
         GTEST_LOCK_EXCLUDED_(g_gmock_mutex) {
     MutexLock l(&g_gmock_mutex);
     VerifyAndClearExpectationsLocked();
-    if (g_mock_object_registry_p)
+    if (g_mock_object_registry_valid_)
       Mock::UnregisterLocked(this);
     ClearDefaultActionsLocked();
   }

--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -383,6 +383,15 @@ class GTEST_API_ Mock {
   static void AllowLeak(const void* mock_obj)
       GTEST_LOCK_EXCLUDED_(internal::g_gmock_mutex);
 
+  // Tells Google Mock about global static mocks, so that they are
+  // not falsely detected as leaks, if they outlive the
+  // global g_mock_object_registry
+  // (this is if a global static mock's destructor is called AFTER
+  //  g_mock_object_registry's destructor)
+  inline static void MarkGlobalStatic(const void* mock_obj) {
+     AllowLeak(mock_obj);
+  }
+
   // Verifies and clears all expectations on the given mock object.
   // If the expectations aren't satisfied, generates one or more
   // Google Test non-fatal failures and returns false.

--- a/googlemock/src/gmock-spec-builders.cc
+++ b/googlemock/src/gmock-spec-builders.cc
@@ -508,8 +508,8 @@ bool UntypedFunctionMockerBase::VerifyAndClearExpectationsLocked()
             And that static instance is probably already destructed. (Same as the registry).
             Therefore write out the message here.
          */
-         std::cout << "Warning: Mocks (typically global static mocks), should not be verified on destruction (at program ending),\n"
-                      "but explicitly by calling Mock::VerifyAndClearExpectations(&your_global_mock_obj)\n"
+         std::cout << "   Warning: Mocks (typically global static mocks), should not be verified on destruction (if this is at program ending!),\n"
+                      "   but explicitly by calling Mock::VerifyAndClearExpectations(&your_global_mock_obj)\n"
                    << untyped_expectation->file() << ':' << untyped_expectation->line() << ": Failure\n" << ss.str() << std::endl;
       }
     }

--- a/googlemock/src/gmock-spec-builders.cc
+++ b/googlemock/src/gmock-spec-builders.cc
@@ -50,7 +50,7 @@
 
 namespace testing {
 
-static MockObjectRegistry *g_mock_object_registry_ptr;
+static bool g_mock_object_registry_valid;
 
 namespace internal {
 
@@ -271,7 +271,7 @@ void ReportUninterestingCall(CallReaction reaction, const string& msg) {
 }
 
 UntypedFunctionMockerBase::UntypedFunctionMockerBase()
-    : mock_obj_(NULL), name_(""), g_mock_object_registry_p(g_mock_object_registry_ptr) {}
+    : mock_obj_(NULL), name_(""), g_mock_object_registry_valid_(g_mock_object_registry_valid) {}
 
 UntypedFunctionMockerBase::~UntypedFunctionMockerBase() {}
 
@@ -514,6 +514,9 @@ bool UntypedFunctionMockerBase::VerifyAndClearExpectationsLocked()
 
 }  // namespace internal
 
+// Class Mock.
+
+namespace {
 
 typedef std::set<internal::UntypedFunctionMockerBase*> FunctionMockers;
 
@@ -544,7 +547,7 @@ class MockObjectRegistry {
   typedef std::map<const void*, MockObjectState> StateMap;
 
   MockObjectRegistry() {
-    g_mock_object_registry_ptr = this;
+    g_mock_object_registry_valid = true;
   }
   // This destructor will be called when a program exits, after all
   // tests in it have been run.  By then, there should be no mock
@@ -554,7 +557,7 @@ class MockObjectRegistry {
     // "using ::std::cout;" doesn't work with Symbian's STLport, where cout is
     // a macro.
 
-    g_mock_object_registry_ptr = 0;
+    g_mock_object_registry_valid = false;
 
     if (!GMOCK_FLAG(catch_leaked_mocks))
       return;
@@ -605,10 +608,6 @@ class MockObjectRegistry {
   StateMap states_;
 };
 
-
-// Class Mock.
-
-namespace {
 
 // Protected by g_gmock_mutex.
 MockObjectRegistry g_mock_object_registry;

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1301,7 +1301,7 @@ class GTEST_API_ UnitTest {
       const std::string& message);
 
   // Creates an empty UnitTest.
-  UnitTest();
+  UnitTest(bool static_unit = false);
 
   // D'tor
   virtual ~UnitTest();
@@ -1326,6 +1326,8 @@ class GTEST_API_ UnitTest {
   internal::UnitTestImpl* impl_;
 
   static UnitTest *ut_instance;
+
+  const bool static_unit_;
   
   // We disallow copying UnitTest.
   GTEST_DISALLOW_COPY_AND_ASSIGN_(UnitTest);

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -3997,7 +3997,7 @@ UnitTest* UnitTest::GetInstance() {
   static UnitTest* const instance = new UnitTest;
   return instance;
 #else
-  static UnitTest instance;
+  static UnitTest instance(true);
   return ut_instance;
 #endif  // (_MSC_VER == 1310 && !defined(_DEBUG)) || defined(__BORLANDC__)
 }
@@ -4308,14 +4308,16 @@ internal::ParameterizedTestCaseRegistry&
 #endif  // GTEST_HAS_PARAM_TEST
 
 // Creates an empty UnitTest.
-UnitTest::UnitTest() {
+UnitTest::UnitTest(bool static_unit) : static_unit_(static_unit_) {
   impl_ = new internal::UnitTestImpl(this);
-  ut_instance = this;
+  if (static_unit_)
+    ut_instance = this;
 }
 
 // Destructor of UnitTest.
 UnitTest::~UnitTest() {
-  ut_instance = 0;
+  if (static_unit_)
+    ut_instance = 0;
   delete impl_;
 }
 

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -3994,7 +3994,7 @@ UnitTest* UnitTest::GetInstance() {
   // design with private destructor.
 
 #if (_MSC_VER == 1310 && !defined(_DEBUG)) || defined(__BORLANDC__)
-  static UnitTest* const instance = new UnitTest;
+  static UnitTest* const instance = new UnitTest(true);
   return instance;
 #else
   static UnitTest instance(true);

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -3995,9 +3995,12 @@ UnitTest* UnitTest::GetInstance() {
 
 #if (_MSC_VER == 1310 && !defined(_DEBUG)) || defined(__BORLANDC__)
   static UnitTest* const instance = new UnitTest(true);
-  return instance;
+  return ut_instance;
 #else
   static UnitTest instance(true);
+
+  // return pointer to static instance which is set to nullptr
+  // when static instance is destructed
   return ut_instance;
 #endif  // (_MSC_VER == 1310 && !defined(_DEBUG)) || defined(__BORLANDC__)
 }

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -4308,7 +4308,7 @@ internal::ParameterizedTestCaseRegistry&
 #endif  // GTEST_HAS_PARAM_TEST
 
 // Creates an empty UnitTest.
-UnitTest::UnitTest(bool static_unit) : static_unit_(static_unit_) {
+UnitTest::UnitTest(bool static_unit) : static_unit_(static_unit) {
   impl_ = new internal::UnitTestImpl(this);
   if (static_unit_)
     ut_instance = this;


### PR DESCRIPTION
Global mocks may outlive the registry. 
Currently such mocks - in their destructors - still access the destructed registry!
(This commit should prevent that, and hence prevent mem-corruption.)

Related to #652 
