### PR TITLE
Fixed issue #823. Fixed feature detection bugs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-
-# Google Test #
+# Google Test U #
+The 'U' stands for 'Unofficial'. This repository will be more actively as I'm using Google Test heavily in my daily work.
+Issues and PRs are welcome! And I'll always be responsive.
 
 [![Build Status](https://travis-ci.org/google/googletest.svg?branch=master)](https://travis-ci.org/google/googletest)
 [![Build status](https://ci.appveyor.com/api/projects/status/4o38plt0xbo1ubc8/branch/master?svg=true)](https://ci.appveyor.com/project/BillyDonahue/googletest/branch/master)
@@ -15,7 +16,7 @@ mailing list for questions, discussions, and development.  There is
 also an IRC channel on OFTC (irc.oftc.net) #gtest available.  Please
 join us!
 
-Getting started information for **Google Test** is available in the 
+Getting started information for **Google Test** is available in the
 [Google Test Primer](googletest/docs/Primer.md) documentation.
 
 **Google Mock** is an extension to Google Test for writing and using C++ mock

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -616,7 +616,7 @@ struct _RTL_CRITICAL_SECTION;
 // Determines if hash_map/hash_set are available.
 // Only used for testing against those containers.
 #if !defined(GTEST_HAS_HASH_MAP_)
-# if _MSC_VER < 1900
+# if _MSC_VER && _MSC_VER < 1900
 #  define GTEST_HAS_HASH_MAP_ 1  // Indicates that hash_map is available.
 #  define GTEST_HAS_HASH_SET_ 1  // Indicates that hash_set is available.
 # endif  // _MSC_VER

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -616,7 +616,7 @@ struct _RTL_CRITICAL_SECTION;
 // Determines if hash_map/hash_set are available.
 // Only used for testing against those containers.
 #if !defined(GTEST_HAS_HASH_MAP_)
-# if _MSC_VER
+# if _MSC_VER < 1900
 #  define GTEST_HAS_HASH_MAP_ 1  // Indicates that hash_map is available.
 #  define GTEST_HAS_HASH_SET_ 1  // Indicates that hash_set is available.
 # endif  // _MSC_VER

--- a/googletest/test/gtest-printers_test.cc
+++ b/googletest/test/gtest-printers_test.cc
@@ -222,7 +222,7 @@ using ::std::hash_map;
 using ::std::hash_set;
 using ::std::hash_multimap;
 using ::std::hash_multiset;
-#elif _MSC_VER < 1900
+#elif _MSC_VER && _MSC_VER < 1900
 using ::stdext::hash_map;
 using ::stdext::hash_set;
 using ::stdext::hash_multimap;

--- a/googletest/test/gtest-printers_test.cc
+++ b/googletest/test/gtest-printers_test.cc
@@ -222,7 +222,7 @@ using ::std::hash_map;
 using ::std::hash_set;
 using ::std::hash_multimap;
 using ::std::hash_multiset;
-#elif _MSC_VER
+#elif _MSC_VER < 1900
 using ::stdext::hash_map;
 using ::stdext::hash_set;
 using ::stdext::hash_multimap;

--- a/googletest/test/gtest_catch_exceptions_test_.cc
+++ b/googletest/test/gtest_catch_exceptions_test_.cc
@@ -138,7 +138,7 @@ TEST_F(CxxExceptionInConstructorTest, ThrowsExceptionInConstructor) {
 }
 
 // Exceptions in destructors are not supported in C++11.
-#if !defined(__GXX_EXPERIMENTAL_CXX0X__) &&  __cplusplus < 201103L
+#if !defined(__GXX_EXPERIMENTAL_CXX0X__) &&  __cplusplus < 201103L && _MSC_VER < 1900
 class CxxExceptionInDestructorTest : public Test {
  public:
   static void TearDownTestCase() {

--- a/googletest/test/gtest_catch_exceptions_test_.cc
+++ b/googletest/test/gtest_catch_exceptions_test_.cc
@@ -138,7 +138,7 @@ TEST_F(CxxExceptionInConstructorTest, ThrowsExceptionInConstructor) {
 }
 
 // Exceptions in destructors are not supported in C++11.
-#if !defined(__GXX_EXPERIMENTAL_CXX0X__) &&  __cplusplus < 201103L && _MSC_VER < 1900
+#if !defined(__GXX_EXPERIMENTAL_CXX0X__) &&  __cplusplus < 201103L && _MSC_VER && _MSC_VER < 1900
 class CxxExceptionInDestructorTest : public Test {
  public:
   static void TearDownTestCase() {


### PR DESCRIPTION
We should check the value of _MSC_VER besides its existence for several scenarios. Including hash_map, hash_set and throwing exceptions in destructors. This PR eliminates the AppVeyor complains which caused by the lack of _MSV_VER value checking.