### PR TITLE
fix python tests when CMAKE_BUILD_TYPE is specified

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -235,20 +235,29 @@ function(py_test name)
   # We are not supporting Python tests on Linux yet as they consider
   # all Linux environments to be google3 and try to use google3 features.
   if (PYTHONINTERP_FOUND)
-    # ${CMAKE_BINARY_DIR} is known at configuration time, so we can
-    # directly bind it from cmake. ${CTEST_CONFIGURATION_TYPE} is known
-    # only at ctest runtime (by calling ctest -c <Configuration>), so
-    # we have to escape $ to delay variable substitution here.
-    if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.1)
-      add_test(
-        NAME ${name}
-        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/${name}.py
-            --build_dir=${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>)
-    else (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.1)
+    if (DEFINED CMAKE_CONFIGURATION_TYPES)
+      # The generator is a multi-configuration type like Visual Studio.
+      # ${CMAKE_BINARY_DIR} is known at configuration time, so we can
+      # directly bind it from cmake. ${CTEST_CONFIGURATION_TYPE} is known
+      # only at ctest runtime (by calling ctest -c <Configuration>), so
+      # we have to escape $ to delay variable substitution here.
+      if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.1)
+        add_test(
+          NAME ${name}
+          COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/${name}.py
+              --build_dir=${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>)
+      else (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.1)
+        add_test(
+          ${name}
+          ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/${name}.py
+            --build_dir=${CMAKE_CURRENT_BINARY_DIR}/\${CTEST_CONFIGURATION_TYPE})
+      endif (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.1)
+    else (DEFINED CMAKE_CONFIGURATION_TYPES)
+      # The generator is a single-configuiration type like Makefiles or Ninja.
       add_test(
         ${name}
         ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/${name}.py
-          --build_dir=${CMAKE_CURRENT_BINARY_DIR}/\${CTEST_CONFIGURATION_TYPE})
-    endif (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.1)
+          --build_dir=${CMAKE_CURRENT_BINARY_DIR})
+    endif (DEFINED CMAKE_CONFIGURATION_TYPES)
   endif()
 endfunction()

--- a/travis.sh
+++ b/travis.sh
@@ -9,7 +9,9 @@ cmake -Dgtest_build_samples=ON \
       -Dgmock_build_samples=ON \
       -Dgtest_build_tests=ON \
       -Dgmock_build_tests=ON \
+      -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
       -DCMAKE_CXX_FLAGS=$CXX_FLAGS \
+      -DCMAKE_VERBOSE_MAKEFILE=$VERBOSE_MAKE \
       ../../$GTEST_TARGET
 make
 CTEST_OUTPUT_ON_FAILURE=1 make test


### PR DESCRIPTION
 Currently, the Python tests are looking in the wrong place for binaries when CMAKE_BUILD_TYPE is specified.  This has not previously been caught because the Travis CI script does not currently set the build type.

This merge request updates the Travis CI script to catch this failure and fixes the failure itself.

There are still other Travis CI variables that don't seem to be used like SHARED_LIB, STATIC_LIB, and CMAKE_PKG.  Perhaps these should be reviewed as well.
