### PR TITLE
Guard CaptureTest using the appropriate feature test

### DIFF
--- a/googletest/test/gtest-port_test.cc
+++ b/googletest/test/gtest-port_test.cc
@@ -927,7 +927,7 @@ TEST(RETest, PartialMatchWorks) {
 
 #endif  // GTEST_USES_POSIX_RE
 
-#if !GTEST_OS_WINDOWS_MOBILE
+#if GTEST_HAS_STREAM_REDIRECTION
 
 TEST(CaptureTest, CapturesStdout) {
   CaptureStdout();
@@ -969,7 +969,7 @@ TEST(CaptureDeathTest, CannotReenterStdoutCapture) {
   // themselves.
 }
 
-#endif  // !GTEST_OS_WINDOWS_MOBILE
+#endif  // GTEST_HAS_STREAM_REDIRECTION
 
 TEST(ThreadLocalTest, DefaultConstructorInitializesToDefaultValues) {
   ThreadLocal<int> t1;


### PR DESCRIPTION
Guard CaptureTest and CaptureDeathTest using the appropriate feature test (GTEST_HAS_STREAM_REDIRECTION), so that this compiles on GTEST_OS_WINDOWS_{PHONE,RT} as well as GTEST_OS_WINDOWS_MOBILE. Fixes #999.