### PR TITLE
Add flag to disable installation of gtest.

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -27,6 +27,9 @@ option(
   "Build gtest with internal symbols hidden in shared libraries."
   OFF)
 
+# When using gtest as subproject you can disable installation
+option(gtest_install "Install gtest headers and libraries" ON)
+
 # Defines pre_project_set_up_hermetic_build() and set_up_hermetic_build().
 include(cmake/hermetic_build.cmake OPTIONAL)
 
@@ -102,10 +105,12 @@ endif()
 ########################################################################
 #
 # Install rules
+if (gtest_install)
 install(TARGETS gtest gtest_main
   DESTINATION lib)
 install(DIRECTORY ${gtest_SOURCE_DIR}/include/gtest
   DESTINATION include)
+endif()
 
 ########################################################################
 #


### PR DESCRIPTION
Whet gtest used as subproject via add_directory() it will add itself
into installation targets. Sometime it's not feasible. Adding new option
will allow parent project to manage gtest installation using

SET(gtest_install OFF CACHE BOOL "Don't install gtest" FORCE)

before invoking add_project.
