### PR TITLE
Fix #923 - support CMAKE_CROSSCOMPILING_EMULATOR for tests

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -216,7 +216,7 @@ find_package(PythonInterp)
 # from the given source files with the given compiler flags.
 function(cxx_test_with_flags name cxx_flags libs)
   cxx_executable_with_flags(${name} "${cxx_flags}" "${libs}" ${ARGN})
-  add_test(${name} ${name})
+  add_test(NAME ${name} COMMAND ${name})
 endfunction()
 
 # cxx_test(name libs srcs...)


### PR DESCRIPTION
Replaced legacy syntax of cmake add_test() with more modern syntax.
This allows running gtests's own tests on remote (cross) systems
using CMAKE_CROSSCOMPILING_EMULATOR with cmake-3.3 or newer.