### PR TITLE
Fixed GTestDir 

### DIFF
--- a/googlemock/msvc/2010/gmock_config.props
+++ b/googlemock/msvc/2010/gmock_config.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="UserMacros">
-    <GTestDir>../../gtest</GTestDir>
+    <GTestDir>../../../googletest</GTestDir>
   </PropertyGroup>
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>


### PR DESCRIPTION
GMock will not build successfully in VS 2010 unless GTestDir is fixed.
