### PR TITLE
Fix out-of-source build in example

### DIFF
--- a/googletest/README.md
+++ b/googletest/README.md
@@ -140,7 +140,7 @@ New file `CMakeLists.txt.in`:
 Existing build's `CMakeLists.txt`:
 
     # Download and unpack googletest at configure time
-    configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+    configure_file(CMakeLists.txt.in ${CMAKE_BINARY_DIR}/googletest-download/CMakeLists.txt)
     execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
       RESULT_VARIABLE result
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )


### PR DESCRIPTION
The example for incorporating googletest into an existing cmake project was missing a CMAKE_BINARY_DIR which breaks out-of-source builds