### PR TITLE
The googlemock CMakeLists.txt does not have proper install targets

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -94,6 +94,14 @@ cxx_library(gmock_main
 
 ########################################################################
 #
+# Install rules
+install(TARGETS gmock gmock_main
+  DESTINATION lib)
+install(DIRECTORY ${gmock_SOURCE_DIR}/include/gmock
+  DESTINATION include)
+
+########################################################################
+#
 # Google Mock's own tests.
 #
 # You can skip this section if you aren't interested in testing


### PR DESCRIPTION
Currently, `make install` does not install the gmock headers and libs. 