### PR TITLE
Fixed false positive warning from clang-tidy when using EXPECT_CALL().

### DIFF
--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -1269,7 +1269,7 @@ class MockSpec {
       const char* file, int line, const char* obj, const char* call) {
     const string source_text(string("EXPECT_CALL(") + obj + ", " + call + ")");
     LogWithLocation(internal::kInfo, file, line, source_text + " invoked");
-    return function_mocker_->AddNewExpectation(
+    return function_mocker_->AddNewExpectation( // NOLINT
         file, line, source_text, matchers_);
   }
 


### PR DESCRIPTION
This is a patch that fixes false clang-tidy positives for the EXPECT_CALL() macro from gmock (#853). 

Here is a small main.cpp file that will produce the issue:

```
#include <gtest/gtest.h>
#include <gmock/gmock.h>

using namespace testing;

class MyClass
{
public:
    virtual void doSomething(){}
};

class MockClass : public MyClass
{
public:
    MOCK_METHOD0(doSomething, void());
};

TEST(MyTest, demonstrate_clang_tidy_warning)
{
    MockClass myMockClass;

    EXPECT_CALL(myMockClass, doSomething()).Times(1);
}

int main(int argc, char **argv)
{
    ::testing::InitGoogleTest(&argc, argv);
    return RUN_ALL_TESTS();
}
```

The suggested fix will disable the false positive warning.
I ran `clang-tidy-3.8` with the options `-checks=-*,clang-analyzer-*,-clang-analyzer-alpha*`
