### PR TITLE
Moved the ignoring of *.pyc files to top level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Ignore CI build directory
 build/
+# python
+*.pyc

--- a/googletest/.gitignore
+++ b/googletest/.gitignore
@@ -1,2 +1,0 @@
-# python
-*.pyc


### PR DESCRIPTION
Moved the ignoring of *pyc files to the top level .gitignore, for also covering the googlemocks python scripts. E.g. the mock generator.