### PR TITLE
Add link to Google Test Primer docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ mailing list for questions, discussions, and development.  There is
 also an IRC channel on OFTC (irc.oftc.net) #gtest available.  Please
 join us!
 
+Getting started information for **Google Test** is available in the 
+[Google Test Primer](googletest/docs/Primer.md) documentation.
+
 **Google Mock** is an extension to Google Test for writing and using C++ mock
 classes.  See the separate [Google Mock documentation](googlemock/README.md).
 


### PR DESCRIPTION
On google code, the main documentation pages were the "Google Test Primer" content. Currently it's hard to find that content on github, so add a direct link in the main README.md.