### PR TITLE
Use override keyword (reference: google/googletest#533)

### DIFF
--- a/googlemock/include/gmock/gmock-generated-function-mockers.h
+++ b/googlemock/include/gmock/gmock-generated-function-mockers.h
@@ -353,9 +353,9 @@ using internal::FunctionMocker;
     GTEST_CONCAT_TOKEN_(gmock##constness##arity##_##Method##_, __LINE__)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD0_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD0_(tn, constness, ct, Method, ovrd, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
-      ) constness { \
+      ) constness ovrd { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 0), \
@@ -372,9 +372,9 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD1_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD1_(tn, constness, ct, Method, ovrd, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
-      GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1) constness { \
+      GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1) constness ovrd { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 1), \
@@ -391,10 +391,10 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD2_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD2_(tn, constness, ct, Method, ovrd, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
-      GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2) constness { \
+      GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2) constness ovrd { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 2), \
@@ -412,11 +412,11 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD3_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD3_(tn, constness, ct, Method, ovrd, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
       GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
-      GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3) constness { \
+      GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3) constness ovrd { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 3), \
@@ -437,12 +437,12 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD4_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD4_(tn, constness, ct, Method, ovrd, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
       GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
       GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
-      GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4) constness { \
+      GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4) constness ovrd { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 4), \
@@ -464,13 +464,13 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD5_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD5_(tn, constness, ct, Method, ovrd, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
       GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
       GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
       GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, \
-      GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5) constness { \
+      GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5) constness ovrd { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 5), \
@@ -493,14 +493,14 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD6_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD6_(tn, constness, ct, Method, ovrd, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
       GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
       GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
       GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, \
       GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5, \
-      GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6) constness { \
+      GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6) constness ovrd { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 6), \
@@ -524,7 +524,7 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD7_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD7_(tn, constness, ct, Method, ovrd, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
       GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
@@ -532,7 +532,7 @@ using internal::FunctionMocker;
       GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, \
       GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5, \
       GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
-      GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7) constness { \
+      GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7) constness ovrd { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 7), \
@@ -557,7 +557,7 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD8_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD8_(tn, constness, ct, Method, ovrd, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
       GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
@@ -566,7 +566,7 @@ using internal::FunctionMocker;
       GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5, \
       GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
       GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7, \
-      GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8) constness { \
+      GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8) constness ovrd { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 8), \
@@ -592,7 +592,7 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD9_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD9_(tn, constness, ct, Method, ovrd, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
       GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
@@ -602,7 +602,7 @@ using internal::FunctionMocker;
       GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
       GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7, \
       GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8, \
-      GMOCK_ARG_(tn, 9, __VA_ARGS__) gmock_a9) constness { \
+      GMOCK_ARG_(tn, 9, __VA_ARGS__) gmock_a9) constness ovrd { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 9), \
@@ -631,7 +631,7 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD10_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD10_(tn, constness, ct, Method, ovrd, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
       GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
@@ -642,7 +642,7 @@ using internal::FunctionMocker;
       GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7, \
       GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8, \
       GMOCK_ARG_(tn, 9, __VA_ARGS__) gmock_a9, \
-      GMOCK_ARG_(tn, 10, __VA_ARGS__) gmock_a10) constness { \
+      GMOCK_ARG_(tn, 10, __VA_ARGS__) gmock_a10) constness ovrd { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 10), \
@@ -672,156 +672,379 @@ using internal::FunctionMocker;
   mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(10, constness, \
       Method)
 
-#define MOCK_METHOD0(m, ...) GMOCK_METHOD0_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD1(m, ...) GMOCK_METHOD1_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD2(m, ...) GMOCK_METHOD2_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD3(m, ...) GMOCK_METHOD3_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD4(m, ...) GMOCK_METHOD4_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD5(m, ...) GMOCK_METHOD5_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD6(m, ...) GMOCK_METHOD6_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD7(m, ...) GMOCK_METHOD7_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD8(m, ...) GMOCK_METHOD8_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD9(m, ...) GMOCK_METHOD9_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD10(m, ...) GMOCK_METHOD10_(, , , m, __VA_ARGS__)
+#if GMOCK_USE_OVERRIDE
+  #define GMOCK_OVERRIDE_ override
+#else
+  #define GMOCK_OVERRIDE_
+#endif
 
-#define MOCK_CONST_METHOD0(m, ...) GMOCK_METHOD0_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD1(m, ...) GMOCK_METHOD1_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD2(m, ...) GMOCK_METHOD2_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD3(m, ...) GMOCK_METHOD3_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD4(m, ...) GMOCK_METHOD4_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD5(m, ...) GMOCK_METHOD5_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD6(m, ...) GMOCK_METHOD6_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD7(m, ...) GMOCK_METHOD7_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD8(m, ...) GMOCK_METHOD8_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD9(m, ...) GMOCK_METHOD9_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD10(m, ...) GMOCK_METHOD10_(, const, , m, __VA_ARGS__)
+#define MOCK_METHOD0(m, ...) \
+    GMOCK_METHOD0_(, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD1(m, ...) \
+    GMOCK_METHOD1_(, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD2(m, ...) \
+    GMOCK_METHOD2_(, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD3(m, ...) \
+    GMOCK_METHOD3_(, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD4(m, ...) \
+    GMOCK_METHOD4_(, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD5(m, ...) \
+    GMOCK_METHOD5_(, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD6(m, ...) \
+    GMOCK_METHOD6_(, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD7(m, ...) \
+    GMOCK_METHOD7_(, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD8(m, ...) \
+    GMOCK_METHOD8_(, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD9(m, ...) \
+    GMOCK_METHOD9_(, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD10(m, ...) \
+    GMOCK_METHOD10_(, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
 
-#define MOCK_METHOD0_T(m, ...) GMOCK_METHOD0_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD1_T(m, ...) GMOCK_METHOD1_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD2_T(m, ...) GMOCK_METHOD2_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD3_T(m, ...) GMOCK_METHOD3_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD4_T(m, ...) GMOCK_METHOD4_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD5_T(m, ...) GMOCK_METHOD5_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD6_T(m, ...) GMOCK_METHOD6_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD7_T(m, ...) GMOCK_METHOD7_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD8_T(m, ...) GMOCK_METHOD8_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD9_T(m, ...) GMOCK_METHOD9_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD10_T(m, ...) GMOCK_METHOD10_(typename, , , m, __VA_ARGS__)
+#define MOCK_CONST_METHOD0(m, ...) \
+    GMOCK_METHOD0_(, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_CONST_METHOD1(m, ...) \
+    GMOCK_METHOD1_(, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_CONST_METHOD2(m, ...) \
+    GMOCK_METHOD2_(, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_CONST_METHOD3(m, ...) \
+    GMOCK_METHOD3_(, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_CONST_METHOD4(m, ...) \
+    GMOCK_METHOD4_(, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_CONST_METHOD5(m, ...) \
+    GMOCK_METHOD5_(, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_CONST_METHOD6(m, ...) \
+    GMOCK_METHOD6_(, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_CONST_METHOD7(m, ...) \
+    GMOCK_METHOD7_(, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_CONST_METHOD8(m, ...) \
+    GMOCK_METHOD8_(, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_CONST_METHOD9(m, ...) \
+    GMOCK_METHOD9_(, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_CONST_METHOD10(m, ...) \
+    GMOCK_METHOD10_(, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+
+#define MOCK_METHOD0_T(m, ...) \
+    GMOCK_METHOD0_(typename, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD1_T(m, ...) \
+    GMOCK_METHOD1_(typename, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD2_T(m, ...) \
+    GMOCK_METHOD2_(typename, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD3_T(m, ...) \
+    GMOCK_METHOD3_(typename, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD4_T(m, ...) \
+    GMOCK_METHOD4_(typename, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD5_T(m, ...) \
+    GMOCK_METHOD5_(typename, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD6_T(m, ...) \
+    GMOCK_METHOD6_(typename, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD7_T(m, ...) \
+    GMOCK_METHOD7_(typename, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD8_T(m, ...) \
+    GMOCK_METHOD8_(typename, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD9_T(m, ...) \
+    GMOCK_METHOD9_(typename, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
+#define MOCK_METHOD10_T(m, ...) \
+    GMOCK_METHOD10_(typename, , , m, GMOCK_OVERRIDE_, __VA_ARGS__)
 
 #define MOCK_CONST_METHOD0_T(m, ...) \
-    GMOCK_METHOD0_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD0_(typename, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD1_T(m, ...) \
-    GMOCK_METHOD1_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD1_(typename, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD2_T(m, ...) \
-    GMOCK_METHOD2_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD2_(typename, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD3_T(m, ...) \
-    GMOCK_METHOD3_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD3_(typename, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD4_T(m, ...) \
-    GMOCK_METHOD4_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD4_(typename, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD5_T(m, ...) \
-    GMOCK_METHOD5_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD5_(typename, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD6_T(m, ...) \
-    GMOCK_METHOD6_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD6_(typename, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD7_T(m, ...) \
-    GMOCK_METHOD7_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD7_(typename, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD8_T(m, ...) \
-    GMOCK_METHOD8_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD8_(typename, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD9_T(m, ...) \
-    GMOCK_METHOD9_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD9_(typename, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD10_T(m, ...) \
-    GMOCK_METHOD10_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD10_(typename, const, , m, GMOCK_OVERRIDE_, __VA_ARGS__)
 
 #define MOCK_METHOD0_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD0_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD0_(, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD1_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD1_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD1_(, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD2_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD2_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD2_(, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD3_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD3_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD3_(, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD4_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD4_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD4_(, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD5_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD5_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD5_(, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD6_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD6_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD6_(, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD7_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD7_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD7_(, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD8_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD8_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD8_(, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD9_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD9_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD9_(, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD10_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD10_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD10_(, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 
 #define MOCK_CONST_METHOD0_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD0_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD0_(, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD1_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD1_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD1_(, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD2_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD2_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD2_(, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD3_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD3_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD3_(, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD4_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD4_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD4_(, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD5_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD5_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD5_(, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD6_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD6_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD6_(, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD7_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD7_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD7_(, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD8_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD8_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD8_(, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD9_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD9_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD9_(, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD10_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD10_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD10_(, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 
 #define MOCK_METHOD0_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD0_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD0_(typename, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD1_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD1_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD1_(typename, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD2_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD2_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD2_(typename, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD3_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD3_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD3_(typename, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD4_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD4_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD4_(typename, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD5_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD5_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD5_(typename, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD6_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD6_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD6_(typename, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD7_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD7_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD7_(typename, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD8_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD8_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD8_(typename, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD9_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD9_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD9_(typename, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_METHOD10_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD10_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD10_(typename, , ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 
 #define MOCK_CONST_METHOD0_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD0_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD0_(typename, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD1_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD1_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD1_(typename, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD2_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD2_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD2_(typename, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD3_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD3_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD3_(typename, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD4_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD4_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD4_(typename, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD5_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD5_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD5_(typename, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD6_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD6_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD6_(typename, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD7_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD7_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD7_(typename, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD8_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD8_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD8_(typename, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD9_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD9_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD9_(typename, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
 #define MOCK_CONST_METHOD10_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD10_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD10_(typename, const, ct, m, GMOCK_OVERRIDE_, __VA_ARGS__)
+
+#define MOCK_NOOVERRIDE_METHOD0(m, ...) \
+    GMOCK_METHOD0_(, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD1(m, ...) \
+    GMOCK_METHOD1_(, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD2(m, ...) \
+    GMOCK_METHOD2_(, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD3(m, ...) \
+    GMOCK_METHOD3_(, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD4(m, ...) \
+    GMOCK_METHOD4_(, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD5(m, ...) \
+    GMOCK_METHOD5_(, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD6(m, ...) \
+    GMOCK_METHOD6_(, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD7(m, ...) \
+    GMOCK_METHOD7_(, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD8(m, ...) \
+    GMOCK_METHOD8_(, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD9(m, ...) \
+    GMOCK_METHOD9_(, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD10(m, ...) \
+    GMOCK_METHOD10_(, , , m, , __VA_ARGS__)
+
+#define MOCK_CONST_NOOVERRIDE_METHOD0(m, ...) \
+    GMOCK_METHOD0_(, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD1(m, ...) \
+    GMOCK_METHOD1_(, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD2(m, ...) \
+    GMOCK_METHOD2_(, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD3(m, ...) \
+    GMOCK_METHOD3_(, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD4(m, ...) \
+    GMOCK_METHOD4_(, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD5(m, ...) \
+    GMOCK_METHOD5_(, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD6(m, ...) \
+    GMOCK_METHOD6_(, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD7(m, ...) \
+    GMOCK_METHOD7_(, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD8(m, ...) \
+    GMOCK_METHOD8_(, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD9(m, ...) \
+    GMOCK_METHOD9_(, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD10(m, ...) \
+    GMOCK_METHOD10_(, const, , m, , __VA_ARGS__)
+
+#define MOCK_NOOVERRIDE_METHOD0_T(m, ...) \
+    GMOCK_METHOD0_(typename, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD1_T(m, ...) \
+    GMOCK_METHOD1_(typename, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD2_T(m, ...) \
+    GMOCK_METHOD2_(typename, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD3_T(m, ...) \
+    GMOCK_METHOD3_(typename, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD4_T(m, ...) \
+    GMOCK_METHOD4_(typename, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD5_T(m, ...) \
+    GMOCK_METHOD5_(typename, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD6_T(m, ...) \
+    GMOCK_METHOD6_(typename, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD7_T(m, ...) \
+    GMOCK_METHOD7_(typename, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD8_T(m, ...) \
+    GMOCK_METHOD8_(typename, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD9_T(m, ...) \
+    GMOCK_METHOD9_(typename, , , m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD10_T(m, ...) \
+    GMOCK_METHOD10_(typename, , , m, , __VA_ARGS__)
+
+#define MOCK_CONST_NOOVERRIDE_METHOD0_T(m, ...) \
+    GMOCK_METHOD0_(typename, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD1_T(m, ...) \
+    GMOCK_METHOD1_(typename, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD2_T(m, ...) \
+    GMOCK_METHOD2_(typename, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD3_T(m, ...) \
+    GMOCK_METHOD3_(typename, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD4_T(m, ...) \
+    GMOCK_METHOD4_(typename, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD5_T(m, ...) \
+    GMOCK_METHOD5_(typename, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD6_T(m, ...) \
+    GMOCK_METHOD6_(typename, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD7_T(m, ...) \
+    GMOCK_METHOD7_(typename, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD8_T(m, ...) \
+    GMOCK_METHOD8_(typename, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD9_T(m, ...) \
+    GMOCK_METHOD9_(typename, const, , m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD10_T(m, ...) \
+    GMOCK_METHOD10_(typename, const, , m, , __VA_ARGS__)
+
+#define MOCK_NOOVERRIDE_METHOD0_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD0_(, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD1_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD1_(, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD2_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD2_(, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD3_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD3_(, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD4_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD4_(, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD5_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD5_(, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD6_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD6_(, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD7_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD7_(, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD8_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD8_(, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD9_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD9_(, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD10_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD10_(, , ct, m, , __VA_ARGS__)
+
+#define MOCK_CONST_NOOVERRIDE_METHOD0_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD0_(, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD1_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD1_(, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD2_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD2_(, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD3_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD3_(, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD4_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD4_(, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD5_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD5_(, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD6_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD6_(, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD7_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD7_(, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD8_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD8_(, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD9_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD9_(, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD10_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD10_(, const, ct, m, , __VA_ARGS__)
+
+#define MOCK_NOOVERRIDE_METHOD0_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD0_(typename, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD1_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD1_(typename, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD2_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD2_(typename, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD3_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD3_(typename, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD4_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD4_(typename, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD5_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD5_(typename, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD6_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD6_(typename, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD7_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD7_(typename, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD8_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD8_(typename, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD9_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD9_(typename, , ct, m, , __VA_ARGS__)
+#define MOCK_NOOVERRIDE_METHOD10_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD10_(typename, , ct, m, , __VA_ARGS__)
+
+#define MOCK_CONST_NOOVERRIDE_METHOD0_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD0_(typename, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD1_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD1_(typename, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD2_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD2_(typename, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD3_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD3_(typename, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD4_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD4_(typename, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD5_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD5_(typename, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD6_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD6_(typename, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD7_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD7_(typename, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD8_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD8_(typename, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD9_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD9_(typename, const, ct, m, , __VA_ARGS__)
+#define MOCK_CONST_NOOVERRIDE_METHOD10_T_WITH_CALLTYPE(ct, m, ...) \
+    GMOCK_METHOD10_(typename, const, ct, m, , __VA_ARGS__)
 
 // A MockFunction<F> class has one mock method whose type is F.  It is
 // useful when you just want your test code to emit some messages and
@@ -877,7 +1100,7 @@ class MockFunction<R()> {
  public:
   MockFunction() {}
 
-  MOCK_METHOD0_T(Call, R());
+  MOCK_NOOVERRIDE_METHOD0_T(Call, R());
 
 #if GTEST_HAS_STD_FUNCTION_
   std::function<R()> AsStdFunction() {
@@ -896,7 +1119,7 @@ class MockFunction<R(A0)> {
  public:
   MockFunction() {}
 
-  MOCK_METHOD1_T(Call, R(A0));
+  MOCK_NOOVERRIDE_METHOD1_T(Call, R(A0));
 
 #if GTEST_HAS_STD_FUNCTION_
   std::function<R(A0)> AsStdFunction() {
@@ -915,7 +1138,7 @@ class MockFunction<R(A0, A1)> {
  public:
   MockFunction() {}
 
-  MOCK_METHOD2_T(Call, R(A0, A1));
+  MOCK_NOOVERRIDE_METHOD2_T(Call, R(A0, A1));
 
 #if GTEST_HAS_STD_FUNCTION_
   std::function<R(A0, A1)> AsStdFunction() {
@@ -934,7 +1157,7 @@ class MockFunction<R(A0, A1, A2)> {
  public:
   MockFunction() {}
 
-  MOCK_METHOD3_T(Call, R(A0, A1, A2));
+  MOCK_NOOVERRIDE_METHOD3_T(Call, R(A0, A1, A2));
 
 #if GTEST_HAS_STD_FUNCTION_
   std::function<R(A0, A1, A2)> AsStdFunction() {
@@ -953,7 +1176,7 @@ class MockFunction<R(A0, A1, A2, A3)> {
  public:
   MockFunction() {}
 
-  MOCK_METHOD4_T(Call, R(A0, A1, A2, A3));
+  MOCK_NOOVERRIDE_METHOD4_T(Call, R(A0, A1, A2, A3));
 
 #if GTEST_HAS_STD_FUNCTION_
   std::function<R(A0, A1, A2, A3)> AsStdFunction() {
@@ -973,7 +1196,7 @@ class MockFunction<R(A0, A1, A2, A3, A4)> {
  public:
   MockFunction() {}
 
-  MOCK_METHOD5_T(Call, R(A0, A1, A2, A3, A4));
+  MOCK_NOOVERRIDE_METHOD5_T(Call, R(A0, A1, A2, A3, A4));
 
 #if GTEST_HAS_STD_FUNCTION_
   std::function<R(A0, A1, A2, A3, A4)> AsStdFunction() {
@@ -993,7 +1216,7 @@ class MockFunction<R(A0, A1, A2, A3, A4, A5)> {
  public:
   MockFunction() {}
 
-  MOCK_METHOD6_T(Call, R(A0, A1, A2, A3, A4, A5));
+  MOCK_NOOVERRIDE_METHOD6_T(Call, R(A0, A1, A2, A3, A4, A5));
 
 #if GTEST_HAS_STD_FUNCTION_
   std::function<R(A0, A1, A2, A3, A4, A5)> AsStdFunction() {
@@ -1013,7 +1236,7 @@ class MockFunction<R(A0, A1, A2, A3, A4, A5, A6)> {
  public:
   MockFunction() {}
 
-  MOCK_METHOD7_T(Call, R(A0, A1, A2, A3, A4, A5, A6));
+  MOCK_NOOVERRIDE_METHOD7_T(Call, R(A0, A1, A2, A3, A4, A5, A6));
 
 #if GTEST_HAS_STD_FUNCTION_
   std::function<R(A0, A1, A2, A3, A4, A5, A6)> AsStdFunction() {
@@ -1033,7 +1256,7 @@ class MockFunction<R(A0, A1, A2, A3, A4, A5, A6, A7)> {
  public:
   MockFunction() {}
 
-  MOCK_METHOD8_T(Call, R(A0, A1, A2, A3, A4, A5, A6, A7));
+  MOCK_NOOVERRIDE_METHOD8_T(Call, R(A0, A1, A2, A3, A4, A5, A6, A7));
 
 #if GTEST_HAS_STD_FUNCTION_
   std::function<R(A0, A1, A2, A3, A4, A5, A6, A7)> AsStdFunction() {
@@ -1053,7 +1276,7 @@ class MockFunction<R(A0, A1, A2, A3, A4, A5, A6, A7, A8)> {
  public:
   MockFunction() {}
 
-  MOCK_METHOD9_T(Call, R(A0, A1, A2, A3, A4, A5, A6, A7, A8));
+  MOCK_NOOVERRIDE_METHOD9_T(Call, R(A0, A1, A2, A3, A4, A5, A6, A7, A8));
 
 #if GTEST_HAS_STD_FUNCTION_
   std::function<R(A0, A1, A2, A3, A4, A5, A6, A7, A8)> AsStdFunction() {
@@ -1075,7 +1298,7 @@ class MockFunction<R(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9)> {
  public:
   MockFunction() {}
 
-  MOCK_METHOD10_T(Call, R(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9));
+  MOCK_NOOVERRIDE_METHOD10_T(Call, R(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9));
 
 #if GTEST_HAS_STD_FUNCTION_
   std::function<R(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9)> AsStdFunction() {

--- a/googlemock/include/gmock/gmock-generated-function-mockers.h.pump
+++ b/googlemock/include/gmock/gmock-generated-function-mockers.h.pump
@@ -140,9 +140,9 @@ $var as = [[$for j, [[gmock_a$j]]]]
 $var matcher_as = [[$for j, \
                      [[GMOCK_MATCHER_(tn, $j, __VA_ARGS__) gmock_a$j]]]]
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD$i[[]]_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD$i[[]]_(tn, constness, ct, Method, ovrd, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
-      $arg_as) constness { \
+      $arg_as) constness ovrd { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value == $i), \
         this_method_does_not_take_$i[[]]_argument[[$if i != 1 [[s]]]]); \
@@ -158,57 +158,31 @@ $var matcher_as = [[$for j, \
 
 
 ]]
+#if GMOCK_USE_OVERRIDE
+  #define GMOCK_OVERRIDE_ override
+#else
+  #define GMOCK_OVERRIDE_
+#endif
+
+$range ov 0..1
+$range ct 0..1
+$range t 0..1
+$range const 0..1
+$for ov [[
+$for ct [[
+$for t [[
+$for const [[
 $for i [[
-#define MOCK_METHOD$i(m, ...) GMOCK_METHOD$i[[]]_(, , , m, __VA_ARGS__)
 
-]]
-
-
-$for i [[
-#define MOCK_CONST_METHOD$i(m, ...) GMOCK_METHOD$i[[]]_(, const, , m, __VA_ARGS__)
-
-]]
+#define MOCK_[[$if const == 1 [[CONST_]]]][[$if ov == 1 [[NOOVERRIDE_]]]]METHOD$i[[$if t == 1 [[_T]]]][[$if ct == 1 [[_WITH_CALLTYPE]]]]([[$if ct == 1 [[ct, ]]]]m, ...) \
+    GMOCK_METHOD$i[[]]_([[$if t == 1 [[typename]]]], [[$if const == 1 [[const]]]], [[$if ct == 1 [[ct]]]], m, [[$if ov == 0 [[GMOCK_OVERRIDE_]]]], __VA_ARGS__)
+]] $$ for i
 
 
-$for i [[
-#define MOCK_METHOD$i[[]]_T(m, ...) GMOCK_METHOD$i[[]]_(typename, , , m, __VA_ARGS__)
-
-]]
-
-
-$for i [[
-#define MOCK_CONST_METHOD$i[[]]_T(m, ...) \
-    GMOCK_METHOD$i[[]]_(typename, const, , m, __VA_ARGS__)
-
-]]
-
-
-$for i [[
-#define MOCK_METHOD$i[[]]_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD$i[[]]_(, , ct, m, __VA_ARGS__)
-
-]]
-
-
-$for i [[
-#define MOCK_CONST_METHOD$i[[]]_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD$i[[]]_(, const, ct, m, __VA_ARGS__)
-
-]]
-
-
-$for i [[
-#define MOCK_METHOD$i[[]]_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD$i[[]]_(typename, , ct, m, __VA_ARGS__)
-
-]]
-
-
-$for i [[
-#define MOCK_CONST_METHOD$i[[]]_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD$i[[]]_(typename, const, ct, m, __VA_ARGS__)
-
-]]
+]] $$ for const
+]] $$ for t
+]] $$ for ct
+]] $$ for ov
 
 // A MockFunction<F> class has one mock method whose type is F.  It is
 // useful when you just want your test code to emit some messages and
@@ -270,7 +244,7 @@ class MockFunction<R($ArgTypes)> {
  public:
   MockFunction() {}
 
-  MOCK_METHOD$i[[]]_T(Call, R($ArgTypes));
+  MOCK_NOOVERRIDE_METHOD$i[[]]_T(Call, R($ArgTypes));
 
 #if GTEST_HAS_STD_FUNCTION_
   std::function<R($ArgTypes)> AsStdFunction() {

--- a/googlemock/test/gmock-actions_test.cc
+++ b/googlemock/test/gmock-actions_test.cc
@@ -214,7 +214,7 @@ class MyNonDefaultConstructible {
   int value_;
 };
 
-#if GTEST_HAS_STD_TYPE_TRAITS_
+#if GTEST_LANG_CXX11
 
 TEST(BuiltInDefaultValueTest, ExistsForDefaultConstructibleType) {
   EXPECT_TRUE(BuiltInDefaultValue<MyDefaultConstructible>::Exists());
@@ -224,7 +224,7 @@ TEST(BuiltInDefaultValueTest, IsDefaultConstructedForDefaultConstructibleType) {
   EXPECT_EQ(42, BuiltInDefaultValue<MyDefaultConstructible>::Get().value());
 }
 
-#endif  // GTEST_HAS_STD_TYPE_TRAITS_
+#endif  // GTEST_LANG_CXX11
 
 TEST(BuiltInDefaultValueTest, DoesNotExistForNonDefaultConstructibleType) {
   EXPECT_FALSE(BuiltInDefaultValue<MyNonDefaultConstructible>::Exists());
@@ -694,12 +694,12 @@ class MockClass {
  public:
   MockClass() {}
 
-  MOCK_METHOD1(IntFunc, int(bool flag));  // NOLINT
-  MOCK_METHOD0(Foo, MyNonDefaultConstructible());
+  MOCK_NOOVERRIDE_METHOD1(IntFunc, int(bool flag));  // NOLINT
+  MOCK_NOOVERRIDE_METHOD0(Foo, MyNonDefaultConstructible());
 #if GTEST_HAS_STD_UNIQUE_PTR_
-  MOCK_METHOD0(MakeUnique, std::unique_ptr<int>());
-  MOCK_METHOD0(MakeUniqueBase, std::unique_ptr<Base>());
-  MOCK_METHOD0(MakeVectorUnique, std::vector<std::unique_ptr<int>>());
+  MOCK_NOOVERRIDE_METHOD0(MakeUnique, std::unique_ptr<int>());
+  MOCK_NOOVERRIDE_METHOD0(MakeUniqueBase, std::unique_ptr<Base>());
+  MOCK_NOOVERRIDE_METHOD0(MakeVectorUnique, std::vector<std::unique_ptr<int>>());
 #endif
 
  private:

--- a/googlemock/test/gmock-cardinalities_test.cc
+++ b/googlemock/test/gmock-cardinalities_test.cc
@@ -53,7 +53,7 @@ using testing::MakeCardinality;
 class MockFoo {
  public:
   MockFoo() {}
-  MOCK_METHOD0(Bar, int());  // NOLINT
+  MOCK_NOOVERRIDE_METHOD0(Bar, int());  // NOLINT
 
  private:
   GTEST_DISALLOW_COPY_AND_ASSIGN_(MockFoo);

--- a/googlemock/test/gmock-generated-function-mockers_test.cc
+++ b/googlemock/test/gmock-generated-function-mockers_test.cc
@@ -143,8 +143,8 @@ class MockFoo : public FooInterface {
 #endif
 
   // Tests that the function return type can contain unprotected comma.
-  MOCK_METHOD0(ReturnTypeWithComma, std::map<int, string>());
-  MOCK_CONST_METHOD1(ReturnTypeWithComma,
+  MOCK_NOOVERRIDE_METHOD0(ReturnTypeWithComma, std::map<int, string>());
+  MOCK_CONST_NOOVERRIDE_METHOD1(ReturnTypeWithComma,
                      std::map<int, string>(int));  // NOLINT
 
   MOCK_METHOD0(OverloadedOnArgumentNumber, int());  // NOLINT
@@ -168,7 +168,7 @@ class MockFoo : public FooInterface {
   MOCK_CONST_METHOD1_WITH_CALLTYPE(STDMETHODCALLTYPE, CTConst, char(int));
 
   // Tests that the function return type can contain unprotected comma.
-  MOCK_METHOD0_WITH_CALLTYPE(STDMETHODCALLTYPE, CTReturnTypeWithComma,
+  MOCK_NOOVERRIDE_METHOD0_WITH_CALLTYPE(STDMETHODCALLTYPE, CTReturnTypeWithComma,
                              std::map<int, string>());
 #endif  // GTEST_OS_WINDOWS
 
@@ -354,7 +354,7 @@ class MockB {
  public:
   MockB() {}
 
-  MOCK_METHOD0(DoB, void());
+  MOCK_NOOVERRIDE_METHOD0(DoB, void());
 
  private:
   GTEST_DISALLOW_COPY_AND_ASSIGN_(MockB);
@@ -405,8 +405,8 @@ class MockStack : public StackInterface<T> {
   MOCK_CONST_METHOD0_T(GetTop, const T&());
 
   // Tests that the function return type can contain unprotected comma.
-  MOCK_METHOD0_T(ReturnTypeWithComma, std::map<int, int>());
-  MOCK_CONST_METHOD1_T(ReturnTypeWithComma, std::map<int, int>(int));  // NOLINT
+  MOCK_NOOVERRIDE_METHOD0_T(ReturnTypeWithComma, std::map<int, int>());
+  MOCK_CONST_NOOVERRIDE_METHOD1_T(ReturnTypeWithComma, std::map<int, int>(int));  // NOLINT
 
  private:
   GTEST_DISALLOW_COPY_AND_ASSIGN_(MockStack);
@@ -503,9 +503,9 @@ TEST(TemplateMockTestWithCallType, Works) {
 #endif  // GTEST_OS_WINDOWS
 
 #define MY_MOCK_METHODS1_ \
-    MOCK_METHOD0(Overloaded, void()); \
-    MOCK_CONST_METHOD1(Overloaded, int(int n)); \
-    MOCK_METHOD2(Overloaded, bool(bool f, int n))
+    MOCK_NOOVERRIDE_METHOD0(Overloaded, void()); \
+    MOCK_CONST_NOOVERRIDE_METHOD1(Overloaded, int(int n)); \
+    MOCK_NOOVERRIDE_METHOD2(Overloaded, bool(bool f, int n))
 
 class MockOverloadedOnArgNumber {
  public:
@@ -529,8 +529,8 @@ TEST(OverloadedMockMethodTest, CanOverloadOnArgNumberInMacroBody) {
 }
 
 #define MY_MOCK_METHODS2_ \
-    MOCK_CONST_METHOD1(Overloaded, int(int n)); \
-    MOCK_METHOD1(Overloaded, int(int n));
+    MOCK_CONST_NOOVERRIDE_METHOD1(Overloaded, int(int n)); \
+    MOCK_NOOVERRIDE_METHOD1(Overloaded, int(int n));
 
 class MockOverloadedOnConstness {
  public:

--- a/googlemock/test/gmock-generated-matchers_test.cc
+++ b/googlemock/test/gmock-generated-matchers_test.cc
@@ -499,7 +499,7 @@ class NativeArrayPassedAsPointerAndSize {
  public:
   NativeArrayPassedAsPointerAndSize() {}
 
-  MOCK_METHOD2(Helper, void(int* array, int size));
+  MOCK_NOOVERRIDE_METHOD2(Helper, void(int* array, int size));
 
  private:
   GTEST_DISALLOW_COPY_AND_ASSIGN_(NativeArrayPassedAsPointerAndSize);

--- a/googlemock/test/gmock-internal-utils_test.cc
+++ b/googlemock/test/gmock-internal-utils_test.cc
@@ -557,8 +557,8 @@ std::string GrabOutput(void(*logger)(), const char* verbosity) {
 
 class DummyMock {
  public:
-  MOCK_METHOD0(TestMethod, void());
-  MOCK_METHOD1(TestMethodArg, void(int dummy));
+  MOCK_NOOVERRIDE_METHOD0(TestMethod, void());
+  MOCK_NOOVERRIDE_METHOD1(TestMethodArg, void(int dummy));
 };
 
 void ExpectCallLogger() {

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -1042,14 +1042,14 @@ TEST(IsNullTest, ReferenceToConstLinkedPtr) {
   EXPECT_FALSE(m.Matches(non_null_p));
 }
 
-#if GTEST_HAS_STD_FUNCTION_
+#if GTEST_LANG_CXX11
 TEST(IsNullTest, StdFunction) {
   const Matcher<std::function<void()>> m = IsNull();
 
   EXPECT_TRUE(m.Matches(std::function<void()>()));
   EXPECT_FALSE(m.Matches([]{}));
 }
-#endif  // GTEST_HAS_STD_FUNCTION_
+#endif  // GTEST_LANG_CXX11
 
 // Tests that IsNull() describes itself properly.
 TEST(IsNullTest, CanDescribeSelf) {
@@ -1090,14 +1090,14 @@ TEST(NotNullTest, ReferenceToConstLinkedPtr) {
   EXPECT_TRUE(m.Matches(non_null_p));
 }
 
-#if GTEST_HAS_STD_FUNCTION_
+#if GTEST_LANG_CXX11
 TEST(NotNullTest, StdFunction) {
   const Matcher<std::function<void()>> m = NotNull();
 
   EXPECT_TRUE(m.Matches([]{}));
   EXPECT_FALSE(m.Matches(std::function<void()>()));
 }
-#endif  // GTEST_HAS_STD_FUNCTION_
+#endif  // GTEST_LANG_CXX11
 
 // Tests that NotNull() describes itself properly.
 TEST(NotNullTest, CanDescribeSelf) {
@@ -2593,7 +2593,7 @@ class AllArgsHelper {
  public:
   AllArgsHelper() {}
 
-  MOCK_METHOD2(Helper, int(char x, int y));
+  MOCK_NOOVERRIDE_METHOD2(Helper, int(char x, int y));
 
  private:
   GTEST_DISALLOW_COPY_AND_ASSIGN_(AllArgsHelper);
@@ -2708,18 +2708,22 @@ class FloatingPointTest : public testing::Test {
         zero_bits_(Floating(0).bits()),
         one_bits_(Floating(1).bits()),
         infinity_bits_(Floating(Floating::Infinity()).bits()),
-        close_to_positive_zero_(AsBits(zero_bits_ + max_ulps_/2)),
-        close_to_negative_zero_(AsBits(zero_bits_ + max_ulps_ - max_ulps_/2)),
-        further_from_negative_zero_(-AsBits(
+        close_to_positive_zero_(
+            Floating::ReinterpretBits(zero_bits_ + max_ulps_/2)),
+        close_to_negative_zero_(
+            -Floating::ReinterpretBits(zero_bits_ + max_ulps_ - max_ulps_/2)),
+        further_from_negative_zero_(-Floating::ReinterpretBits(
             zero_bits_ + max_ulps_ + 1 - max_ulps_/2)),
-        close_to_one_(AsBits(one_bits_ + max_ulps_)),
-        further_from_one_(AsBits(one_bits_ + max_ulps_ + 1)),
+        close_to_one_(Floating::ReinterpretBits(one_bits_ + max_ulps_)),
+        further_from_one_(Floating::ReinterpretBits(one_bits_ + max_ulps_ + 1)),
         infinity_(Floating::Infinity()),
-        close_to_infinity_(AsBits(infinity_bits_ - max_ulps_)),
-        further_from_infinity_(AsBits(infinity_bits_ - max_ulps_ - 1)),
+        close_to_infinity_(
+            Floating::ReinterpretBits(infinity_bits_ - max_ulps_)),
+        further_from_infinity_(
+            Floating::ReinterpretBits(infinity_bits_ - max_ulps_ - 1)),
         max_(Floating::Max()),
-        nan1_(AsBits(Floating::kExponentBitMask | 1)),
-        nan2_(AsBits(Floating::kExponentBitMask | 200)) {
+        nan1_(Floating::ReinterpretBits(Floating::kExponentBitMask | 1)),
+        nan2_(Floating::ReinterpretBits(Floating::kExponentBitMask | 200)) {
   }
 
   void TestSize() {
@@ -2800,12 +2804,6 @@ class FloatingPointTest : public testing::Test {
   // Some NaNs.
   const RawType nan1_;
   const RawType nan2_;
-
- private:
-  template <typename T>
-  static RawType AsBits(T value) {
-    return Floating::ReinterpretBits(static_cast<Bits>(value));
-  }
 };
 
 // Tests floating-point matchers with fixed epsilons.
@@ -3181,8 +3179,6 @@ MATCHER_P(FieldIIs, inner_matcher, "") {
   return ExplainMatchResult(inner_matcher, arg.i, result_listener);
 }
 
-#if GTEST_HAS_RTTI
-
 TEST(WhenDynamicCastToTest, SameType) {
   Derived derived;
   derived.i = 4;
@@ -3240,8 +3236,12 @@ TEST(WhenDynamicCastToTest, AmbiguousCast) {
 
 TEST(WhenDynamicCastToTest, Describe) {
   Matcher<Base*> matcher = WhenDynamicCastTo<Derived*>(Pointee(_));
+#if GTEST_HAS_RTTI
   const string prefix =
       "when dynamic_cast to " + internal::GetTypeName<Derived*>() + ", ";
+#else  // GTEST_HAS_RTTI
+  const string prefix = "when dynamic_cast, ";
+#endif  // GTEST_HAS_RTTI
   EXPECT_EQ(prefix + "points to a value that is anything", Describe(matcher));
   EXPECT_EQ(prefix + "does not point to a value that is anything",
             DescribeNegation(matcher));
@@ -3274,8 +3274,6 @@ TEST(WhenDynamicCastToTest, BadReference) {
   Base& as_base_ref = derived;
   EXPECT_THAT(as_base_ref, Not(WhenDynamicCastTo<const OtherDerived&>(_)));
 }
-
-#endif  // GTEST_HAS_RTTI
 
 // Minimal const-propagating pointer.
 template <typename T>

--- a/googlemock/test/gmock-nice-strict_test.cc
+++ b/googlemock/test/gmock-nice-strict_test.cc
@@ -42,7 +42,7 @@ class Mock {
  public:
   Mock() {}
 
-  MOCK_METHOD0(DoThis, void());
+  MOCK_NOOVERRIDE_METHOD0(DoThis, void());
 
  private:
   GTEST_DISALLOW_COPY_AND_ASSIGN_(Mock);
@@ -99,8 +99,8 @@ class MockBar {
 
   const string& str() const { return str_; }
 
-  MOCK_METHOD0(This, int());
-  MOCK_METHOD2(That, string(int, bool));
+  MOCK_NOOVERRIDE_METHOD0(This, int());
+  MOCK_NOOVERRIDE_METHOD2(That, string(int, bool));
 
  private:
   string str_;

--- a/googlemock/test/gmock-spec-builders_test.cc
+++ b/googlemock/test/gmock-spec-builders_test.cc
@@ -111,7 +111,7 @@ class MockIncomplete {
  public:
   // This line verifies that a mock method can take a by-reference
   // argument of an incomplete type.
-  MOCK_METHOD1(ByRefFunc, void(const Incomplete& x));
+  MOCK_NOOVERRIDE_METHOD1(ByRefFunc, void(const Incomplete& x));
 };
 
 // Tells Google Mock how to print a value of type Incomplete.
@@ -145,11 +145,11 @@ class MockA {
  public:
   MockA() {}
 
-  MOCK_METHOD1(DoA, void(int n));
-  MOCK_METHOD1(ReturnResult, Result(int n));
-  MOCK_METHOD0(ReturnNonDefaultConstructible, NonDefaultConstructible());
-  MOCK_METHOD2(Binary, bool(int x, int y));
-  MOCK_METHOD2(ReturnInt, int(int x, int y));
+  MOCK_NOOVERRIDE_METHOD1(DoA, void(int n));
+  MOCK_NOOVERRIDE_METHOD1(ReturnResult, Result(int n));
+  MOCK_NOOVERRIDE_METHOD0(ReturnNonDefaultConstructible, NonDefaultConstructible());
+  MOCK_NOOVERRIDE_METHOD2(Binary, bool(int x, int y));
+  MOCK_NOOVERRIDE_METHOD2(ReturnInt, int(int x, int y));
 
  private:
   GTEST_DISALLOW_COPY_AND_ASSIGN_(MockA);
@@ -159,8 +159,8 @@ class MockB {
  public:
   MockB() {}
 
-  MOCK_CONST_METHOD0(DoB, int());  // NOLINT
-  MOCK_METHOD1(DoB, int(int n));  // NOLINT
+  MOCK_CONST_NOOVERRIDE_METHOD0(DoB, int());  // NOLINT
+  MOCK_NOOVERRIDE_METHOD1(DoB, int(int n));  // NOLINT
 
  private:
   GTEST_DISALLOW_COPY_AND_ASSIGN_(MockB);
@@ -170,7 +170,7 @@ class ReferenceHoldingMock {
  public:
   ReferenceHoldingMock() {}
 
-  MOCK_METHOD1(AcceptReference, void(linked_ptr<MockA>*));
+  MOCK_NOOVERRIDE_METHOD1(AcceptReference, void(linked_ptr<MockA>*));
 
  private:
   GTEST_DISALLOW_COPY_AND_ASSIGN_(ReferenceHoldingMock);
@@ -1954,9 +1954,9 @@ class MockC {
  public:
   MockC() {}
 
-  MOCK_METHOD6(VoidMethod, void(bool cond, int n, string s, void* p,
+  MOCK_NOOVERRIDE_METHOD6(VoidMethod, void(bool cond, int n, string s, void* p,
                                 const Printable& x, Unprintable y));
-  MOCK_METHOD0(NonVoidMethod, int());  // NOLINT
+  MOCK_NOOVERRIDE_METHOD0(NonVoidMethod, int());  // NOLINT
 
  private:
   GTEST_DISALLOW_COPY_AND_ASSIGN_(MockC);
@@ -2195,7 +2195,7 @@ class LogTestHelper {
  public:
   LogTestHelper() {}
 
-  MOCK_METHOD1(Foo, PrintMeNot(PrintMeNot));
+  MOCK_NOOVERRIDE_METHOD1(Foo, PrintMeNot(PrintMeNot));
 
  private:
   GTEST_DISALLOW_COPY_AND_ASSIGN_(LogTestHelper);


### PR DESCRIPTION
reference: google/googletest#533

This enables the override keyword (you need to turn on the GMOCK_USE_OVERRIDE macro to enable this feature, which allows people to migrate at will).