### PR TITLE
Prevent call to member-function on NULL-object.

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -2656,10 +2656,12 @@ void TestInfo::Run() {
     test->Run();
   }
 
-  // Deletes the test object.
+  // Deletes the test object (if it was created in the first place).
   impl->os_stack_trace_getter()->UponLeavingGTest();
-  internal::HandleExceptionsInMethodIfSupported(
-      test, &Test::DeleteSelf_, "the test fixture's destructor");
+  if (test != NULL) {
+    internal::HandleExceptionsInMethodIfSupported(
+        test, &Test::DeleteSelf_, "the test fixture's destructor");
+  }
 
   result_.set_elapsed_time(internal::GetTimeInMillis() - start);
 


### PR DESCRIPTION
This fixes one error in a test, which was found by _Undefined-Behavior Sanitizer_.

Debugging the test `gmock_ex_test` verified, that the object `test` can indeed be `NULL`.
This pull-request prevents trying to destruct object `test` when it is NULL.
