### PR TITLE
Add HasParam() for value-parametrized tests

### DIFF
--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1747,6 +1747,11 @@ class WithParamInterface {
   typedef T ParamType;
   virtual ~WithParamInterface() {}
 
+  // Returns true if the test is called with a parameter,
+  // i.e. within TEST_P.
+  // This function is helpful for test fixture member functions.
+  bool HasParam() const { return parameter_; }
+
   // The current parameter value. Is also available in the test fixture's
   // constructor. This member function is non-static, even though it only
   // references static data, to reduce the opportunity for incorrect uses


### PR DESCRIPTION
There is no restriction for value-parametrized tests
to be called only within TEST_P.
Upon calling within TEST_F,
SetUp, TearDown, and other member functions of a test fixture
can be made aware of the call without a parameter.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/googletest/691)

<!-- Reviewable:end -->
