### PR TITLE
Remove gcc 6 misleading indentations warnings

### DIFF
--- a/googlemock/include/gmock/gmock-generated-matchers.h
+++ b/googlemock/include/gmock/gmock-generated-matchers.h
@@ -1376,7 +1376,8 @@ AnyOf(M1 m1, M2 m2, M3 m3, M4 m4, M5 m5, M6 m6, M7 m7, M8 m8, M9 m9, M10 m10) {
 // ================
 //
 // To learn more about using these macros, please search for 'MATCHER'
-// on https://github.com/google/googletest/blob/master/googlemock/docs/CookBook.md
+// on https://github.com/google/googletest/blob/master/googlemock/docs/
+// CookBook.md
 
 #define MATCHER(name, description)\
   class name##Matcher {\
@@ -1397,8 +1398,9 @@ AnyOf(M1 m1, M2 m2, M3 m3, M4 m4, M5 m5, M6 m6, M7 m7, M8 m8, M9 m9, M10 m10) {
      private:\
       ::testing::internal::string FormatDescription(bool negation) const {\
         const ::testing::internal::string gmock_description = (description);\
-        if (!gmock_description.empty())\
+        if (!gmock_description.empty()) {\
           return gmock_description;\
+        }\
         return ::testing::internal::FormatMatcherDescription(\
             negation, #name, \
             ::testing::internal::UniversalTersePrintTupleFieldsToStrings(\
@@ -1446,8 +1448,9 @@ AnyOf(M1 m1, M2 m2, M3 m3, M4 m4, M5 m5, M6 m6, M7 m7, M8 m8, M9 m9, M10 m10) {
      private:\
       ::testing::internal::string FormatDescription(bool negation) const {\
         const ::testing::internal::string gmock_description = (description);\
-        if (!gmock_description.empty())\
+        if (!gmock_description.empty()) {\
           return gmock_description;\
+        }\
         return ::testing::internal::FormatMatcherDescription(\
             negation, #name, \
             ::testing::internal::UniversalTersePrintTupleFieldsToStrings(\
@@ -1499,8 +1502,9 @@ AnyOf(M1 m1, M2 m2, M3 m3, M4 m4, M5 m5, M6 m6, M7 m7, M8 m8, M9 m9, M10 m10) {
      private:\
       ::testing::internal::string FormatDescription(bool negation) const {\
         const ::testing::internal::string gmock_description = (description);\
-        if (!gmock_description.empty())\
+        if (!gmock_description.empty()) {\
           return gmock_description;\
+        }\
         return ::testing::internal::FormatMatcherDescription(\
             negation, #name, \
             ::testing::internal::UniversalTersePrintTupleFieldsToStrings(\
@@ -1557,8 +1561,9 @@ AnyOf(M1 m1, M2 m2, M3 m3, M4 m4, M5 m5, M6 m6, M7 m7, M8 m8, M9 m9, M10 m10) {
      private:\
       ::testing::internal::string FormatDescription(bool negation) const {\
         const ::testing::internal::string gmock_description = (description);\
-        if (!gmock_description.empty())\
+        if (!gmock_description.empty()) {\
           return gmock_description;\
+        }\
         return ::testing::internal::FormatMatcherDescription(\
             negation, #name, \
             ::testing::internal::UniversalTersePrintTupleFieldsToStrings(\
@@ -1620,8 +1625,9 @@ AnyOf(M1 m1, M2 m2, M3 m3, M4 m4, M5 m5, M6 m6, M7 m7, M8 m8, M9 m9, M10 m10) {
      private:\
       ::testing::internal::string FormatDescription(bool negation) const {\
         const ::testing::internal::string gmock_description = (description);\
-        if (!gmock_description.empty())\
+        if (!gmock_description.empty()) {\
           return gmock_description;\
+        }\
         return ::testing::internal::FormatMatcherDescription(\
             negation, #name, \
             ::testing::internal::UniversalTersePrintTupleFieldsToStrings(\
@@ -1691,8 +1697,9 @@ AnyOf(M1 m1, M2 m2, M3 m3, M4 m4, M5 m5, M6 m6, M7 m7, M8 m8, M9 m9, M10 m10) {
      private:\
       ::testing::internal::string FormatDescription(bool negation) const {\
         const ::testing::internal::string gmock_description = (description);\
-        if (!gmock_description.empty())\
+        if (!gmock_description.empty()) {\
           return gmock_description;\
+        }\
         return ::testing::internal::FormatMatcherDescription(\
             negation, #name, \
             ::testing::internal::UniversalTersePrintTupleFieldsToStrings(\
@@ -1765,8 +1772,9 @@ AnyOf(M1 m1, M2 m2, M3 m3, M4 m4, M5 m5, M6 m6, M7 m7, M8 m8, M9 m9, M10 m10) {
      private:\
       ::testing::internal::string FormatDescription(bool negation) const {\
         const ::testing::internal::string gmock_description = (description);\
-        if (!gmock_description.empty())\
+        if (!gmock_description.empty()) {\
           return gmock_description;\
+        }\
         return ::testing::internal::FormatMatcherDescription(\
             negation, #name, \
             ::testing::internal::UniversalTersePrintTupleFieldsToStrings(\
@@ -1843,8 +1851,9 @@ AnyOf(M1 m1, M2 m2, M3 m3, M4 m4, M5 m5, M6 m6, M7 m7, M8 m8, M9 m9, M10 m10) {
      private:\
       ::testing::internal::string FormatDescription(bool negation) const {\
         const ::testing::internal::string gmock_description = (description);\
-        if (!gmock_description.empty())\
+        if (!gmock_description.empty()) {\
           return gmock_description;\
+        }\
         return ::testing::internal::FormatMatcherDescription(\
             negation, #name, \
             ::testing::internal::UniversalTersePrintTupleFieldsToStrings(\
@@ -1928,8 +1937,9 @@ AnyOf(M1 m1, M2 m2, M3 m3, M4 m4, M5 m5, M6 m6, M7 m7, M8 m8, M9 m9, M10 m10) {
      private:\
       ::testing::internal::string FormatDescription(bool negation) const {\
         const ::testing::internal::string gmock_description = (description);\
-        if (!gmock_description.empty())\
+        if (!gmock_description.empty()) {\
           return gmock_description;\
+        }\
         return ::testing::internal::FormatMatcherDescription(\
             negation, #name, \
             ::testing::internal::UniversalTersePrintTupleFieldsToStrings(\
@@ -2019,8 +2029,9 @@ AnyOf(M1 m1, M2 m2, M3 m3, M4 m4, M5 m5, M6 m6, M7 m7, M8 m8, M9 m9, M10 m10) {
      private:\
       ::testing::internal::string FormatDescription(bool negation) const {\
         const ::testing::internal::string gmock_description = (description);\
-        if (!gmock_description.empty())\
+        if (!gmock_description.empty()) {\
           return gmock_description;\
+        }\
         return ::testing::internal::FormatMatcherDescription(\
             negation, #name, \
             ::testing::internal::UniversalTersePrintTupleFieldsToStrings(\
@@ -2115,8 +2126,9 @@ AnyOf(M1 m1, M2 m2, M3 m3, M4 m4, M5 m5, M6 m6, M7 m7, M8 m8, M9 m9, M10 m10) {
      private:\
       ::testing::internal::string FormatDescription(bool negation) const {\
         const ::testing::internal::string gmock_description = (description);\
-        if (!gmock_description.empty())\
+        if (!gmock_description.empty()) {\
           return gmock_description;\
+        }\
         return ::testing::internal::FormatMatcherDescription(\
             negation, #name, \
             ::testing::internal::UniversalTersePrintTupleFieldsToStrings(\

--- a/googlemock/include/gmock/gmock-generated-matchers.h.pump
+++ b/googlemock/include/gmock/gmock-generated-matchers.h.pump
@@ -639,8 +639,9 @@ $var param_field_decls2 = [[$for j
      private:\
       ::testing::internal::string FormatDescription(bool negation) const {\
         const ::testing::internal::string gmock_description = (description);\
-        if (!gmock_description.empty())\
+        if (!gmock_description.empty()) {\
           return gmock_description;\
+        }\
         return ::testing::internal::FormatMatcherDescription(\
             negation, #name, \
             ::testing::internal::UniversalTersePrintTupleFieldsToStrings(\


### PR DESCRIPTION
This removes some simple warnings that I hit when using Gmock with gcc6 and -Wall -Wextra -Werror.
