### PR TITLE
fix building on VS 2015

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ option(BUILD_GTEST "Builds the googletest subproject" OFF)
 #Note that googlemock target already builds googletest
 option(BUILD_GMOCK "Builds the googlemock subproject" ON)
 
+if( ANDROID_STUDIO_WRAPPED_EXE )
+    add_definitions( -DGTEST_REDIRECT_TO_ANDROID_LOG )
+endif()
+
 if(BUILD_GMOCK)
   add_subdirectory( googlemock )
 elseif(BUILD_GTEST)

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -80,9 +80,9 @@ macro(config_compiler_and_linker)
       # http://stackoverflow.com/questions/3232669 explains the issue.
       set(cxx_base_flags "${cxx_base_flags} -wd4702")
     endif()
-    if (NOT (MSVC_VERSION GREATER 1900))  # 1900 is Visual Studio 2015
+    if (NOT (MSVC_VERSION GREATER_EQUAL 1900))  # 1900 is Visual Studio 2015
       # BigObj required for tests.
-      set(cxx_base_flags "${cxx_base_flags} -bigobj")
+      set(cxx_base_flags "${cxx_base_flags} -bigobj -std:c++latest")
     endif()
 
     set(cxx_base_flags "${cxx_base_flags} -D_UNICODE -DUNICODE -DWIN32 -D_WIN32")

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -158,6 +158,9 @@ function(cxx_library_with_type name type cxx_flags)
   if (CMAKE_USE_PTHREADS_INIT)
     target_link_libraries(${name} ${CMAKE_THREAD_LIBS_INIT})
   endif()
+  if( COMMAND make_universal )
+      make_universal( ${name} )
+  endif()
 endfunction()
 
 ########################################################################

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -323,7 +323,9 @@
 // -std={c,gnu}++{0x,11} is passed.  The C++11 standard specifies a
 // value for __cplusplus, and recent versions of clang, gcc, and
 // probably other compilers set that too in C++11 mode.
-# if __GXX_EXPERIMENTAL_CXX0X__ || __cplusplus >= 201103L
+// VS 2015 fully supports C++14 (and some C++17 features), but still defines __cplusplus as 199711L
+// and it does not support std::tr1::tuple anymore (but supports std::tuple)
+# if __GXX_EXPERIMENTAL_CXX0X__ || __cplusplus >= 201103L || _MSC_VER >= 1900
 // Compiling in at least C++11 mode.
 #  define GTEST_LANG_CXX11 1
 # else

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -146,7 +146,40 @@
 # define vsnprintf _vsnprintf
 #endif  // GTEST_OS_WINDOWS
 
+#if defined( GTEST_REDIRECT_TO_ANDROID_LOG )
+# include <android/log.h>
+#endif // GTEST_REDIRECT_TO_ANDROID_LOG
+
 namespace testing {
+
+#if defined( GTEST_REDIRECT_TO_ANDROID_LOG )
+namespace internal {
+void vprintf( char const * const fmt, va_list /*const*/ args )
+{
+    __android_log_vprint( ANDROID_LOG_INFO, "GTest", fmt, args );
+}
+
+void printf( char const * const fmt, ... )
+{
+    va_list args;
+    va_start( args, fmt );
+    vprintf( fmt, args );
+    va_end( args );
+}
+
+template <typename ... Args>
+int fprintf( FILE * const p_stream, char const * const fmt, Args ... args )
+{
+    if ( p_stream == stderr )
+        __android_log_print( ANDROID_LOG_ERROR, "GTest", fmt, args... );
+    else
+        ::fprintf( p_stream, fmt, args... );
+}
+} // namespace internal
+using internal::vprintf;
+using internal::printf;
+using internal::fprintf;
+#endif // GTEST_REDIRECT_TO_ANDROID_LOG
 
 using internal::CountIf;
 using internal::ForEach;


### PR DESCRIPTION
 VS 2015 fully supports C++14 (and some C++17 features), but still defines __cplusplus as 199711L. However, VS 2015 does not support std::tr1::tuple anymore and this causes failure to compile GTest.

This change adds msvc flag which turns on all latest c++ features and also in `gtest-port.h` performs compiler version check while determining if C++11 is supported.