### PR TITLE
Speed up printing of characters which need hex escaping

### DIFF
--- a/googletest/src/gtest-printers.cc
+++ b/googletest/src/gtest-printers.cc
@@ -180,7 +180,10 @@ static CharFormat PrintAsCharLiteralTo(Char c, ostream* os) {
         *os << static_cast<char>(c);
         return kAsIs;
       } else {
-        *os << "\\x" + String::FormatHexInt(static_cast<UnsignedChar>(c));
+        ostream::fmtflags flags = os->flags();
+        *os << "\\x" << std::hex << std::uppercase
+            << static_cast<int>(static_cast<UnsignedChar>(c));
+        os->flags(flags);
         return kHexEscape;
       }
   }


### PR DESCRIPTION
This change speeds up the runtime of a value-parameterized test I have
which has lots of values with large strings full of unprintable
characters by 2x. I profiled it and traced most of the slowness during
googletest startup down to the way String::FormatHexInt was creating and
destroyed a stringstream for each character in the string for each
value.
