### PR TITLE
Add include dirs to targets if CMake version supports it

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -92,6 +92,14 @@ cxx_library(gmock_main
             src/gmock-all.cc
             src/gmock_main.cc)
 
+# If the CMake version supports it, attach header directory information
+# to the targets for when we are part of a parent build (ie being pulled
+# in via add_subdirectory() rather than being a standalone build).
+if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
+  target_include_directories(gmock      INTERFACE "${gmock_SOURCE_DIR}/include")
+  target_include_directories(gmock_main INTERFACE "${gmock_SOURCE_DIR}/include")
+endif()
+
 ########################################################################
 #
 # Google Mock's own tests.

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -91,6 +91,14 @@ cxx_library(gtest "${cxx_strict}" src/gtest-all.cc)
 cxx_library(gtest_main "${cxx_strict}" src/gtest_main.cc)
 target_link_libraries(gtest_main gtest)
 
+# If the CMake version supports it, attach header directory information
+# to the targets for when we are part of a parent build (ie being pulled
+# in via add_subdirectory() rather than being a standalone build).
+if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
+  target_include_directories(gtest      INTERFACE "${gtest_SOURCE_DIR}/include")
+  target_include_directories(gtest_main INTERFACE "${gtest_SOURCE_DIR}/include")
+endif()
+
 ########################################################################
 #
 # Install rules


### PR DESCRIPTION
I've verified on OS X 10.10.5 that with this change, googletest and googlemock builds with the following CMake versions:

- 2.6.4
- 2.8.10.2
- 2.8.11.1
- 3.4.1

I've also verified that the include directories are successfully attached to the targets when using CMake 2.8.11.1 and 3.4.1, and are not attached when using CMake 2.6.4 or 2.8.10.2, hence confirming the expected behaviour.