### PR TITLE
PUMP line breaking fix

### DIFF
--- a/googletest/scripts/pump.py
+++ b/googletest/scripts/pump.py
@@ -739,14 +739,14 @@ def WrapComment(line, output):
 
 
 def FindSplitPos(seg, max_len, splitter):
-  space_at = seg.find(splitter)
-  if space_at == -1:
+  splitter_at = seg.find(splitter)
+  if splitter_at == -1:
     return len(seg)
-  else:
-    if space_at > max_len:
-      return space_at
-    else:
-      return seg.rfind(splitter, 0, max_len)
+
+  if splitter_at > max_len:
+    return splitter_at
+
+  return seg.rfind(splitter, 0, max_len)
 
 
 def WrapCode(line, line_concat, output):
@@ -758,7 +758,8 @@ def WrapCode(line, line_concat, output):
     indent = 0
 
   prefix = indent*' '  # Prefix of the current line
-  max_len = max_line_length - indent - len(line_concat)  # Maximum length of the current line
+  # Maximum length of the current line
+  max_len = max_line_length - indent - len(line_concat)
   new_prefix = prefix + 4*' '  # Prefix of a continuation line
   new_max_len = max_len - 4  # Maximum length of a continuation line
   # Prefers to wrap a line after a ',' or ';'.
@@ -769,7 +770,6 @@ def WrapCode(line, line_concat, output):
     while cur_line == '' and len(seg.strip()) > max_len:
       seg = seg.lstrip()
       split_at = FindSplitPos(seg, max_len, ' ')
-
       output.append(prefix + seg[:split_at].strip() + line_concat)
       seg = seg[split_at + 1:]
       prefix = new_prefix

--- a/googletest/scripts/pump.py
+++ b/googletest/scripts/pump.py
@@ -740,6 +740,9 @@ def WrapComment(line, output):
 
 def WrapCode(line, line_concat, output):
   indent = len(line) - len(line.lstrip())
+  if indent > 80:
+    indent %= 80
+    
   prefix = indent*' '  # Prefix of the current line
   max_len = 80 - indent - len(line_concat)  # Maximum length of the current line
   new_prefix = prefix + 4*' '  # Prefix of a continuation line

--- a/googletest/scripts/pump.py
+++ b/googletest/scripts/pump.py
@@ -738,13 +738,27 @@ def WrapComment(line, output):
     output.append(prefix + cur_line.strip())
 
 
+def FindSplitPos(seg, max_len, splitter):
+  space_at = seg.find(splitter)
+  if space_at == -1:
+    return len(seg)
+  else:
+    if space_at > max_len:
+      return space_at
+    else:
+      return seg.rfind(splitter, 0, max_len)
+
+
 def WrapCode(line, line_concat, output):
+  max_line_length = 80
+  max_reasonable_indent = 60
+
   indent = len(line) - len(line.lstrip())
-  if indent > 80:
-    indent %= 80
-    
+  if indent >= max_reasonable_indent:
+    indent = 0
+
   prefix = indent*' '  # Prefix of the current line
-  max_len = 80 - indent - len(line_concat)  # Maximum length of the current line
+  max_len = max_line_length - indent - len(line_concat)  # Maximum length of the current line
   new_prefix = prefix + 4*' '  # Prefix of a continuation line
   new_max_len = max_len - 4  # Maximum length of a continuation line
   # Prefers to wrap a line after a ',' or ';'.
@@ -754,7 +768,8 @@ def WrapCode(line, line_concat, output):
     # If the line is still too long, wrap at a space.
     while cur_line == '' and len(seg.strip()) > max_len:
       seg = seg.lstrip()
-      split_at = seg.rfind(' ', 0, max_len)
+      split_at = FindSplitPos(seg, max_len, ' ')
+
       output.append(prefix + seg[:split_at].strip() + line_concat)
       seg = seg[split_at + 1:]
       prefix = new_prefix


### PR DESCRIPTION
Hello (:

I was playing with PUMP in my own project, and in one file I had line which has 80 spaces indentation and a '\' at the end. Apparently PUMP had problem with it because it was consuming whole RAM etc.
After quick research I found that the WrapCode method support maximum only <80 characters long line and it goes crazy in some cases, so I did two things:
-Introduced 'max_reasonable_indent' as 60 characters. If line has longer indentation it's already weird and we'll only help it, stripping that indentation away.

Was plying some more and found couple more problematic cases, so
-Introduced FindSplitPos function, which cover corner cases that I found.

If I just broke some 'line breaking rules' and this should be done in different way, please let me know.
