### PR TITLE
Fix #920 MinGW >=3.22.3 inclusion of _EMULATE_GLIBC breaking build

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -2325,8 +2325,13 @@ inline int IsATTY(int /* fd */) { return 0; }
 inline int IsATTY(int fd) { return _isatty(fd); }
 #  endif  // GTEST_OS_WINDOWS_MOBILE
 inline int StrCaseCmp(const char* s1, const char* s2) {
+#  if _EMULATE_GLIBC
+  return strcasecmp(s1, s2);
+#   else
   return _stricmp(s1, s2);
+#  endif  // _EMULATE_GLIBC
 }
+
 inline char* StrDup(const char* src) { return _strdup(src); }
 # endif  // __BORLANDC__
 


### PR DESCRIPTION
Fixes build for MinGW  >=3.22.3 and closes issue #920.

MinGW commit ff51a7 added use of _EMULATE_GLIBC definition for including
either GNU's glibc strcasecmp() and strncasecmp() or MSVC's non-ansi
_stricmp() and _strnicmp() functions

This commit adds compiler definitions to check for _EMULATE_GLIC and returns the correct strcasecmp() or _stricmp(). I believe this is the correct use of checking for compiler definitions in the source rather than adding the definitions in cmake. 

An alternative approach would to add -D_EMULATE_GLIBC=0 to CMakeLists.txt when detecting MinGW >=3.22.3; however it it negates the use of the flag and will break the build if someone wanted EMULATE_GLIBC=1. 

