### PR TITLE
Macros for pthreads lead to inconsitency on MinGW #752

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Ignore CI build directory
 build/
+
+*.txt.user

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -604,7 +604,7 @@ struct _RTL_CRITICAL_SECTION;
     || GTEST_OS_QNX || GTEST_OS_FREEBSD || GTEST_OS_NACL)
 #endif  // GTEST_HAS_PTHREAD
 
-#if GTEST_HAS_PTHREAD
+#if GTEST_HAS_PTHREAD && !GTEST_OS_WINDOWS_MINGW
 // gtest-port.h guarantees to #include <pthread.h> when GTEST_HAS_PTHREAD is
 // true.
 # include <pthread.h>  // NOLINT
@@ -1441,7 +1441,7 @@ void SetInjectableArgvs(const ::std::vector<testing::internal::string>*
 
 // Defines synchronization primitives.
 #if GTEST_IS_THREADSAFE
-# if GTEST_HAS_PTHREAD
+# if GTEST_HAS_PTHREAD && !GTEST_OS_WINDOWS_MINGW
 // Sleeps for (roughly) n milliseconds.  This function is only for testing
 // Google Test's own constructs.  Don't use it in user tests, either
 // directly or indirectly.
@@ -1458,7 +1458,7 @@ inline void SleepMilliseconds(int n) {
 // Notification has already been imported into the namespace.
 // Nothing to do here.
 
-# elif GTEST_HAS_PTHREAD
+# elif GTEST_HAS_PTHREAD && !GTEST_OS_WINDOWS_MINGW
 // Allows a controller thread to pause execution of newly created
 // threads until notified.  Instances of this class must be created
 // and destroyed in the controller thread.
@@ -1918,7 +1918,7 @@ class ThreadLocal : public ThreadLocalBase {
   GTEST_DISALLOW_COPY_AND_ASSIGN_(ThreadLocal);
 };
 
-# elif GTEST_HAS_PTHREAD
+# elif GTEST_HAS_PTHREAD && !GTEST_OS_WINDOWS_MINGW
 
 // MutexBase and Mutex implement mutex on pthreads-based platforms.
 class MutexBase {

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -442,7 +442,7 @@ class FormatEpochTimeInMillisAsIso8601Test : public Test {
     // tzset() distinguishes between the TZ variable being present and empty
     // and not being present, so we have to consider the case of time_zone
     // being NULL.
-#if _MSC_VER
+#if _MSC_VER || GTEST_OS_WINDOWS_MINGW
     // ...Unless it's MSVC, whose standard library's _putenv doesn't
     // distinguish between an empty and a missing variable.
     const std::string env_var =


### PR DESCRIPTION
Some changes to support the MinGW compiler supplied with Qt 5.x for Windows.
This way the Windows threads are used instead of win-pthreads.
