### PR TITLE
Fix broken links to docs sub-pages

### DIFF
--- a/googlemock/README.md
+++ b/googlemock/README.md
@@ -53,18 +53,18 @@ the Apache License, which is different from Google Mock's license.
 If you are new to the project, we suggest that you read the user
 documentation in the following order:
 
-  * Learn the [basics](../../tree/master/googletest/docs/Primer.md) of
+  * Learn the [basics](../../master/googletest/docs/Primer.md) of
     Google Test, if you choose to use Google Mock with it (recommended).
-  * Read [Google Mock for Dummies](../../tree/master/googlemock/docs/ForDummies.md).
+  * Read [Google Mock for Dummies](../../master/googlemock/docs/ForDummies.md).
   * Read the instructions below on how to build Google Mock.
 
 You can also watch Zhanyong's [talk](http://www.youtube.com/watch?v=sYpCyLI47rM) on Google Mock's usage and implementation.
 
 Once you understand the basics, check out the rest of the docs:
 
-  * [CheatSheet](../../tree/master/googlemock/docs/CheatSheet.md) - all the commonly used stuff
+  * [CheatSheet](../../master/googlemock/docs/CheatSheet.md) - all the commonly used stuff
     at a glance.
-  * [CookBook](../../tree/master/googlemock/docs/CookBook.md) - recipes for getting things done,
+  * [CookBook](../../master/googlemock/docs/CookBook.md) - recipes for getting things done,
     including advanced techniques.
 
 If you need help, please check the


### PR DESCRIPTION
The links were using blob/tree/master, which should be blob/master to work properly.