### PR TITLE
Provide a boolean context for ASSERT_TRUE and EXPECT_TRUE

### DIFF
--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1861,13 +1861,13 @@ class TestWithParam : public Test, public WithParamInterface<T> {
 // AssertionResult. For more information on how to use AssertionResult with
 // these macros see comments on that class.
 #define EXPECT_TRUE(condition) \
-  GTEST_TEST_BOOLEAN_(condition, #condition, false, true, \
+  GTEST_TEST_BOOLEAN_(!!(condition), #condition, false, true, \
                       GTEST_NONFATAL_FAILURE_)
 #define EXPECT_FALSE(condition) \
   GTEST_TEST_BOOLEAN_(!(condition), #condition, true, false, \
                       GTEST_NONFATAL_FAILURE_)
 #define ASSERT_TRUE(condition) \
-  GTEST_TEST_BOOLEAN_(condition, #condition, false, true, \
+  GTEST_TEST_BOOLEAN_(!!(condition), #condition, false, true, \
                       GTEST_FATAL_FAILURE_)
 #define ASSERT_FALSE(condition) \
   GTEST_TEST_BOOLEAN_(!(condition), #condition, true, false, \


### PR DESCRIPTION
ASSERT_TRUE and EXPECT_TRUE do not provide a boolean context.

This can be manifest in the following way:

std::shared_ptr<int> foo(new int(5));
ASSERT_TRUE(foo); // this does not compile.

Patch by David Wilcox:
https://groups.google.com/forum/#!topic/googletestframework/uGgC5dopP50

Signed-off-by: Gregor Jasny gjasny@googlemail.com
