### PR TITLE
Adds GTEST_HAS_FILE_SYSTEM flag

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -1438,6 +1438,7 @@ GTEST_API_ std::string GetCapturedStderr();
 
 #endif  // GTEST_HAS_STREAM_REDIRECTION
 
+#if GTEST_HAS_FILE_SYSTEM
 // Returns a path to temporary directory.
 GTEST_API_ std::string TempDir();
 
@@ -1446,6 +1447,7 @@ GTEST_API_ size_t GetFileSize(FILE* file);
 
 // Reads the entire content of a file as a string.
 GTEST_API_ std::string ReadEntireFile(FILE* file);
+#endif // GTEST_HAS_FILE_SYSTEM
 
 // All command line arguments.
 GTEST_API_ const ::std::vector<testing::internal::string>& GetArgvs();
@@ -2370,7 +2372,7 @@ inline bool IsDir(const StatStruct& st) { return S_ISDIR(st.st_mode); }
 #else // GTEST_HAS_FILE_SYSTEM
 
 inline char* StrDup(const char* src) {
-  char* dst = (char*)malloc(strlen(src) + 1);
+  char* dst = static_cast<char*>(malloc(strlen(src) + 1));
   if (dst != NULL)
     strcpy(dst, src);
   return dst;
@@ -2378,7 +2380,7 @@ inline char* StrDup(const char* src) {
 
 inline int StrCaseCmp(const char* s1, const char* s2) {
   while (*s1 != '\0' && *s2 != '\0') {
-    if (toupper(*s1) && toupper(*s2)) {
+    if (toupper(*s1) == toupper(*s2)) {
       s1++;
       s2++;
     }

--- a/googletest/src/gtest-filepath.cc
+++ b/googletest/src/gtest-filepath.cc
@@ -33,6 +33,7 @@
 #include "gtest/internal/gtest-filepath.h"
 #include "gtest/internal/gtest-port.h"
 
+#if GTEST_HAS_FILE_SYSTEM
 #include <stdlib.h>
 
 #if GTEST_OS_WINDOWS_MOBILE
@@ -385,3 +386,4 @@ void FilePath::Normalize() {
 
 }  // namespace internal
 }  // namespace testing
+#endif // GTEST_HAS_FILE_SYSTEM

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -247,11 +247,13 @@ GTEST_API_ std::string CodePointToUtf8(UInt32 code_point);
 // will be encoded as individual Unicode characters from Basic Normal Plane.
 GTEST_API_ std::string WideStringToUtf8(const wchar_t* str, int num_chars);
 
+#if GTEST_HAS_FILE_SYSTEM
 // Reads the GTEST_SHARD_STATUS_FILE environment variable, and creates the file
 // if the variable is present. If a file already exists at this location, this
 // function will write over it. If the variable is present, but the file cannot
 // be created, prints an error and exits.
 void WriteToShardStatusFileIfNeeded();
+#endif // GTEST_HAS_FILE_SYSTEM
 
 // Checks whether sharding is enabled by examining the relevant
 // environment variable values. If the variables are present,
@@ -377,10 +379,12 @@ class GTEST_API_ UnitTestOptions {
   // Returns the output format, or "" for normal printed output.
   static std::string GetOutputFormat();
 
+#if GTEST_HAS_FILE_SYSTEM
   // Returns the absolute path of the requested output file, or the
   // default (test_detail.xml in the original working directory) if
   // none was explicitly specified.
   static std::string GetAbsolutePathToOutputFile();
+#endif // GTEST_HAS_FILE_SYSTEM
 
   // Functions for processing the gtest_filter flag.
 
@@ -410,9 +414,11 @@ class GTEST_API_ UnitTestOptions {
   static bool MatchesFilter(const std::string& name, const char* filter);
 };
 
+#if GTEST_HAS_FILE_SYSTEM
 // Returns the current application's name, removing directory path if that
 // is present.  Used by UnitTestOptions::GetOutputFile.
 GTEST_API_ FilePath GetCurrentExecutableName();
+#endif // GTEST_HAS_FILE_SYSTEM
 
 // The role interface for getting the OS stack trace as a string.
 class OsStackTraceGetterInterface {
@@ -652,11 +658,13 @@ class GTEST_API_ UnitTestImpl {
     // RUN_ALL_TESTS().  Therefore we capture the current directory in
     // AddTestInfo(), which is called to register a TEST or TEST_F
     // before main() is reached.
+#if GTEST_HAS_FILE_SYSTEM
     if (original_working_dir_.IsEmpty()) {
       original_working_dir_.Set(FilePath::GetCurrentDir());
       GTEST_CHECK_(!original_working_dir_.IsEmpty())
           << "Failed to get the current working directory.";
     }
+#endif // GTEST_HAS_FILE_SYSTEM
 
     GetTestCase(test_info->test_case_name(),
                 test_info->type_param(),
@@ -768,9 +776,11 @@ class GTEST_API_ UnitTestImpl {
   friend class ReplaceDeathTestFactory;
 #endif  // GTEST_HAS_DEATH_TEST
 
+#if GTEST_HAS_FILE_SYSTEM
   // Initializes the event listener performing XML output as specified by
   // UnitTestOptions. Must not be called before InitGoogleTest.
   void ConfigureXmlOutput();
+#endif  // GTEST_HAS_FILE_SYSTEM
 
 #if GTEST_CAN_STREAM_RESULTS_
   // Initializes the event listener for streaming test results to a socket.

--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -1055,6 +1055,7 @@ std::string GetCapturedStderr() {
 
 #endif  // GTEST_HAS_STREAM_REDIRECTION
 
+#if GTEST_HAS_FILE_SYSTEM
 std::string TempDir() {
 #if GTEST_OS_WINDOWS_MOBILE
   return "\\temp\\";
@@ -1099,6 +1100,7 @@ std::string ReadEntireFile(FILE* file) {
 
   return content;
 }
+#endif // GTEST_HAS_FILE_SYSTEM
 
 #if GTEST_HAS_DEATH_TEST
 

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -3553,6 +3553,7 @@ std::string XmlUnitTestResultPrinter::RemoveInvalidXmlCharacters(
 //     </testcase>
 //   </testsuite>
 // </testsuites>
+#endif // GTEST_HAS_FILE_SYSTEM
 
 // Formats the given time in milliseconds as seconds.
 std::string FormatTimeInMillisAsSeconds(TimeInMillis ms) {
@@ -3592,6 +3593,7 @@ std::string FormatEpochTimeInMillisAsIso8601(TimeInMillis ms) {
       String::FormatIntWidth2(time_struct.tm_sec);
 }
 
+#if GTEST_HAS_FILE_SYSTEM
 // Streams an XML CDATA section, escaping invalid CDATA sequences as needed.
 void XmlUnitTestResultPrinter::OutputXmlCDataSection(::std::ostream* stream,
                                                      const char* data) {

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -1929,7 +1929,11 @@ TEST(ShouldRunTestOnShardTest, IsPartitionWhenThereAreFiveShards) {
 
 TEST(UnitTestTest, CanGetOriginalWorkingDir) {
   ASSERT_TRUE(UnitTest::GetInstance()->original_working_dir() != NULL);
+#if GTEST_HAS_FILE_SYSTEM
   EXPECT_STRNE(UnitTest::GetInstance()->original_working_dir(), "");
+#else
+  EXPECT_STREQ(UnitTest::GetInstance()->original_working_dir(), "");
+#endif // GTEST_HAS_FILE_SYSTEM
 }
 
 TEST(UnitTestTest, ReturnsPlausibleTimestamp) {


### PR DESCRIPTION
Adds GTEST_HAS_FILE_SYSTEM flag for compiling on some (embedded) systems
without file system.