### PR TITLE
Explicitly enabling MacOSX RPath in CMakeLists to avoid warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.6.2)
 
 project( googletest-distribution )
+set( CMAKE_MACOSX_RPATH 1)
 
 enable_testing()
 


### PR DESCRIPTION
Basically this makes cMake's default behavior more explicit and avoids the associated warning.
