### PR TITLE
Fix memory leak (reachable) in ThreadIdToThreadLocals (Platform MS Windows)

### DIFF
--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -531,8 +531,8 @@ class ThreadLocalRegistryImpl {
   // Returns map of thread local instances.
   static ThreadIdToThreadLocals* GetThreadLocalsMapLocked() {
     mutex_.AssertHeld();
-    static ThreadIdToThreadLocals* map = new ThreadIdToThreadLocals;
-    return map;
+    static ThreadIdToThreadLocals map;
+    return &map;
   }
 
   // Protects access to GetThreadLocalsMapLocked() and its return value.


### PR DESCRIPTION
Hello,

I am trying to port gtest to U++ bazar project (www.ultimatepp.org) , but it's memory dectors shows that there are memory leaks on MS Windows. I fount that one of this leaks comes from static ThreadLocalRegistryImpl method "ThreadIdToThreadLocals\* GetThreadLocalsMapLocked()" - gtest-port.cpp - line 532. Below is the original implementation:

``` cpp
  // Returns map of thread local instances.
  static ThreadIdToThreadLocals* GetThreadLocalsMapLocked() {
    mutex_.AssertHeld();
    static ThreadIdToThreadLocals* map = new ThreadIdToThreadLocals;
    return map;
  }
```

As you can see the problem here is that this static variable is never deleted in the gtest code. The solution here is simply, instead of allocating on stack let's allocate this on heap:

``` cpp
  // Returns map of thread local instances.
  static ThreadIdToThreadLocals* GetThreadLocalsMapLocked() {
    mutex_.AssertHeld();
    static ThreadIdToThreadLocals map;
    return &map;
  }
```

In this solution destructor of ThreadIdToThreadLocals will be called when all static variable should be cleaned.

Sincerely,
Zbigniew Rębacz

---

Discussion in https://github.com/google/googletest/issues/692
