### PR TITLE
Make GTEST_TEST_NO_THROW_ output the exception message

### DIFF
--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1148,18 +1148,24 @@ class NativeArray {
       fail(gtest_msg.value)
 
 #define GTEST_TEST_NO_THROW_(statement, fail) \
+  std::string GTEST_CONCAT_TOKEN_(gtest_exmsg_testnothrow_,__LINE__); \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
   if (::testing::internal::AlwaysTrue()) { \
     try { \
       GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement); \
     } \
+    catch (const std::exception& e) { \
+      GTEST_CONCAT_TOKEN_(gtest_exmsg_testnothrow_,__LINE__) = e.what(); \
+      goto GTEST_CONCAT_TOKEN_(gtest_label_testnothrow_, __LINE__); \
+    } \
     catch (...) { \
+      GTEST_CONCAT_TOKEN_(gtest_exmsg_testnothrow_,__LINE__) = "no std::exception"; \
       goto GTEST_CONCAT_TOKEN_(gtest_label_testnothrow_, __LINE__); \
     } \
   } else \
     GTEST_CONCAT_TOKEN_(gtest_label_testnothrow_, __LINE__): \
-      fail("Expected: " #statement " doesn't throw an exception.\n" \
-           "  Actual: it throws.")
+      fail(("Expected: " #statement " doesn't throw an exception.\n" \
+            "  Actual: it throws: " + GTEST_CONCAT_TOKEN_(gtest_exmsg_testnothrow_,__LINE__)).c_str())
 
 #define GTEST_TEST_ANY_THROW_(statement, fail) \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_ \


### PR DESCRIPTION
When I am using *_NO_THROW statements and they fail, I want to know what was the cause for the exception. The

```
Actual: it throws.
```

message doesn't help me a lot, so I extended the macro to save the messages from std::exceptions into a string variable, which is then printed as well. Throwing reasonable exceptions I thereby can fix most of the problems without using breakpoints.
