### PR TITLE
build fixed for mingw 5.3

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -622,7 +622,7 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 // Determines if hash_map/hash_set are available.
 // Only used for testing against those containers.
 #if !defined(GTEST_HAS_HASH_MAP_)
-# if _MSC_VER
+# if defined (_MSC_VER) && (_MSC_VER < 1900)
 #  define GTEST_HAS_HASH_MAP_ 1  // Indicates that hash_map is available.
 #  define GTEST_HAS_HASH_SET_ 1  // Indicates that hash_set is available.
 # endif  // _MSC_VER

--- a/googletest/test/gtest-printers_test.cc
+++ b/googletest/test/gtest-printers_test.cc
@@ -222,11 +222,11 @@ using ::std::hash_map;
 using ::std::hash_set;
 using ::std::hash_multimap;
 using ::std::hash_multiset;
-#elif _MSC_VER
-using ::stdext::hash_map;
-using ::stdext::hash_set;
-using ::stdext::hash_multimap;
-using ::stdext::hash_multiset;
+#elif _MSC_VER && GTEST_HAS_HASH_MAP_
+	using ::stdext::hash_map;
+	using ::stdext::hash_set;
+	using ::stdext::hash_multimap;
+	using ::stdext::hash_multiset;
 #endif
 
 // Prints a value to a string using the universal value printer.  This

--- a/googletest/test/gtest_catch_exceptions_test_.cc
+++ b/googletest/test/gtest_catch_exceptions_test_.cc
@@ -138,7 +138,7 @@ TEST_F(CxxExceptionInConstructorTest, ThrowsExceptionInConstructor) {
 }
 
 // Exceptions in destructors are not supported in C++11.
-#if !defined(__GXX_EXPERIMENTAL_CXX0X__) &&  __cplusplus < 201103L
+#if !defined(__GXX_EXPERIMENTAL_CXX0X__) &&  (__cplusplus < 201103L) && (_MSC_VER < 1900)
 class CxxExceptionInDestructorTest : public Test {
  public:
   static void TearDownTestCase() {


### PR DESCRIPTION
fixed pointers casting GTEST_CRITICAL_SECTION* to CRITICAL_SECTION* and vice versa introduced in pull request #721 

Signed-off-by: Eugene Smirnov <o1o2o3o4o5@gmail.com>