### PR TITLE
Fix a few documentation nits in the mock dummies guide

### DIFF
--- a/googlemock/docs/ForDummies.md
+++ b/googlemock/docs/ForDummies.md
@@ -23,8 +23,8 @@ Using Google Mock involves three basic steps:
 # Why Google Mock? #
 While mock objects help you remove unnecessary dependencies in tests and make them fast and reliable, using mocks manually in C++ is _hard_:
 
-  * Someone has to implement the mocks. The job is usually tedious and error-prone. No wonder people go great distance to avoid it.
-  * The quality of those manually written mocks is a bit, uh, unpredictable. You may see some really polished ones, but you may also see some that were hacked up in a hurry and have all sorts of ad hoc restrictions.
+  * Someone has to implement the mocks. The job is usually tedious and error-prone. No wonder people go great distances to avoid it.
+  * The quality of those manually written mocks is a bit, uh, unpredictable. You may see some really polished ones, but you may also see some that were hacked up in a hurry and have all sorts of ad-hoc restrictions.
   * The knowledge you gained from using one mock doesn't transfer to the next.
 
 In contrast, Java and Python programmers have some fine mock frameworks, which automate the creation of mocks. As a result, mocking is a proven effective technique and widely adopted practice in those communities. Having the right tool absolutely makes the difference.


### PR DESCRIPTION
Add a hyphen to 'ad hoc' and change 'distance' to plural.