### PR TITLE
update relative path to google test directory

### DIFF
--- a/googlemock/make/Makefile
+++ b/googlemock/make/Makefile
@@ -17,7 +17,7 @@
 # Points to the root of Google Test, relative to where this file is.
 # Remember to tweak this if you move this file, or if you want to use
 # a copy of Google Test at a different location.
-GTEST_DIR = ../gtest
+GTEST_DIR = ../../googletest
 
 # Points to the root of Google Mock, relative to where this file is.
 # Remember to tweak this if you move this file.


### PR DESCRIPTION
after moving mock files to googlemock/ sub directory,  the relative path to google test directory is changed.