### PR TITLE
Minimal changes to fix build failures on Microsoft Visual Studio 2015

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -622,7 +622,7 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 // Determines if hash_map/hash_set are available.
 // Only used for testing against those containers.
 #if !defined(GTEST_HAS_HASH_MAP_)
-# if _MSC_VER
+# if defined(_MSC_VER) && (_MSC_VER < 1900)
 #  define GTEST_HAS_HASH_MAP_ 1  // Indicates that hash_map is available.
 #  define GTEST_HAS_HASH_SET_ 1  // Indicates that hash_set is available.
 # endif  // _MSC_VER

--- a/googletest/test/gtest-printers_test.cc
+++ b/googletest/test/gtest-printers_test.cc
@@ -216,6 +216,7 @@ using ::testing::internal::UniversalTersePrintTupleFieldsToStrings;
 #endif
 using ::testing::internal::string;
 
+#if GTEST_HAS_HASH_MAP_
 // The hash_* classes are not part of the C++ standard.  STLport
 // defines them in namespace std.  MSVC defines them in ::stdext.  GCC
 // defines them in ::.
@@ -229,6 +230,7 @@ using ::stdext::hash_map;
 using ::stdext::hash_set;
 using ::stdext::hash_multimap;
 using ::stdext::hash_multiset;
+#endif
 #endif
 
 // Prints a value to a string using the universal value printer.  This

--- a/googletest/test/gtest_catch_exceptions_test_.cc
+++ b/googletest/test/gtest_catch_exceptions_test_.cc
@@ -138,7 +138,7 @@ TEST_F(CxxExceptionInConstructorTest, ThrowsExceptionInConstructor) {
 }
 
 // Exceptions in destructors are not supported in C++11.
-#if !defined(__GXX_EXPERIMENTAL_CXX0X__) &&  __cplusplus < 201103L
+#if !defined(__GXX_EXPERIMENTAL_CXX0X__) &&  __cplusplus < 201103L && _MSC_VER < 1900
 class CxxExceptionInDestructorTest : public Test {
  public:
   static void TearDownTestCase() {


### PR DESCRIPTION
Should fix #1033 

Fixes the following errors:

```
hash_map(17): error C2338: <hash_map> is deprecated and will be REMOVED. Please use <unordered_map>. You can define _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS to acknowledge that you have received this warning. [googlemock\gtest\gtest-printers_test.vcxproj]
hash_set(17): error C2338: <hash_set> is deprecated and will be REMOVED. Please use <unordered_set>. You can define _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS to acknowledge that you have received this warning. [googlemock\gtest\gtest-printers_test.vcxproj]
googletest\test\gtest_catch_exceptions_test_.cc(152): error C2220: warning treated as error - no 'object' file generated
googletest\test\gtest_catch_exceptions_test_.cc(152): warning C4297: 'CxxExceptionInDestructorTest::~CxxExceptionInDestructorTest': function assumed not to throw an exception but does
  googletest\test\gtest_catch_exceptions_test_.cc(152): note: destructor or deallocator has a (possibly implicit) non-throwing exception specification
```

There were already some checks for _MSC_VER in the code, so this commit
continues in that vein.
