### PR TITLE
Fixing broken relative links in Google Mock documentation

### DIFF
--- a/googlemock/README.md
+++ b/googlemock/README.md
@@ -79,7 +79,7 @@ posting a question on the
 Google Mock is not a testing framework itself.  Instead, it needs a
 testing framework for writing tests.  Google Mock works seamlessly
 with [Google Test](http://code.google.com/p/googletest/), but
-you can also use it with [any C++ testing framework](../../tree/master/googlemock/docs/ForDummies.md#using-google-mock-with-any-testing-framework).
+you can also use it with [any C++ testing framework](../../master/googlemock/docs/ForDummies.md#using-google-mock-with-any-testing-framework).
 
 ### Requirements for End Users ###
 

--- a/googlemock/README.md
+++ b/googlemock/README.md
@@ -53,7 +53,7 @@ the Apache License, which is different from Google Mock's license.
 If you are new to the project, we suggest that you read the user
 documentation in the following order:
 
-  * Learn the [basics](../../../googletest/docs/Primer.md) of
+  * Learn the [basics](../../googletest/docs/Primer.md) of
     Google Test, if you choose to use Google Mock with it (recommended).
   * Read [Google Mock for Dummies](docs/ForDummies.md).
   * Read the instructions below on how to build Google Mock.

--- a/googlemock/README.md
+++ b/googlemock/README.md
@@ -90,7 +90,7 @@ You must use the bundled version of Google Test when using Google Mock.
 You can also easily configure Google Mock to work with another testing
 framework, although it will still need Google Test.  Please read
 ["Using_Google_Mock_with_Any_Testing_Framework"](
-    ../../tree/master/googlemock/docs/ForDummies.md#using-google-mock-with-any-testing-framework)
+    ../../master/googlemock/docs/ForDummies.md#using-google-mock-with-any-testing-framework)
 for instructions.
 
 Google Mock depends on advanced C++ features and thus requires a more

--- a/googlemock/README.md
+++ b/googlemock/README.md
@@ -53,7 +53,7 @@ the Apache License, which is different from Google Mock's license.
 If you are new to the project, we suggest that you read the user
 documentation in the following order:
 
-  * Learn the [basics](../../googletest/docs/Primer.md) of
+  * Learn the [basics](../../tree/master/googletest/docs/Primer.md) of
     Google Test, if you choose to use Google Mock with it (recommended).
   * Read [Google Mock for Dummies](docs/ForDummies.md).
   * Read the instructions below on how to build Google Mock.

--- a/googlemock/README.md
+++ b/googlemock/README.md
@@ -79,7 +79,7 @@ posting a question on the
 Google Mock is not a testing framework itself.  Instead, it needs a
 testing framework for writing tests.  Google Mock works seamlessly
 with [Google Test](http://code.google.com/p/googletest/), but
-you can also use it with [any C++ testing framework](../../tree/master/googlemock/docs/ForDummies.md#Using_Google_Mock_with_Any_Testing_Framework).
+you can also use it with [any C++ testing framework](../../tree/master/googlemock/docs/ForDummies.md#using-google-mock-with-any-testing-framework).
 
 ### Requirements for End Users ###
 
@@ -90,7 +90,7 @@ You must use the bundled version of Google Test when using Google Mock.
 You can also easily configure Google Mock to work with another testing
 framework, although it will still need Google Test.  Please read
 ["Using_Google_Mock_with_Any_Testing_Framework"](
-    ../../tree/master/googlemock/docs/ForDummies.md#Using_Google_Mock_with_Any_Testing_Framework)
+    ../../tree/master/googlemock/docs/ForDummies.md#using-google-mock-with-any-testing-framework)
 for instructions.
 
 Google Mock depends on advanced C++ features and thus requires a more

--- a/googlemock/README.md
+++ b/googlemock/README.md
@@ -55,7 +55,7 @@ documentation in the following order:
 
   * Learn the [basics](../../tree/master/googletest/docs/Primer.md) of
     Google Test, if you choose to use Google Mock with it (recommended).
-  * Read [Google Mock for Dummies](docs/ForDummies.md).
+  * Read [Google Mock for Dummies](../../tree/master/googlemock/docs/ForDummies.md).
   * Read the instructions below on how to build Google Mock.
 
 You can also watch Zhanyong's [talk](http://www.youtube.com/watch?v=sYpCyLI47rM) on Google Mock's usage and implementation.

--- a/googlemock/README.md
+++ b/googlemock/README.md
@@ -68,8 +68,8 @@ Once you understand the basics, check out the rest of the docs:
     including advanced techniques.
 
 If you need help, please check the
-[KnownIssues](../../tree/master/googlemock/docs/KnownIssues.md) and
-[FrequentlyAskedQuestions](../../tree/master/googlemock/docs/FrequentlyAskedQuestions.md) before
+[KnownIssues](docs/KnownIssues.md) and
+[FrequentlyAskedQuestions](docs/FrequentlyAskedQuestions.md) before
 posting a question on the
 [discussion group](http://groups.google.com/group/googlemock).
 

--- a/googlemock/README.md
+++ b/googlemock/README.md
@@ -62,14 +62,14 @@ You can also watch Zhanyong's [talk](http://www.youtube.com/watch?v=sYpCyLI47rM)
 
 Once you understand the basics, check out the rest of the docs:
 
-  * [CheatSheet](docs/CheatSheet.md) - all the commonly used stuff
+  * [CheatSheet](../../tree/master/googlemock/docs/CheatSheet.md) - all the commonly used stuff
     at a glance.
-  * [CookBook](docs/CookBook.md) - recipes for getting things done,
+  * [CookBook](../../tree/master/googlemock/docs/CookBook.md) - recipes for getting things done,
     including advanced techniques.
 
 If you need help, please check the
-[KnownIssues](docs/KnownIssues.md) and
-[FrequentlyAskedQuestions](docs/FrequentlyAskedQuestions.md) before
+[KnownIssues](../../tree/master/googlemock/docs/KnownIssues.md) and
+[FrequentlyAskedQuestions](../../tree/master/googlemock/docs/FrequentlyAskedQuestions.md) before
 posting a question on the
 [discussion group](http://groups.google.com/group/googlemock).
 
@@ -79,7 +79,7 @@ posting a question on the
 Google Mock is not a testing framework itself.  Instead, it needs a
 testing framework for writing tests.  Google Mock works seamlessly
 with [Google Test](http://code.google.com/p/googletest/), but
-you can also use it with [any C++ testing framework](googlemock/ForDummies.md#Using_Google_Mock_with_Any_Testing_Framework).
+you can also use it with [any C++ testing framework](../../tree/master/googlemock/docs/ForDummies.md#Using_Google_Mock_with_Any_Testing_Framework).
 
 ### Requirements for End Users ###
 
@@ -90,7 +90,7 @@ You must use the bundled version of Google Test when using Google Mock.
 You can also easily configure Google Mock to work with another testing
 framework, although it will still need Google Test.  Please read
 ["Using_Google_Mock_with_Any_Testing_Framework"](
-    docs/ForDummies.md#Using_Google_Mock_with_Any_Testing_Framework)
+    ../../tree/master/googlemock/docs/ForDummies.md#Using_Google_Mock_with_Any_Testing_Framework)
 for instructions.
 
 Google Mock depends on advanced C++ features and thus requires a more

--- a/googlemock/README.md
+++ b/googlemock/README.md
@@ -53,7 +53,7 @@ the Apache License, which is different from Google Mock's license.
 If you are new to the project, we suggest that you read the user
 documentation in the following order:
 
-  * Learn the [basics](../googletest/docs/Primer.md) of
+  * Learn the [basics](../../../googletest/docs/Primer.md) of
     Google Test, if you choose to use Google Mock with it (recommended).
   * Read [Google Mock for Dummies](docs/ForDummies.md).
   * Read the instructions below on how to build Google Mock.


### PR DESCRIPTION
This pull request offers a solution to issue #873, and ensures that every relative link in [googletest/googlemock/README.md](https://github.com/google/googletest/blob/master/googlemock/README.md) is working properly. It is likely that there are similar relative link issues in other parts of the documentation, which I will review.
