### PR TITLE
Fixing links in old googlemock documentation

### DIFF
--- a/googlemock/docs/v1_5/Documentation.md
+++ b/googlemock/docs/v1_5/Documentation.md
@@ -1,9 +1,9 @@
 This page lists all documentation wiki pages for Google Mock **version 1.5.0** -- **if you use a different version of Google Mock, please read the documentation for that specific version instead.**
 
-  * [ForDummies](V1_5_ForDummies.md) -- start here if you are new to Google Mock.
-  * [CheatSheet](V1_5_CheatSheet.md) -- a quick reference.
-  * [CookBook](V1_5_CookBook.md) -- recipes for doing various tasks using Google Mock.
-  * [FrequentlyAskedQuestions](V1_5_FrequentlyAskedQuestions.md) -- check here before asking a question on the mailing list.
+  * [ForDummies](ForDummies.md) -- start here if you are new to Google Mock.
+  * [CheatSheet](CheatSheet.md) -- a quick reference.
+  * [CookBook](CookBook.md) -- recipes for doing various tasks using Google Mock.
+  * [FrequentlyAskedQuestions](FrequentlyAskedQuestions.md) -- check here before asking a question on the mailing list.
 
 To contribute code to Google Mock, read:
 

--- a/googlemock/docs/v1_6/Documentation.md
+++ b/googlemock/docs/v1_6/Documentation.md
@@ -8,5 +8,5 @@ This page lists all documentation wiki pages for Google Mock **1.6**
 
 To contribute code to Google Mock, read:
 
-  * [DevGuide](DevGuide.md) -- read this _before_ writing your first patch.
+  * [DevGuide](../DevGuide.md) -- read this _before_ writing your first patch.
   * [Pump Manual](http://code.google.com/p/googletest/wiki/PumpManual) -- how we generate some of Google Mock's source files.

--- a/googlemock/docs/v1_6/Documentation.md
+++ b/googlemock/docs/v1_6/Documentation.md
@@ -1,12 +1,12 @@
 This page lists all documentation wiki pages for Google Mock **1.6**
 - **if you use a released version of Google Mock, please read the documentation for that specific version instead.**
 
-  * [ForDummies](V1_6_ForDummies.md) -- start here if you are new to Google Mock.
-  * [CheatSheet](V1_6_CheatSheet.md) -- a quick reference.
-  * [CookBook](V1_6_CookBook.md) -- recipes for doing various tasks using Google Mock.
-  * [FrequentlyAskedQuestions](V1_6_FrequentlyAskedQuestions.md) -- check here before asking a question on the mailing list.
+  * [ForDummies](ForDummies.md) -- start here if you are new to Google Mock.
+  * [CheatSheet](CheatSheet.md) -- a quick reference.
+  * [CookBook](CookBook.md) -- recipes for doing various tasks using Google Mock.
+  * [FrequentlyAskedQuestions](FrequentlyAskedQuestions.md) -- check here before asking a question on the mailing list.
 
 To contribute code to Google Mock, read:
 
   * [DevGuide](DevGuide.md) -- read this _before_ writing your first patch.
-  * [Pump Manual](http://code.google.com/p/googletest/wiki/V1_6_PumpManual) -- how we generate some of Google Mock's source files.
+  * [Pump Manual](http://code.google.com/p/googletest/wiki/PumpManual) -- how we generate some of Google Mock's source files.

--- a/googlemock/docs/v1_7/Documentation.md
+++ b/googlemock/docs/v1_7/Documentation.md
@@ -8,5 +8,5 @@ This page lists all documentation wiki pages for Google Mock **(the SVN trunk ve
 
 To contribute code to Google Mock, read:
 
-  * [DevGuide](DevGuide.md) -- read this _before_ writing your first patch.
+  * [DevGuide](../DevGuide.md) -- read this _before_ writing your first patch.
   * [Pump Manual](http://code.google.com/p/googletest/wiki/PumpManual) -- how we generate some of Google Mock's source files.

--- a/googlemock/docs/v1_7/Documentation.md
+++ b/googlemock/docs/v1_7/Documentation.md
@@ -1,10 +1,10 @@
 This page lists all documentation wiki pages for Google Mock **(the SVN trunk version)**
 - **if you use a released version of Google Mock, please read the documentation for that specific version instead.**
 
-  * [ForDummies](V1_7_ForDummies.md) -- start here if you are new to Google Mock.
-  * [CheatSheet](V1_7_CheatSheet.md) -- a quick reference.
-  * [CookBook](V1_7_CookBook.md) -- recipes for doing various tasks using Google Mock.
-  * [FrequentlyAskedQuestions](V1_7_FrequentlyAskedQuestions.md) -- check here before asking a question on the mailing list.
+  * [ForDummies](ForDummies.md) -- start here if you are new to Google Mock.
+  * [CheatSheet](CheatSheet.md) -- a quick reference.
+  * [CookBook](CookBook.md) -- recipes for doing various tasks using Google Mock.
+  * [FrequentlyAskedQuestions](FrequentlyAskedQuestions.md) -- check here before asking a question on the mailing list.
 
 To contribute code to Google Mock, read:
 


### PR DESCRIPTION
This PR fixes a few links in the Documentation.md files in the v1_5, v1_6, and v1_7 subdirectories of googlemock/docs.