### PR TITLE
request #915 - enable dash-separated aliases of command line arguments

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -5018,10 +5018,12 @@ const char* ParseFlagValue(const char* str,
   // str and flag must not be NULL.
   if (str == NULL || flag == NULL) return NULL;
 
-  // The flag must start with "--" followed by GTEST_FLAG_PREFIX_.
+  // The flag must start with "--" followed by GTEST_FLAG_PREFIX_ or GTEST_FLAG_PREFIX_DASH_.
   const std::string flag_str = std::string("--") + GTEST_FLAG_PREFIX_ + flag;
+  const std::string flag_str_dash = std::string("--") + GTEST_FLAG_PREFIX_DASH_ + flag;
   const size_t flag_len = flag_str.length();
-  if (strncmp(str, flag_str.c_str(), flag_len) != 0) return NULL;
+  if (strncmp(str, flag_str.c_str(), flag_len) != 0 &&
+      strncmp(str, flag_str_dash.c_str(), flag_len) != 0) return NULL;
 
   // Skips the flag name.
   const char* flag_end = str + flag_len;

--- a/googletest/test/gtest_filter_unittest.py
+++ b/googletest/test/gtest_filter_unittest.py
@@ -93,8 +93,8 @@ TOTAL_SHARDS_ENV_VAR = 'GTEST_TOTAL_SHARDS'
 SHARD_INDEX_ENV_VAR = 'GTEST_SHARD_INDEX'
 SHARD_STATUS_FILE_ENV_VAR = 'GTEST_SHARD_STATUS_FILE'
 
-# The command line flag for specifying the test filters.
-FILTER_FLAG = 'gtest_filter'
+# The command line flags for specifying the test filters.
+FILTER_FLAG = ['gtest_filter', 'gtest-filter']
 
 # The command line flag for including disabled tests.
 ALSO_RUN_DISABED_TESTS_FLAG = 'gtest_also_run_disabled_tests'
@@ -277,15 +277,16 @@ class GTestFilterUnitTest(gtest_test_utils.TestCase):
       self.AssertSetEqual(tests_run, tests_to_run)
     # pylint: enable-msg=C6403
 
-    # Next, tests using the command line flag.
+    # Next, tests using the command line flags.
 
-    if gtest_filter is None:
-      args = []
-    else:
-      args = ['--%s=%s' % (FILTER_FLAG, gtest_filter)]
+    for flag in FILTER_FLAG:
+        if gtest_filter is None:
+          args = []
+        else:
+          args = ['--%s=%s' % (flag, gtest_filter)]
 
-    tests_run = RunAndExtractTestList(args)[0]
-    self.AssertSetEqual(tests_run, tests_to_run)
+        tests_run = RunAndExtractTestList(args)[0]
+        self.AssertSetEqual(tests_run, tests_to_run)
 
   def RunAndVerifyWithSharding(self, gtest_filter, total_shards, tests_to_run,
                                args=None, check_exit_0=False):
@@ -338,13 +339,14 @@ class GTestFilterUnitTest(gtest_test_utils.TestCase):
 
     tests_to_run = self.AdjustForParameterizedTests(tests_to_run)
 
-    # Construct the command line.
-    args = ['--%s' % ALSO_RUN_DISABED_TESTS_FLAG]
-    if gtest_filter is not None:
-      args.append('--%s=%s' % (FILTER_FLAG, gtest_filter))
-
-    tests_run = RunAndExtractTestList(args)[0]
-    self.AssertSetEqual(tests_run, tests_to_run)
+    for flag in FILTER_FLAG:
+        # Construct the command line.
+        args = ['--%s' % ALSO_RUN_DISABED_TESTS_FLAG]
+        if gtest_filter is not None:
+          args.append('--%s=%s' % (flag, gtest_filter))
+    
+        tests_run = RunAndExtractTestList(args)[0]
+        self.AssertSetEqual(tests_run, tests_to_run)
 
   def setUp(self):
     """Sets up test case.
@@ -566,12 +568,13 @@ class GTestFilterUnitTest(gtest_test_utils.TestCase):
   def testFlagOverridesEnvVar(self):
     """Tests that the filter flag overrides the filtering env. variable."""
 
-    SetEnvVar(FILTER_ENV_VAR, 'Foo*')
-    args = ['--%s=%s' % (FILTER_FLAG, '*One')]
-    tests_run = RunAndExtractTestList(args)[0]
-    SetEnvVar(FILTER_ENV_VAR, None)
-
-    self.AssertSetEqual(tests_run, ['BarTest.TestOne', 'BazTest.TestOne'])
+    for flag in FILTER_FLAG:
+        SetEnvVar(FILTER_ENV_VAR, 'Foo*')
+        args = ['--%s=%s' % (flag, '*One')]
+        tests_run = RunAndExtractTestList(args)[0]
+        SetEnvVar(FILTER_ENV_VAR, None)
+    
+        self.AssertSetEqual(tests_run, ['BarTest.TestOne', 'BazTest.TestOne'])
 
   def testShardStatusFileIsCreated(self):
     """Tests that the shard file is created if specified in the environment."""


### PR DESCRIPTION
Enabled dash-separator for command line arguments, both "_" and "-" separators are ready to use. Unit tests are updated as well.