### PR TITLE
modify ### As a Shared Library (DLL) ###

### DIFF
--- a/googletest/README.md
+++ b/googletest/README.md
@@ -198,7 +198,7 @@ as a shared library (known as a DLL on Windows) if you prefer.
 
 To compile *gtest* as a shared library, add
 
-    -DGTEST_CREATE_SHARED_LIBRARY=1
+    -DBUILD_SHARED_LIBS=ON
 
 to the compiler flags.  You'll also need to tell the linker to produce
 a shared library instead - consult your linker's manual for how to do


### PR DESCRIPTION
"-DGTEST_CREATE_SHARED_LIBRARY=1" dont't work for build a shared library
but " -DBUILD_SHARED_LIBS=ON" can. 
referred from this link http://stackoverflow.com/questions/13513905/how-to-setup-googletest-as-a-shared-library-on-linux