### PR TITLE
Honour symbol visibility for all target types.

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -47,6 +47,11 @@ endif()
 project(gtest CXX C)
 cmake_minimum_required(VERSION 2.6.4)
 
+# It's nice when gtest_hide_internal_symbols does what it says it will do.
+if(POLICY CMP0063)
+    cmake_policy(SET CMP0063 NEW)
+endif()
+
 if (COMMAND set_up_hermetic_build)
   set_up_hermetic_build()
 endif()


### PR DESCRIPTION
This is mostly useful for hiding symbols when the libraries are built
statically.
Solves warnings about 'direct access to global weak symbol' when linking against
other libraries built with hidden symbols.