### PR TITLE
Generate import configs for other CMake projects to include

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -92,10 +92,21 @@ cxx_library(gmock_main
             src/gmock-all.cc
             src/gmock_main.cc)
 
+
 # If the CMake version supports it, attach header directory information
 # to the targets for when we are part of a parent build (ie being pulled
 # in via add_subdirectory() rather than being a standalone build).
-if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
+if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "3.0.0")
+  target_include_directories(gmock INTERFACE 
+    $<BUILD_INTERFACE:${gmock_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+   
+  target_include_directories(gmock_main INTERFACE 
+    $<BUILD_INTERFACE:${gmock_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+elseif (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
   target_include_directories(gmock      INTERFACE "${gmock_SOURCE_DIR}/include")
   target_include_directories(gmock_main INTERFACE "${gmock_SOURCE_DIR}/include")
 endif()
@@ -103,10 +114,22 @@ endif()
 ########################################################################
 #
 # Install rules
-install(TARGETS gmock gmock_main
-  DESTINATION lib)
+# Note: export GtestTargets so that both gtest and gmock can be  
+# imported from one config file.
+set_target_properties(gmock gmock_main PROPERTIES DEBUG_POSTFIX "d")
+
+install(TARGETS gmock gmock_main EXPORT GtestTargets
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+)
 install(DIRECTORY ${gmock_SOURCE_DIR}/include/gmock
   DESTINATION include)
+
+install(EXPORT GtestTargets
+  FILE GmockConfig.cmake
+  NAMESPACE Gtest::
+  DESTINATION cmake
+)
 
 ########################################################################
 #

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -94,7 +94,17 @@ target_link_libraries(gtest_main gtest)
 # If the CMake version supports it, attach header directory information
 # to the targets for when we are part of a parent build (ie being pulled
 # in via add_subdirectory() rather than being a standalone build).
-if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
+if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "3.0.0")
+  target_include_directories(gtest INTERFACE
+    $<BUILD_INTERFACE:${gtest_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+  
+  target_include_directories(gtest_main INTERFACE 
+    $<BUILD_INTERFACE:${gtest_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+elseif (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
   target_include_directories(gtest      INTERFACE "${gtest_SOURCE_DIR}/include")
   target_include_directories(gtest_main INTERFACE "${gtest_SOURCE_DIR}/include")
 endif()
@@ -102,11 +112,20 @@ endif()
 ########################################################################
 #
 # Install rules
-install(TARGETS gtest gtest_main
-  DESTINATION lib)
+set_target_properties(gtest gtest_main PROPERTIES DEBUG_POSTFIX "d")
+
+install(TARGETS gtest gtest_main EXPORT GtestTargets
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+)
 install(DIRECTORY ${gtest_SOURCE_DIR}/include/gtest
   DESTINATION include)
 
+install(EXPORT GtestTargets
+  FILE GtestConfig.cmake
+  NAMESPACE Gtest::
+  DESTINATION cmake
+)
 ########################################################################
 #
 # Samples on how to link user tests with gtest or gtest_main.


### PR DESCRIPTION
for both Debug and Release builds by appending 'd' to the binary names
of the debug binaries.
