### PR TITLE
Fix Google Mock's python tests

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -50,10 +50,13 @@ endif()
 # if they are the same (the default).
 add_subdirectory("${gtest_dir}" "${gmock_BINARY_DIR}/gtest")
 
-# Although Google Test's CMakeLists.txt calls this function, the
+# Although Google Test's CMakeLists.txt calls these functions, the
 # changes there don't affect the current scope.  Therefore we have to
-# call it again here.
+# call them again here.
 config_compiler_and_linker()  # from ${gtest_dir}/cmake/internal_utils.cmake
+
+# Sets PYTHONINTERP_FOUND and PYTHON_EXECUTABLE.
+find_package(PythonInterp)  # from ${gtest_dir}/cmake/internal_utils.cmake
 
 # Adds Google Mock's and Google Test's header directories to the search path.
 include_directories("${gmock_SOURCE_DIR}/include"

--- a/googlemock/test/gmock_test_utils.py
+++ b/googlemock/test/gmock_test_utils.py
@@ -41,11 +41,11 @@ import sys
 SCRIPT_DIR = os.path.dirname(__file__) or '.'
 
 # isdir resolves symbolic links.
-gtest_tests_util_dir = os.path.join(SCRIPT_DIR, '../gtest/test')
+gtest_tests_util_dir = os.path.join(SCRIPT_DIR, '../googletest/test')
 if os.path.isdir(gtest_tests_util_dir):
   GTEST_TESTS_UTIL_DIR = gtest_tests_util_dir
 else:
-  GTEST_TESTS_UTIL_DIR = os.path.join(SCRIPT_DIR, '../../gtest/test')
+  GTEST_TESTS_UTIL_DIR = os.path.join(SCRIPT_DIR, '../../googletest/test')
 
 sys.path.append(GTEST_TESTS_UTIL_DIR)
 import gtest_test_utils  # pylint: disable-msg=C6204


### PR DESCRIPTION
They have been stopped working for a while because of a bug in CMake. Enabling the tests caught another bugs related to the googletest path. After these 2 fixes, `make test` for Google Mock should include 2 more tests `gmock_leak_test` and `gmock_output_test` and runs normally.
