### PR TITLE
Added explicit calling convention when needed

### DIFF
--- a/googlemock/src/gmock_main.cc
+++ b/googlemock/src/gmock_main.cc
@@ -43,7 +43,7 @@
 
 GTEST_API_ int _tmain(int argc, TCHAR** argv) {
 #else
-GTEST_API_ int main(int argc, char** argv) {
+GTEST_API_ int GTEST_CRUNTIME_CALLING_CONV_ main(int argc, char** argv) {
 #endif  // GTEST_OS_WINDOWS_MOBILE
   std::cout << "Running main() from gmock_main.cc\n";
   // Since Google Mock depends on Google Test, InitGoogleMock() is

--- a/googletest/include/gtest/gtest-message.h
+++ b/googletest/include/gtest/gtest-message.h
@@ -86,7 +86,7 @@ class GTEST_API_ Message {
  private:
   // The type of basic IO manipulators (endl, ends, and flush) for
   // narrow streams.
-  typedef std::ostream& (*BasicNarrowIoManip)(std::ostream&);
+  typedef std::ostream& (GTEST_CRUNTIME_CALLING_CONV_ *BasicNarrowIoManip)(std::ostream&);
 
  public:
   // Constructs an empty Message.

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -310,7 +310,7 @@ class GTEST_API_ AssertionResult {
   // Allows streaming basic output manipulators such as endl or flush into
   // this object.
   AssertionResult& operator<<(
-      ::std::ostream& (*basic_manipulator)(::std::ostream& stream)) {
+      ::std::ostream& (GTEST_CRUNTIME_CALLING_CONV_ *basic_manipulator)(::std::ostream& stream)) {
     AppendMessage(Message() << basic_manipulator);
     return *this;
   }

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -985,6 +985,12 @@ using ::std::tuple_size;
 # define GTEST_ATTRIBUTE_NO_SANITIZE_THREAD_
 #endif  // __clang__
 
+#if defined(_MSC_VER) && defined(_M_IX86)
+#  define GTEST_CRUNTIME_CALLING_CONV_ __cdecl
+#else
+#  define GTEST_CRUNTIME_CALLING_CONV_
+#endif
+
 namespace testing {
 
 class Message;

--- a/googletest/src/gtest_main.cc
+++ b/googletest/src/gtest_main.cc
@@ -31,7 +31,7 @@
 
 #include "gtest/gtest.h"
 
-GTEST_API_ int main(int argc, char **argv) {
+GTEST_API_ int GTEST_CRUNTIME_CALLING_CONV_ main(int argc, char **argv) {
   printf("Running main() from gtest_main.cc\n");
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
It's needed in 2 different cases:
- when we define main function
- when we accept function pointers for standard runtime functions

This is only needed for Win32, since it supports different calling conventions. This change allows users to change MSVC default calling convention (using /Gz or /Gr) and still compiles.
