### PR TITLE
fixed link in googlemock documentation

### DIFF
--- a/googlemock/docs/CheatSheet.md
+++ b/googlemock/docs/CheatSheet.md
@@ -77,7 +77,7 @@ The typical flow is:
   1. Create the mock objects.
   1. Optionally, set the default actions of the mock objects.
   1. Set your expectations on the mock objects (How will they be called? What wil they do?).
-  1. Exercise code that uses the mock objects; if necessary, check the result using [Google Test](http://code.google.com/p/googletest/) assertions.
+  1. Exercise code that uses the mock objects; if necessary, check the result using [Google Test](../../googletest/) assertions.
   1. When a mock objects is destructed, Google Mock automatically verifies that all expectations on it have been satisfied.
 
 Here is an example:
@@ -197,7 +197,7 @@ matcher will be changed.
 |`NanSensitiveFloatEq(a_float)`|`argument` is a `float` value approximately equal to `a_float`, treating two NaNs as equal.    |
 
 The above matchers use ULP-based comparison (the same as used in
-[Google Test](http://code.google.com/p/googletest/)). They
+[Google Test](../../googletest/)). They
 automatically pick a reasonable error bound based on the absolute
 value of the expected value.  `DoubleEq()` and `FloatEq()` conform to
 the IEEE standard, which requires comparing two NaNs for equality to
@@ -227,7 +227,7 @@ The `argument` can be either a C string or a C++ string object:
 
 `ContainsRegex()` and `MatchesRegex()` use the regular expression
 syntax defined
-[here](http://code.google.com/p/googletest/wiki/AdvancedGuide#Regular_Expression_Syntax).
+[here](../../googletest/docs/AdvancedGuide.md#regular-expression-syntax).
 `StrCaseEq()`, `StrCaseNe()`, `StrEq()`, and `StrNe()` work for wide
 strings as well.
 
@@ -322,7 +322,7 @@ You can make a matcher from one or more other matchers:
 
 |`MatcherCast<T>(m)`|casts matcher `m` to type `Matcher<T>`.|
 |:------------------|:--------------------------------------|
-|`SafeMatcherCast<T>(m)`| [safely casts](http://code.google.com/p/googlemock/wiki/CookBook#Casting_Matchers) matcher `m` to type `Matcher<T>`. |
+|`SafeMatcherCast<T>(m)`| [safely casts](CookBook.md#casting-matchers) matcher `m` to type `Matcher<T>`. |
 |`Truly(predicate)` |`predicate(argument)` returns something considered by C++ to be true, where `predicate` is a function or functor.|
 
 ## Matchers as Predicates ##
@@ -347,7 +347,7 @@ You can make a matcher from one or more other matchers:
 
 ## Matchers as Test Assertions ##
 
-|`ASSERT_THAT(expression, m)`|Generates a [fatal failure](http://code.google.com/p/googletest/wiki/Primer#Assertions) if the value of `expression` doesn't match matcher `m`.|
+|`ASSERT_THAT(expression, m)`|Generates a [fatal failure](../../googletest/docs/Primer.md#assertions) if the value of `expression` doesn't match matcher `m`.|
 |:---------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------|
 |`EXPECT_THAT(expression, m)`|Generates a non-fatal failure if the value of `expression` doesn't match matcher `m`.                                                          |
 
@@ -553,7 +553,7 @@ class MockFunction<R(A1, ..., An)> {
   MOCK_METHODn(Call, R(A1, ..., An));
 };
 ```
-See this [recipe](http://code.google.com/p/googlemock/wiki/CookBook#Using_Check_Points) for one application of it.
+See this [recipe](CookBook.md#using-check-points) for one application of it.
 
 # Flags #
 

--- a/googlemock/docs/CookBook.md
+++ b/googlemock/docs/CookBook.md
@@ -905,7 +905,7 @@ Matches(AllOf(Ge(0), Le(100), Ne(50)))
 
 Since matchers are basically predicates that also know how to describe
 themselves, there is a way to take advantage of them in
-[Google Test](http://code.google.com/p/googletest/) assertions. It's
+[Google Test](../../googletest/) assertions. It's
 called `ASSERT_THAT` and `EXPECT_THAT`:
 
 ```
@@ -948,7 +948,7 @@ Expected: starts with "Hello"
 ```
 
 **Credit:** The idea of `(ASSERT|EXPECT)_THAT` was stolen from the
-[Hamcrest](http://code.google.com/p/hamcrest/) project, which adds
+[Hamcrest](https://github.com/hamcrest/) project, which adds
 `assertThat()` to JUnit.
 
 ## Using Predicates as Matchers ##
@@ -1343,7 +1343,7 @@ Remember that `_` is the wildcard matcher that matches anything. With this, if `
 
 Note that the order of the two `EXPECT_CALLs` is important, as a newer `EXPECT_CALL` takes precedence over an older one.
 
-For more on uninteresting calls, nice mocks, and strict mocks, read ["The Nice, the Strict, and the Naggy"](https://code.google.com/p/googlemock/wiki/CookBook#The_Nice,_the_Strict,_and_the_Naggy).
+For more on uninteresting calls, nice mocks, and strict mocks, read ["The Nice, the Strict, and the Naggy"](#the-nice-the-strict-and-the-naggy).
 
 ## Expecting Ordered Calls ##
 
@@ -1387,7 +1387,7 @@ instead of being overly constraining.
 
 Google Mock allows you to impose an arbitrary DAG (directed acyclic
 graph) on the calls. One way to express the DAG is to use the
-[After](http://code.google.com/p/googlemock/wiki/CheatSheet#The_After_Clause) clause of `EXPECT_CALL`.
+[After](CheatSheet.md#the-after-clause) clause of `EXPECT_CALL`.
 
 Another way is via the `InSequence()` clause (not the same as the
 `InSequence` class), which we borrowed from jMock 2. It's less
@@ -2484,7 +2484,7 @@ MockFoo::~MockFoo() {}
 
 When it's being destoyed, your friendly mock object will automatically
 verify that all expectations on it have been satisfied, and will
-generate [Google Test](http://code.google.com/p/googletest/) failures
+generate [Google Test](../../googletest/) failures
 if not. This is convenient as it leaves you with one less thing to
 worry about. That is, unless you are not sure if your mock object will
 be destoyed.
@@ -2803,7 +2803,7 @@ obvious that the third `EXPECT_CALL` is written wrong. Case solved.
 ## Running Tests in Emacs ##
 
 If you build and run your tests in Emacs, the source file locations of
-Google Mock and [Google Test](http://code.google.com/p/googletest/)
+Google Mock and [Google Test](../../googletest/)
 errors will be highlighted. Just press `<Enter>` on one of them and
 you'll be taken to the offending line. Or, you can just type `C-x ``
 to jump to the next error.
@@ -2838,7 +2838,7 @@ and you should see an `OUTPUT_DIR` directory being created with files
 These three files contain everything you need to use Google Mock (and
 Google Test).  Just copy them to anywhere you want and you are ready
 to write tests and use mocks.  You can use the
-[scrpts/test/Makefile](http://code.google.com/p/googlemock/source/browse/trunk/scripts/test/Makefile) file as an example on how to compile your tests
+[scrpts/test/Makefile](../scripts/test/Makefile) file as an example on how to compile your tests
 against them.
 
 # Extending Google Mock #
@@ -3670,6 +3670,6 @@ This printer knows how to print built-in C++ types, native arrays, STL
 containers, and any type that supports the `<<` operator.  For other
 types, it prints the raw bytes in the value and hopes that you the
 user can figure it out.
-[Google Test's advanced guide](http://code.google.com/p/googletest/wiki/AdvancedGuide#Teaching_Google_Test_How_to_Print_Your_Values)
+[Google Test's advanced guide](../../googletest/docs/AdvancedGuide.md#teaching-google-test-how-to-print-your-values)
 explains how to extend the printer to do a better job at
 printing your particular type than to dump the bytes.

--- a/googlemock/docs/DevGuide.md
+++ b/googlemock/docs/DevGuide.md
@@ -15,7 +15,7 @@ All Google Mock source and pre-built packages are provided under the [New BSD Li
 ## The Google Mock Community ##
 
 The Google Mock community exists primarily through the [discussion group](http://groups.google.com/group/googlemock), the
-[issue tracker](http://code.google.com/p/googlemock/issues/list) and, to a lesser extent, the [source control repository](http://code.google.com/p/googlemock/source/checkout). You are definitely encouraged to contribute to the
+[issue tracker](https://github.com/google/googletest/issues) and, to a lesser extent, the [source control repository](../). You are definitely encouraged to contribute to the
 discussion and you can also help us to keep the effectiveness of the
 group high by following and promoting the guidelines listed here.
 
@@ -52,12 +52,12 @@ Checking out the Google Mock source is most useful if you plan to
 tweak it yourself.  You check out the source for Google Mock using a
 [Subversion](http://subversion.tigris.org/) client as you would for any
 other project hosted on Google Code.  Please see the instruction on
-the [source code access page](http://code.google.com/p/googlemock/source/checkout) for how to do it.
+the [source code access page](../) for how to do it.
 
 ## Compiling from Source ##
 
 Once you check out the code, you can find instructions on how to
-compile it in the [README](http://code.google.com/p/googlemock/source/browse/trunk/README) file.
+compile it in the [README](../README.md) file.
 
 ## Testing ##
 
@@ -90,8 +90,8 @@ instructions for how to sign and return it.
 ## Coding Style ##
 
 To keep the source consistent, readable, diffable and easy to merge,
-we use a fairly rigid coding style, as defined by the [google-styleguide](http://code.google.com/p/google-styleguide/) project.  All patches will be expected
-to conform to the style outlined [here](http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml).
+we use a fairly rigid coding style, as defined by the [google-styleguide](https://github.com/google/styleguide) project.  All patches will be expected
+to conform to the style outlined [here](https://github.com/google/styleguide/blob/gh-pages/cppguide.xml).
 
 ## Submitting Patches ##
 
@@ -104,7 +104,7 @@ Please do submit code. Here's what you need to do:
   1. Ensure that there are unit tests for your code.
   1. Sign a Contributor License Agreement.
   1. Create a patch file using `svn diff`.
-  1. We use [Rietveld](http://codereview.appspot.com/) to do web-based code reviews.  You can read about the tool [here](http://code.google.com/p/rietveld/wiki/CodeReviewHelp).  When you are ready, upload your patch via Rietveld and notify `googlemock@googlegroups.com` to review it.  There are several ways to upload the patch.  We recommend using the [upload\_gmock.py](http://code.google.com/p/googlemock/source/browse/trunk/scripts/upload_gmock.py) script, which you can find in the `scripts/` folder in the SVN trunk.
+  1. We use [Rietveld](http://codereview.appspot.com/) to do web-based code reviews.  You can read about the tool [here](https://github.com/rietveld-codereview/rietveld/wiki).  When you are ready, upload your patch via Rietveld and notify `googlemock@googlegroups.com` to review it.  There are several ways to upload the patch.  We recommend using the [upload\_gmock.py](../scripts/upload_gmock.py) script, which you can find in the `scripts/` folder in the SVN trunk.
 
 ## Google Mock Committers ##
 

--- a/googlemock/docs/Documentation.md
+++ b/googlemock/docs/Documentation.md
@@ -9,4 +9,4 @@ This page lists all documentation wiki pages for Google Mock **(the SVN trunk ve
 To contribute code to Google Mock, read:
 
   * [DevGuide](DevGuide.md) -- read this _before_ writing your first patch.
-  * [Pump Manual](http://code.google.com/p/googletest/wiki/PumpManual) -- how we generate some of Google Mock's source files.
+  * [Pump Manual](../googletest/docs/PumpManual.md) -- how we generate some of Google Mock's source files.

--- a/googlemock/docs/ForDummies.md
+++ b/googlemock/docs/ForDummies.md
@@ -1,6 +1,6 @@
 
 
-(**Note:** If you get compiler errors that you don't understand, be sure to consult [Google Mock Doctor](http://code.google.com/p/googlemock/wiki/FrequentlyAskedQuestions#How_am_I_supposed_to_make_sense_of_these_horrible_template_error).)
+(**Note:** If you get compiler errors that you don't understand, be sure to consult [Google Mock Doctor](FrequentlyAskedQuestions.md#how-am-i-supposed-to-make-sense-of-these-horrible-template-errors).)
 
 # What Is Google C++ Mocking Framework? #
 When you write a prototype or test, often it's not feasible or wise to rely on real objects entirely. A **mock object** implements the same interface as a real object (so it can be used as one), but lets you specify at run time how it will be used and what it should do (which methods will be called? in which order? how many times? with what arguments? what will they return? etc).
@@ -76,7 +76,7 @@ If you are lucky, the mocks you need to use have already been implemented by som
 Using the `Turtle` interface as example, here are the simple steps you need to follow:
 
   1. Derive a class `MockTurtle` from `Turtle`.
-  1. Take a _virtual_ function of `Turtle` (while it's possible to [mock non-virtual methods using templates](http://code.google.com/p/googlemock/wiki/CookBook#Mocking_Nonvirtual_Methods), it's much more involved). Count how many arguments it has.
+  1. Take a _virtual_ function of `Turtle` (while it's possible to [mock non-virtual methods using templates](CookBook.md#mocking-nonvirtual-methods), it's much more involved). Count how many arguments it has.
   1. In the `public:` section of the child class, write `MOCK_METHODn();` (or `MOCK_CONST_METHODn();` if you are mocking a `const` method), where `n` is the number of the arguments; if you counted wrong, shame on you, and a compiler error will tell you so.
   1. Now comes the fun part: you take the function signature, cut-and-paste the _function name_ as the _first_ argument to the macro, and leave what's left as the _second_ argument (in case you're curious, this is the _type of the function_).
   1. Repeat until all virtual functions you want to mock are done.
@@ -105,7 +105,7 @@ You don't need to define these mock methods somewhere else - the `MOCK_METHOD*` 
 tool requires that you have Python 2.4 installed.  You give it a C++ file and the name of an abstract class defined in it,
 and it will print the definition of the mock class for you.  Due to the
 complexity of the C++ language, this script may not always work, but
-it can be quite handy when it does.  For more details, read the [user documentation](http://code.google.com/p/googlemock/source/browse/trunk/scripts/generator/README).
+it can be quite handy when it does.  For more details, read the [user documentation](../scripts/generator/README).
 
 ## Where to Put It ##
 When you define a mock class, you need to decide where to put its definition. Some people put it in a `*_test.cc`. This is fine when the interface being mocked (say, `Foo`) is owned by the same person or team. Otherwise, when the owner of `Foo` changes it, your test could break. (You can't really expect `Foo`'s maintainer to fix every test that uses `Foo`, can you?)
@@ -169,7 +169,7 @@ This means `EXPECT_CALL()` should be read as expecting that a call will occur _i
 Admittedly, this test is contrived and doesn't do much. You can easily achieve the same effect without using Google Mock. However, as we shall reveal soon, Google Mock allows you to do _much more_ with the mocks.
 
 ## Using Google Mock with Any Testing Framework ##
-If you want to use something other than Google Test (e.g. [CppUnit](http://apps.sourceforge.net/mediawiki/cppunit/index.php?title=Main_Page) or
+If you want to use something other than Google Test (e.g. [CppUnit](http://sourceforge.net/projects/cppunit/) or
 [CxxTest](http://cxxtest.tigris.org/)) as your testing framework, just change the `main()` function in the previous section to:
 ```
 int main(int argc, char** argv) {
@@ -187,7 +187,7 @@ sometimes causes the test program to crash.  You'll still be able to
 notice that the test has failed, but it's not a graceful failure.
 
 A better solution is to use Google Test's
-[event listener API](http://code.google.com/p/googletest/wiki/AdvancedGuide#Extending_Google_Test_by_Handling_Test_Events)
+[event listener API](../../googletest/docs/AdvancedGuide.md#extending-google-test-by-handling-test-events)
 to report a test failure to your testing framework properly.  You'll need to
 implement the `OnTestPartResult()` method of the event listener interface, but it
 should be straightforward.
@@ -301,7 +301,7 @@ says that `turtle.GetY()` will be called _at least twice_ (Google Mock knows thi
 
 Of course, if you explicitly write a `Times()`, Google Mock will not try to infer the cardinality itself. What if the number you specified is larger than there are `WillOnce()` clauses? Well, after all `WillOnce()`s are used up, Google Mock will do the _default_ action for the function every time (unless, of course, you have a `WillRepeatedly()`.).
 
-What can we do inside `WillOnce()` besides `Return()`? You can return a reference using `ReturnRef(variable)`, or invoke a pre-defined function, among [others](http://code.google.com/p/googlemock/wiki/CheatSheet#Actions).
+What can we do inside `WillOnce()` besides `Return()`? You can return a reference using `ReturnRef(variable)`, or invoke a pre-defined function, among [others](CheatSheet.md#actions).
 
 **Important note:** The `EXPECT_CALL()` statement evaluates the action clause only once, even though the action may be performed many times. Therefore you must be careful about side effects. The following may not do what you want:
 

--- a/googlemock/docs/FrequentlyAskedQuestions.md
+++ b/googlemock/docs/FrequentlyAskedQuestions.md
@@ -7,7 +7,7 @@ tried [Google Mock Doctor](#How_am_I_supposed_to_make_sense_of_these_horrible_te
 
 ## When I call a method on my mock object, the method for the real object is invoked instead.  What's the problem? ##
 
-In order for a method to be mocked, it must be _virtual_, unless you use the [high-perf dependency injection technique](http://code.google.com/p/googlemock/wiki/CookBook#Mocking_Nonvirtual_Methods).
+In order for a method to be mocked, it must be _virtual_, unless you use the [high-perf dependency injection technique](CookBook.md#mocking-nonvirtual-methods).
 
 ## I wrote some matchers.  After I upgraded to a new version of Google Mock, they no longer compile.  What's going on? ##
 
@@ -196,8 +196,8 @@ class MyGreatMatcher {
 ```
 
 For more information, you can read these
-[two](http://code.google.com/p/googlemock/wiki/CookBook#Writing_New_Monomorphic_Matchers)
-[recipes](http://code.google.com/p/googlemock/wiki/CookBook#Writing_New_Polymorphic_Matchers)
+[two](CookBook.md#writing-new-monomorphic-matchers)
+[recipes](CookBook.md#writing-new-polymorphic-matchers)
 from the cookbook.  As always, you
 are welcome to post questions on `googlemock@googlegroups.com` if you
 need any help.
@@ -206,7 +206,7 @@ need any help.
 
 Google Mock works out of the box with Google Test.  However, it's easy
 to configure it to work with any testing framework of your choice.
-[Here](http://code.google.com/p/googlemock/wiki/ForDummies#Using_Google_Mock_with_Any_Testing_Framework) is how.
+[Here](ForDummies.md#using-google-mock-with-any-testing-framework) is how.
 
 ## How am I supposed to make sense of these horrible template errors? ##
 
@@ -474,10 +474,10 @@ verbose level.
 If you find yourself needing to perform some action that's not
 supported by Google Mock directly, remember that you can define your own
 actions using
-[MakeAction()](http://code.google.com/p/googlemock/wiki/CookBook#Writing_New_Actions) or
-[MakePolymorphicAction()](http://code.google.com/p/googlemock/wiki/CookBook#Writing_New_Polymorphic_Actions),
+[MakeAction()](CookBook.md#writing-new-actions) or
+[MakePolymorphicAction()](CookBook.md#writing_new_polymorphic_actions),
 or you can write a stub function and invoke it using
-[Invoke()](http://code.google.com/p/googlemock/wiki/CookBook#Using_Functions_Methods_Functors).
+[Invoke()](CookBook.md#using-functions_methods_functors).
 
 ## MOCK\_METHODn()'s second argument looks funny.  Why don't you use the MOCK\_METHODn(Method, return\_type, arg\_1, ..., arg\_n) syntax? ##
 
@@ -599,7 +599,7 @@ when the mock method is called.  `SetArgPointee()` says what the
 side effect is, but doesn't say what the return value should be.  You
 need `DoAll()` to chain a `SetArgPointee()` with a `Return()`.
 
-See this [recipe](http://code.google.com/p/googlemock/wiki/CookBook#Mocking_Side_Effects) for more details and an example.
+See this [recipe](CookBook.md#mocking_side_effects) for more details and an example.
 
 
 ## My question is not in your FAQ! ##
@@ -607,12 +607,12 @@ See this [recipe](http://code.google.com/p/googlemock/wiki/CookBook#Mocking_Side
 If you cannot find the answer to your question in this FAQ, there are
 some other resources you can use:
 
-  1. read other [wiki pages](http://code.google.com/p/googlemock/w/list),
+  1. read other [documentation](Documentation.md),
   1. search the mailing list [archive](http://groups.google.com/group/googlemock/topics),
   1. ask it on [googlemock@googlegroups.com](mailto:googlemock@googlegroups.com) and someone will answer it (to prevent spam, we require you to join the [discussion group](http://groups.google.com/group/googlemock) before you can post.).
 
 Please note that creating an issue in the
-[issue tracker](http://code.google.com/p/googlemock/issues/list) is _not_
+[issue tracker](https://github.com/google/googletest/issues) is _not_
 a good way to get your answer, as it is monitored infrequently by a
 very small number of people.
 


### PR DESCRIPTION
Hi I did repair the links in the documentation.
I tried to use relative links wherever possible so that it will work on other servers.