### PR TITLE
Fix: Markdown in V1_7_Primer.md

### DIFF
--- a/googletest/docs/V1_7_Primer.md
+++ b/googletest/docs/V1_7_Primer.md
@@ -108,6 +108,7 @@ streamed to an assertion, it will be translated to UTF-8 when printed.
 ## Basic Assertions ##
 
 These assertions do basic true/false condition testing.
+
 | **Fatal assertion** | **Nonfatal assertion** | **Verifies** |
 |:--------------------|:-----------------------|:-------------|
 | `ASSERT_TRUE(`_condition_`)`;  | `EXPECT_TRUE(`_condition_`)`;   | _condition_ is true |


### PR DESCRIPTION
table "Basic Assertions" is now rendered correctly as table
