### PR TITLE
Fix compilation of googletest with MinGW using Win32 threads

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -46,7 +46,9 @@ endmacro()
 # Google Mock.  You can tweak these definitions to suit your need.  A
 # variable's value is empty before it's explicitly assigned to.
 macro(config_compiler_and_linker)
-  if (NOT gtest_disable_pthreads)
+  # Note: pthreads on MinGW is not supported, even if available
+  # instead, we use windows threading primitives
+  if (NOT gtest_disable_pthreads AND NOT MINGW)
     # Defines CMAKE_USE_PTHREADS_INIT and CMAKE_THREAD_LIBS_INIT.
     find_package(Threads)
   endif()

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -396,10 +396,16 @@
 #  include <io.h>
 # endif
 // In order to avoid having to include <windows.h>, use forward declaration
-// assuming CRITICAL_SECTION is a typedef of _RTL_CRITICAL_SECTION.
+#if GTEST_OS_WINDOWS_MINGW
+// MinGW defined _CRITICAL_SECTION and _RTL_CRITICAL_SECTION as two
+// separate (equivalent) structs, instead of using typedef
+typedef struct _CRITICAL_SECTION GTEST_CRITICAL_SECTION;
+#else
+// Assume CRITICAL_SECTION is a typedef of _RTL_CRITICAL_SECTION.
 // This assumption is verified by
 // WindowsTypesTest.CRITICAL_SECTIONIs_RTL_CRITICAL_SECTION.
-struct _RTL_CRITICAL_SECTION;
+typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
+#endif
 #else
 // This assumes that non-Windows OSes provide unistd.h. For OSes where this
 // is not the case, we need to include headers that provide the functions
@@ -1693,7 +1699,7 @@ class GTEST_API_ Mutex {
   // by the linker.
   MutexType type_;
   long critical_section_init_phase_;  // NOLINT
-  _RTL_CRITICAL_SECTION* critical_section_;
+  GTEST_CRITICAL_SECTION* critical_section_;
 
   GTEST_DISALLOW_COPY_AND_ASSIGN_(Mutex);
 };

--- a/googletest/test/gtest-port_test.cc
+++ b/googletest/test/gtest-port_test.cc
@@ -1295,9 +1295,16 @@ TEST(WindowsTypesTest, HANDLEIsVoidStar) {
   StaticAssertTypeEq<HANDLE, void*>();
 }
 
+#if GTEST_OS_WINDOWS_MINGW
+TEST(WindowsTypesTest, _CRITICAL_SECTIONIs_CRITICAL_SECTION) {
+  StaticAssertTypeEq<CRITICAL_SECTION, _CRITICAL_SECTION>();
+}
+#else
 TEST(WindowsTypesTest, CRITICAL_SECTIONIs_RTL_CRITICAL_SECTION) {
   StaticAssertTypeEq<CRITICAL_SECTION, _RTL_CRITICAL_SECTION>();
 }
+#endif
+
 #endif  // GTEST_OS_WINDOWS
 
 }  // namespace internal

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -442,7 +442,7 @@ class FormatEpochTimeInMillisAsIso8601Test : public Test {
     // tzset() distinguishes between the TZ variable being present and empty
     // and not being present, so we have to consider the case of time_zone
     // being NULL.
-#if _MSC_VER
+#if _MSC_VER || GTEST_OS_WINDOWS_MINGW
     // ...Unless it's MSVC, whose standard library's _putenv doesn't
     // distinguish between an empty and a missing variable.
     const std::string env_var =


### PR DESCRIPTION
Fixes #708.

Allows to compile googletest with MinGW when pthreads support is disabled.
Also, the cmake build automatically disables pthreads supportwhen MinGW is used.

Tested on Win7, with MinGW 4.8.1, cmake 3.5.0. All tests pass, except for gmock-matchers_test that fails because of a limitation of MinGW not being able to handle "too many sections", most likely unrelated to the issue being addressed here (see below).

Unfortunately, I am not able to (legally) test with MSVC compiler, anybody please help test.

Also tested on Linux, although I expect no differences.

cmake command line used for testing:
`cmake -G "MinGW Makefiles" -Dgtest_build_samples=ON -Dgmock_build_samples=ON -Dgtest_build_tests=ON -Dgmock_build_tests=ON ..`

MinGW "too many section" issue:
```
c:/mingw-2/bin/../lib/gcc/mingw32/4.8.1/../../../../mingw32/bin/as.exe: CMakeFiles\gmock-matchers_test.dir\test\gmock-matchers_test.cc.obj: too many sections (43319)
C:\Users\ilmagico\AppData\Local\Temp\cc4PXqrl.s: Assembler messages:
C:\Users\ilmagico\AppData\Local\Temp\cc4PXqrl.s: Fatal error: can't write CMakeFiles\gmock-matchers_test.dir\test\gmock-matchers_test.cc.obj: File too big
c:/mingw-2/bin/../lib/gcc/mingw32/4.8.1/../../../../mingw32/bin/as.exe: CMakeFiles\gmock-matchers_test.dir\test\gmock-matchers_test.cc.obj: too many sections (43319)
C:\Users\ilmagico\AppData\Local\Temp\cc4PXqrl.s: Fatal error: can't close CMakeFiles\gmock-matchers_test.dir\test\gmock-matchers_test.cc.obj: File too big
```
and (after using `make --keep-going`)
```
98% tests passed, 1 tests failed out of 59

Total Test time (real) =  26.45 sec

The following tests FAILED:
          9 - gmock-matchers_test (Not Run)
```
Apparently this limitation is lifted in recent versions of MinGW64 (when compiling in 64-bit mode), if I get a chance I'll try that too.