### PR TITLE
Clarifying documentation language

### DIFF
--- a/googlemock/docs/CookBook.md
+++ b/googlemock/docs/CookBook.md
@@ -18,8 +18,9 @@ You must always put a mock method definition (`MOCK_METHOD*`) in a
 `public:` section of the mock class, regardless of the method being
 mocked being `public`, `protected`, or `private` in the base class.
 This allows `ON_CALL` and `EXPECT_CALL` to reference the mock function
-from outside of the mock class.  (Yes, C++ allows a subclass to change
-the access level of a virtual function in the base class.)  Example:
+from outside of the mock class.  (Yes, C++ allows a subclass to specify
+a different access level than the base class on a virtual function.)
+Example:
 
 ```
 class Foo {


### PR DESCRIPTION
The old language might mislead someone into thinking that the access level on the base class itself was changed. This happened to a co-worker of mine, a (relative) novice in C++.
