### PR TITLE
Fix ODR violation of gtest global variables in gmock

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -81,16 +81,11 @@ endif()
 # Google Mock libraries.  We build them using more strict warnings than what
 # are used for other targets, to ensure that Google Mock can be compiled by
 # a user aggressive about warnings.
-cxx_library(gmock
-            "${cxx_strict}"
-            "${gtest_dir}/src/gtest-all.cc"
-            src/gmock-all.cc)
+cxx_library(gmock "${cxx_strict}" src/gmock-all.cc)
+target_link_libraries(gmock gtest)
 
-cxx_library(gmock_main
-            "${cxx_strict}"
-            "${gtest_dir}/src/gtest-all.cc"
-            src/gmock-all.cc
-            src/gmock_main.cc)
+cxx_library(gmock_main "${cxx_strict}" src/gmock_main.cc)
+target_link_libraries(gmock_main gmock)
 
 # If the CMake version supports it, attach header directory information
 # to the targets for when we are part of a parent build (ie being pulled
@@ -154,18 +149,18 @@ if (gmock_build_tests)
   ############################################################
   # C++ tests built with non-standard compiler flags.
 
-  cxx_library(gmock_main_no_exception "${cxx_no_exception}"
-    "${gtest_dir}/src/gtest-all.cc" src/gmock-all.cc src/gmock_main.cc)
+  cxx_library(gmock_main_no_exception "${cxx_no_exception}" src/gmock_main.cc)
+  target_link_libraries(gmock_main_no_exception gmock)
 
-  cxx_library(gmock_main_no_rtti "${cxx_no_rtti}"
-    "${gtest_dir}/src/gtest-all.cc" src/gmock-all.cc src/gmock_main.cc)
+  cxx_library(gmock_main_no_rtti "${cxx_no_rtti}" src/gmock_main.cc)
+  target_link_libraries(gmock_main_no_rtti gmock)
 
   if (NOT MSVC OR MSVC_VERSION LESS 1600)  # 1600 is Visual Studio 2010.
     # Visual Studio 2010, 2012, and 2013 define symbols in std::tr1 that
     # conflict with our own definitions. Therefore using our own tuple does not
     # work on those compilers.
-    cxx_library(gmock_main_use_own_tuple "${cxx_use_own_tuple}"
-      "${gtest_dir}/src/gtest-all.cc" src/gmock-all.cc src/gmock_main.cc)
+    cxx_library(gmock_main_use_own_tuple "${cxx_use_own_tuple}" src/gmock_main.cc)
+    target_link_libraries(gmock_main_use_own_tuple gmock)
 
     cxx_test_with_flags(gmock_use_own_tuple_test "${cxx_use_own_tuple}"
       gmock_main_use_own_tuple test/gmock-spec-builders_test.cc)
@@ -177,8 +172,8 @@ if (gmock_build_tests)
   cxx_test_with_flags(gmock_no_rtti_test "${cxx_no_rtti}"
     gmock_main_no_rtti test/gmock-spec-builders_test.cc)
 
-  cxx_shared_library(shared_gmock_main "${cxx_default}"
-    "${gtest_dir}/src/gtest-all.cc" src/gmock-all.cc src/gmock_main.cc)
+  cxx_shared_library(shared_gmock_main "${cxx_default}" src/gmock_main.cc)
+  target_link_libraries(shared_gmock_main gmock)
 
   # Tests that a binary can be built with Google Mock as a shared library.  On
   # some system configurations, it may not possible to run the binary without


### PR DESCRIPTION
When both gtest and gmock are DSOs configured by cmake, and are dynamically
linked into a program, the program crashes with a double free error upon exit,
if the test program is invoked with at least one gtest flag specified,
or if there is a death test in the program. This is due to ODR violation
of global `std::string` variables (holding command line arguments) defined in
gtest but duplicated in gmock, because gtest is linked into gmock.
This updates cmake configuration for gmock to remove gtest from gmock
libraries. Notice that the gmock configure script also doesn't link gtest into gmock.
This also removes gmock from gmock_main to be consistent with gtest and
gtest_main.

Tested by running googletest unit tests as well by running tests in a
larger codebase that uses googletest (both DSO and .a) as a testing framework 
on a linux system with gcc-4.9 and gcc-5.4.

Potentially also fixes some bugs mentioned in https://github.com/google/googletest/issues/930