### PR TITLE
Fix GetCurrentExecutableName to allow suffix

### DIFF
--- a/googletest/test/gtest-options_test.cc
+++ b/googletest/test/gtest-options_test.cc
@@ -107,18 +107,18 @@ TEST(OutputFileHelpersTest, GetCurrentExecutableName) {
   const std::string exe_str = GetCurrentExecutableName().string();
 #if GTEST_OS_WINDOWS
   const bool success =
-      _strcmpi("gtest-options_test", exe_str.c_str()) == 0 ||
-      _strcmpi("gtest-options-ex_test", exe_str.c_str()) == 0 ||
-      _strcmpi("gtest_all_test", exe_str.c_str()) == 0 ||
-      _strcmpi("gtest_dll_test", exe_str.c_str()) == 0;
+      exe_str.find("gtest-options_test") == 0 ||
+      exe_str.find("gtest-options-ex_test") == 0 ||
+      exe_str.find("gtest_all_test") == 0 ||
+      exe_str.find("gtest_dll_test") == 0;
 #else
   // TODO(wan@google.com): remove the hard-coded "lt-" prefix when
   //   Chandler Carruth's libtool replacement is ready.
   const bool success =
-      exe_str == "gtest-options_test" ||
-      exe_str == "gtest_all_test" ||
-      exe_str == "lt-gtest_all_test" ||
-      exe_str == "gtest_dll_test";
+      exe_str.find("gtest-options_test") == 0 ||
+      exe_str.find("gtest_all_test") == 0 ||
+      exe_str.find("lt-gtest_all_test") == 0 ||
+      exe_str.find("gtest_dll_test") == 0;
 #endif  // GTEST_OS_WINDOWS
   if (!success)
     FAIL() << "GetCurrentExecutableName() returns " << exe_str;


### PR DESCRIPTION
I'm pulling ToT googletest into a project using Android.mk builds and would like to run these tests as a part of _HOST_ unit tests to avoid the latency of having to run it on the device. Doing so appends _host to the executables as well as the libraries. This change will allow others to add whatever suffix to the generated tests and libraries they'd like.