### PR TITLE
CMake: use threads if allowed and found, not just if found.

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -164,7 +164,7 @@ if (gmock_build_tests)
   cxx_test(gmock_link_test gmock_main test/gmock_link2_test.cc)
   cxx_test(gmock_test gmock_main)
 
-  if (CMAKE_USE_PTHREADS_INIT)
+  if (DEFINED GTEST_HAS_PTHREAD)
     cxx_test(gmock_stress_test gmock)
   endif()
 

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -48,10 +48,14 @@ endmacro()
 macro(config_compiler_and_linker)
   # Note: pthreads on MinGW is not supported, even if available
   # instead, we use windows threading primitives
+  unset(GTEST_HAS_PTHREAD)
   if (NOT gtest_disable_pthreads AND NOT MINGW)
     # Defines CMAKE_USE_PTHREADS_INIT and CMAKE_THREAD_LIBS_INIT.
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads)
+    if (CMAKE_USE_PTHREADS_INIT)
+      set(GTEST_HAS_PTHREAD ON)
+    endif()
   endif()
 
   fix_default_compiler_settings_()
@@ -126,7 +130,8 @@ macro(config_compiler_and_linker)
     set(cxx_no_rtti_flags "")
   endif()
 
-  if (CMAKE_USE_PTHREADS_INIT)  # The pthreads library is available and allowed.
+  # The pthreads library is available and allowed?
+  if (DEFINED GTEST_HAS_PTHREAD)
     set(GTEST_HAS_PTHREAD_MACRO "-DGTEST_HAS_PTHREAD=1")
   else()
     set(GTEST_HAS_PTHREAD_MACRO "-DGTEST_HAS_PTHREAD=0")
@@ -159,7 +164,7 @@ function(cxx_library_with_type name type cxx_flags)
       PROPERTIES
       COMPILE_DEFINITIONS "GTEST_CREATE_SHARED_LIBRARY=1")
   endif()
-  if (CMAKE_USE_PTHREADS_INIT)
+  if (DEFINED GTEST_HAS_PTHREAD)
     target_link_libraries(${name} ${CMAKE_THREAD_LIBS_INIT})
   endif()
 endfunction()


### PR DESCRIPTION
If the user's cmakelists.txt first look for threads using
find_package(Threads), then set(gtest_disable_pthreads ON),
and then include googletest. GoogleTest will not look for
threads. But since they have already been found before in
user's cmakelists, it will use them regardless.

This helped me fix build issue in https://github.com/darktable-org/rawspeed/commit/e079559f9e05597183f681cd94cff42b9c51a9d7
on windows/MSYS2, even though there are threads, and they
are usable, googletest build was failing with issues
about AutoHandle. I was first looking for threads, and only
then including googletest, so no matter the value of
gtest_disable_pthreads, it failed.

The other obvious solution is for user to first include
googletest, and only then look for threads by himself.

-----

Thoughts? Changes?
Needs a reproducer?
Should `NOT gtest_disable_pthreads AND NOT MINGW AND CMAKE_USE_PTHREADS_INIT` be stored as one variable (`HAS_THREADS`?) and that variable be used? May prevent breakage in the future.