### PR TITLE
target_include_directories for gmock, should also include gtest headers

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -96,8 +96,8 @@ cxx_library(gmock_main
 # to the targets for when we are part of a parent build (ie being pulled
 # in via add_subdirectory() rather than being a standalone build).
 if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
-  target_include_directories(gmock      INTERFACE "${gmock_SOURCE_DIR}/include")
-  target_include_directories(gmock_main INTERFACE "${gmock_SOURCE_DIR}/include")
+  target_include_directories(gmock      INTERFACE "${gmock_SOURCE_DIR}/include" "${gtest_SOURCE_DIR}/include")
+  target_include_directories(gmock_main INTERFACE "${gmock_SOURCE_DIR}/include" "${gtest_SOURCE_DIR}/include")
 endif()
 
 ########################################################################


### PR DESCRIPTION
Regarding #655
As one can see, the target `gmock` or `gmock_main` ([ref](https://github.com/google/googletest/blob/a9b73f8139a92315f37e48a3ff3d43e3929055bc/googlemock/CMakeLists.txt#L84)), has the same functionality as as `gtest` or `gtest_main` ([ref](https://github.com/google/googletest/blob/a9b73f8139a92315f37e48a3ff3d43e3929055bc/googletest/CMakeLists.txt#L90)), therefore when linking against target `gmock` or `gmock_main`, one should get not only the gmock-includes, but also the gtest-includes.
