### PR TITLE
Guard the install rules added by 98d988deac06637364f6cd41c45c3db4a8a0b6bc

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -27,6 +27,8 @@ option(
   "Build gtest with internal symbols hidden in shared libraries."
   OFF)
 
+option(gtest_enable_install "Enable gtest install targets" ON)
+
 # Defines pre_project_set_up_hermetic_build() and set_up_hermetic_build().
 include(cmake/hermetic_build.cmake OPTIONAL)
 
@@ -102,10 +104,12 @@ endif()
 ########################################################################
 #
 # Install rules
-install(TARGETS gtest gtest_main
-  DESTINATION lib)
-install(DIRECTORY ${gtest_SOURCE_DIR}/include/gtest
-  DESTINATION include)
+if (gtest_enable_install)
+  install(TARGETS gtest gtest_main
+    DESTINATION lib)
+  install(DIRECTORY ${gtest_SOURCE_DIR}/include/gtest
+    DESTINATION include)
+endif()
 
 ########################################################################
 #


### PR DESCRIPTION
Guard the install rules added by 98d988deac06637364f6cd41c45c3db4a8a0b6bc by a new option `gtest_enable_install`.

The motivation for doing this is to allow CMake projects that
directly add GoogleTest (i.e. `add_subdirectory(/path/gtest)`) to their
project a way of preventing interference with their install rules.

User's of GoogleTest might use it directly in their CMake project
because of [1] to ensure it is built with same flags as the rest of
their project. [2] is an example of doing this.

In GoogleTest 1.7 these install rules didn't exist so it wasn't a
problem but with newer GoogleTest versions GoogleTest's install rules
get added to the outer project's install rules which might not be
desirable.

With this change a user of GoogleTest can now do

```
set(gtest_enable_install FALSE)
add_subdirectory(/path/gtest)
```

which will hide the cache varaible definition and disable the install
rules. The cache variable definition is `ON` by default so stand-alone
builds of GoogleTest will have the install rules as before.

[1] https://github.com/google/googletest/blob/master/googletest/docs/FAQ.md#why-is-it-not-recommended-to-install-a-pre-compiled-copy-of-google-test-for-example-into-usrlocal
[2] https://crascit.com/2015/07/25/cmake-gtest/