### PR TITLE
don't throw exception in destructor in MSVC 2015

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -625,6 +625,7 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 # if _MSC_VER
 #  define GTEST_HAS_HASH_MAP_ 1  // Indicates that hash_map is available.
 #  define GTEST_HAS_HASH_SET_ 1  // Indicates that hash_set is available.
+#  define _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS // Note that hash_map and hash_map are deprecated and will be removed!
 # endif  // _MSC_VER
 #endif  // !defined(GTEST_HAS_HASH_MAP_)
 

--- a/googletest/test/gtest_catch_exceptions_test_.cc
+++ b/googletest/test/gtest_catch_exceptions_test_.cc
@@ -138,7 +138,7 @@ TEST_F(CxxExceptionInConstructorTest, ThrowsExceptionInConstructor) {
 }
 
 // Exceptions in destructors are not supported in C++11.
-#if !defined(__GXX_EXPERIMENTAL_CXX0X__) &&  __cplusplus < 201103L
+#if !defined(__GXX_EXPERIMENTAL_CXX0X__) && !(_MSC_VER >= 1400) &&  __cplusplus < 201103L
 class CxxExceptionInDestructorTest : public Test {
  public:
   static void TearDownTestCase() {


### PR DESCRIPTION
fix for issue #987