### PR TITLE
export gtest and gmock cmake config packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,13 @@ option(BUILD_GTEST "Builds the googletest subproject" OFF)
 #Note that googlemock target already builds googletest
 option(BUILD_GMOCK "Builds the googlemock subproject" ON)
 
+# this should preferably be ON
+option(BUILD_WITH_DEBUG_POSTFIX "Builds libraries with a debug postfix 'd'" OFF)
+
+if(BUILD_WITH_DEBUG_POSTFIX)
+	set(CMAKE_DEBUG_POSTFIX "d")
+endif()
+
 if(BUILD_GMOCK)
   add_subdirectory( googlemock )
 elseif(BUILD_GTEST)

--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -96,14 +96,19 @@ cxx_library(gmock_main
 # to the targets for when we are part of a parent build (ie being pulled
 # in via add_subdirectory() rather than being a standalone build).
 if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
-  target_include_directories(gmock      INTERFACE "${gmock_SOURCE_DIR}/include")
-  target_include_directories(gmock_main INTERFACE "${gmock_SOURCE_DIR}/include")
+  target_include_directories(gmock INTERFACE
+    "$<BUILD_INTERFACE:${gmock_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include>")
+  target_include_directories(gmock_main INTERFACE
+    "$<BUILD_INTERFACE:${gmock_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include>")
 endif()
 
 ########################################################################
 #
 # Install rules
 install(TARGETS gmock gmock_main
+  EXPORT gmockConfig
   DESTINATION lib)
 install(DIRECTORY ${gmock_SOURCE_DIR}/include/gmock
   DESTINATION include)
@@ -200,3 +205,6 @@ if (gmock_build_tests)
   cxx_executable(gmock_output_test_ test gmock)
   py_test(gmock_output_test)
 endif()
+
+install(EXPORT gmockConfig
+  DESTINATION lib/cmake)

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -95,14 +95,19 @@ target_link_libraries(gtest_main gtest)
 # to the targets for when we are part of a parent build (ie being pulled
 # in via add_subdirectory() rather than being a standalone build).
 if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
-  target_include_directories(gtest      INTERFACE "${gtest_SOURCE_DIR}/include")
-  target_include_directories(gtest_main INTERFACE "${gtest_SOURCE_DIR}/include")
+  target_include_directories(gtest INTERFACE
+    "$<BUILD_INTERFACE:${gtest_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include>")
+  target_include_directories(gtest_main INTERFACE
+    "$<BUILD_INTERFACE:${gtest_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include>")
 endif()
 
 ########################################################################
 #
 # Install rules
 install(TARGETS gtest gtest_main
+  EXPORT gtestConfig
   DESTINATION lib)
 install(DIRECTORY ${gtest_SOURCE_DIR}/include/gtest
   DESTINATION include)
@@ -284,3 +289,6 @@ if (gtest_build_tests)
   cxx_executable(gtest_xml_output_unittest_ test gtest)
   py_test(gtest_xml_output_unittest)
 endif()
+
+install(EXPORT gtestConfig
+  DESTINATION lib/cmake)


### PR DESCRIPTION
- export gtest and gmock cmake config packages
- fix BUILD and INSTALL interface of include directories
- add option to enable debug postfix (`d`) on library filenames (off by default)
