### PR TITLE
Minimal changes to let samples build with c++11 & -Wsuggest-override

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -20,6 +20,8 @@ option(gtest_build_tests "Build all of gtest's own tests." OFF)
 
 option(gtest_build_samples "Build gtest's sample programs." OFF)
 
+option(gtest_build_samples_cxx11 "Build gtest's sample programs as C++11." OFF)
+
 option(gtest_disable_pthreads "Disable uses of pthreads in gtest." OFF)
 
 option(
@@ -116,16 +118,16 @@ install(DIRECTORY ${gtest_SOURCE_DIR}/include/gtest
 # or specifying the -Dgtest_build_samples=ON flag when running cmake.
 
 if (gtest_build_samples)
-  cxx_executable(sample1_unittest samples gtest_main samples/sample1.cc)
-  cxx_executable(sample2_unittest samples gtest_main samples/sample2.cc)
-  cxx_executable(sample3_unittest samples gtest_main)
-  cxx_executable(sample4_unittest samples gtest_main samples/sample4.cc)
-  cxx_executable(sample5_unittest samples gtest_main samples/sample1.cc)
-  cxx_executable(sample6_unittest samples gtest_main)
-  cxx_executable(sample7_unittest samples gtest_main)
-  cxx_executable(sample8_unittest samples gtest_main)
-  cxx_executable(sample9_unittest samples gtest)
-  cxx_executable(sample10_unittest samples gtest)
+  cxx_sample(sample1_unittest samples gtest_main samples/sample1.cc)
+  cxx_sample(sample2_unittest samples gtest_main samples/sample2.cc)
+  cxx_sample(sample3_unittest samples gtest_main)
+  cxx_sample(sample4_unittest samples gtest_main samples/sample4.cc)
+  cxx_sample(sample5_unittest samples gtest_main samples/sample1.cc)
+  cxx_sample(sample6_unittest samples gtest_main)
+  cxx_sample(sample7_unittest samples gtest_main)
+  cxx_sample(sample8_unittest samples gtest_main)
+  cxx_sample(sample9_unittest samples gtest)
+  cxx_sample(sample10_unittest samples gtest)
 endif()
 
 ########################################################################

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -207,6 +207,23 @@ function(cxx_executable name dir libs)
     ${name} "${cxx_default}" "${libs}" "${dir}/${name}.cc" ${ARGN})
 endfunction()
 
+
+# cxx_sample(name dir lib srcs...)
+#
+# same as cxx_executable, but obeys gtest_build_samples_cxx11
+# by turning on a semistrict C++11 mode when building samples.
+function(cxx_sample name dir libs)
+  if (gtest_build_samples_cxx11)
+    if (MSVC)
+      set("cxx11_flag" "")
+    else()
+      set("cxx11_flag" "-std=c++11 -Wsuggest-override")
+    endif()
+  endif()
+  cxx_executable_with_flags(
+    ${name} "${cxx_default} ${cxx11_flag}" "${libs}" "${dir}/${name}.cc" ${ARGN})
+endfunction()
+
 # Sets PYTHONINTERP_FOUND and PYTHON_EXECUTABLE.
 find_package(PythonInterp)
 

--- a/googletest/include/gtest/gtest-test-part.h
+++ b/googletest/include/gtest/gtest-test-part.h
@@ -163,7 +163,7 @@ class GTEST_API_ HasNewFatalFailureHelper
  public:
   HasNewFatalFailureHelper();
   virtual ~HasNewFatalFailureHelper();
-  virtual void ReportTestPartResult(const TestPartResult& result);
+  virtual void ReportTestPartResult(const TestPartResult& result) GTEST_OVERRIDE;
   bool has_new_fatal_failure() const { return has_new_fatal_failure_; }
  private:
   bool has_new_fatal_failure_;

--- a/googletest/include/gtest/gtest-typed-test.h
+++ b/googletest/include/gtest/gtest-typed-test.h
@@ -173,7 +173,7 @@ INSTANTIATE_TYPED_TEST_CASE_P(My, FooTest, MyTypes);
    private: \
     typedef CaseName<gtest_TypeParam_> TestFixture; \
     typedef gtest_TypeParam_ TypeParam; \
-    virtual void TestBody(); \
+    virtual void TestBody() GTEST_OVERRIDE; \
   }; \
   bool gtest_##CaseName##_##TestName##_registered_ GTEST_ATTRIBUTE_UNUSED_ = \
       ::testing::internal::TypeParameterizedTest< \
@@ -228,7 +228,7 @@ INSTANTIATE_TYPED_TEST_CASE_P(My, FooTest, MyTypes);
    private: \
     typedef CaseName<gtest_TypeParam_> TestFixture; \
     typedef gtest_TypeParam_ TypeParam; \
-    virtual void TestBody(); \
+    virtual void TestBody() GTEST_OVERRIDE; \
   }; \
   static bool gtest_##TestName##_defined_ GTEST_ATTRIBUTE_UNUSED_ = \
       GTEST_TYPED_TEST_CASE_P_STATE_(CaseName).AddTestName(\

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1043,21 +1043,32 @@ class TestEventListener {
 // above.
 class EmptyTestEventListener : public TestEventListener {
  public:
-  virtual void OnTestProgramStart(const UnitTest& /*unit_test*/) {}
+  virtual void OnTestProgramStart(const UnitTest& /*unit_test*/)
+                                                       GTEST_OVERRIDE {}
   virtual void OnTestIterationStart(const UnitTest& /*unit_test*/,
-                                    int /*iteration*/) {}
-  virtual void OnEnvironmentsSetUpStart(const UnitTest& /*unit_test*/) {}
-  virtual void OnEnvironmentsSetUpEnd(const UnitTest& /*unit_test*/) {}
-  virtual void OnTestCaseStart(const TestCase& /*test_case*/) {}
-  virtual void OnTestStart(const TestInfo& /*test_info*/) {}
-  virtual void OnTestPartResult(const TestPartResult& /*test_part_result*/) {}
-  virtual void OnTestEnd(const TestInfo& /*test_info*/) {}
-  virtual void OnTestCaseEnd(const TestCase& /*test_case*/) {}
-  virtual void OnEnvironmentsTearDownStart(const UnitTest& /*unit_test*/) {}
-  virtual void OnEnvironmentsTearDownEnd(const UnitTest& /*unit_test*/) {}
+                                    int /*iteration*/) GTEST_OVERRIDE {}
+  virtual void OnEnvironmentsSetUpStart(const UnitTest& /*unit_test*/)
+                                                       GTEST_OVERRIDE {}
+  virtual void OnEnvironmentsSetUpEnd(const UnitTest& /*unit_test*/)
+                                                       GTEST_OVERRIDE {}
+  virtual void OnTestCaseStart(const TestCase& /*test_case*/)
+                                                       GTEST_OVERRIDE {}
+  virtual void OnTestStart(const TestInfo& /*test_info*/)
+                                                       GTEST_OVERRIDE {}
+  virtual void OnTestPartResult(const TestPartResult& /*test_part_result*/)
+                                                       GTEST_OVERRIDE {}
+  virtual void OnTestEnd(const TestInfo& /*test_info*/)
+                                                       GTEST_OVERRIDE {}
+  virtual void OnTestCaseEnd(const TestCase& /*test_case*/)
+                                                       GTEST_OVERRIDE {}
+  virtual void OnEnvironmentsTearDownStart(const UnitTest& /*unit_test*/)
+                                                       GTEST_OVERRIDE {}
+  virtual void OnEnvironmentsTearDownEnd(const UnitTest& /*unit_test*/)
+                                                       GTEST_OVERRIDE {}
   virtual void OnTestIterationEnd(const UnitTest& /*unit_test*/,
-                                  int /*iteration*/) {}
-  virtual void OnTestProgramEnd(const UnitTest& /*unit_test*/) {}
+                                  int /*iteration*/) GTEST_OVERRIDE {}
+  virtual void OnTestProgramEnd(const UnitTest& /*unit_test*/)
+                                                       GTEST_OVERRIDE {}
 };
 
 // TestEventListeners lets users add listeners to track events in Google Test.

--- a/googletest/include/gtest/internal/gtest-death-test-internal.h
+++ b/googletest/include/gtest/internal/gtest-death-test-internal.h
@@ -147,8 +147,8 @@ class DeathTestFactory {
 // A concrete DeathTestFactory implementation for normal use.
 class DefaultDeathTestFactory : public DeathTestFactory {
  public:
-  virtual bool Create(const char* statement, const RE* regex,
-                      const char* file, int line, DeathTest** test);
+  virtual bool Create (const char* statement, const RE* regex,
+                      const char* file, int line, DeathTest** test) GTEST_OVERRIDE;
 };
 
 // Returns true if exit_status describes a process that was terminated

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -476,12 +476,12 @@ class TestFactoryBase {
   GTEST_DISALLOW_COPY_AND_ASSIGN_(TestFactoryBase);
 };
 
-// This class provides implementation of TeastFactoryBase interface.
+// This class provides implementation of TestFactoryBase interface.
 // It is used in TEST and TEST_F macros.
 template <class TestClass>
 class TestFactoryImpl : public TestFactoryBase {
  public:
-  virtual Test* CreateTest() { return new TestClass; }
+  virtual Test* CreateTest() GTEST_OVERRIDE { return new TestClass; }
 };
 
 #if GTEST_OS_WINDOWS
@@ -1216,7 +1216,7 @@ class GTEST_TEST_CLASS_NAME_(test_case_name, test_name) : public parent_class {\
  public:\
   GTEST_TEST_CLASS_NAME_(test_case_name, test_name)() {}\
  private:\
-  virtual void TestBody();\
+  virtual void TestBody() GTEST_OVERRIDE;\
   static ::testing::TestInfo* const test_info_ GTEST_ATTRIBUTE_UNUSED_;\
   GTEST_DISALLOW_COPY_AND_ASSIGN_(\
       GTEST_TEST_CLASS_NAME_(test_case_name, test_name));\

--- a/googletest/include/gtest/internal/gtest-param-util.h
+++ b/googletest/include/gtest/internal/gtest-param-util.h
@@ -296,10 +296,10 @@ class ValuesInIteratorRangeGenerator : public ParamGeneratorInterface<T> {
       : container_(begin, end) {}
   virtual ~ValuesInIteratorRangeGenerator() {}
 
-  virtual ParamIteratorInterface<T>* Begin() const {
+  virtual ParamIteratorInterface<T>* Begin() const GTEST_OVERRIDE {
     return new Iterator(this, container_.begin());
   }
-  virtual ParamIteratorInterface<T>* End() const {
+  virtual ParamIteratorInterface<T>* End() const GTEST_OVERRIDE {
     return new Iterator(this, container_.end());
   }
 
@@ -313,14 +313,14 @@ class ValuesInIteratorRangeGenerator : public ParamGeneratorInterface<T> {
         : base_(base), iterator_(iterator) {}
     virtual ~Iterator() {}
 
-    virtual const ParamGeneratorInterface<T>* BaseGenerator() const {
+    virtual const ParamGeneratorInterface<T>* BaseGenerator() const GTEST_OVERRIDE {
       return base_;
     }
-    virtual void Advance() {
+    virtual void Advance() GTEST_OVERRIDE {
       ++iterator_;
       value_.reset();
     }
-    virtual ParamIteratorInterface<T>* Clone() const {
+    virtual ParamIteratorInterface<T>* Clone() const GTEST_OVERRIDE {
       return new Iterator(*this);
     }
     // We need to use cached value referenced by iterator_ because *iterator_
@@ -330,12 +330,12 @@ class ValuesInIteratorRangeGenerator : public ParamGeneratorInterface<T> {
     // can advance iterator_ beyond the end of the range, and we cannot
     // detect that fact. The client code, on the other hand, is
     // responsible for not calling Current() on an out-of-range iterator.
-    virtual const T* Current() const {
+    virtual const T* Current() const GTEST_OVERRIDE {
       if (value_.get() == NULL)
         value_.reset(new T(*iterator_));
       return value_.get();
     }
-    virtual bool Equals(const ParamIteratorInterface<T>& other) const {
+    virtual bool Equals(const ParamIteratorInterface<T>& other) const GTEST_OVERRIDE {
       // Having the same base generator guarantees that the other
       // iterator is of the same type and we can downcast.
       GTEST_CHECK_(BaseGenerator() == other.BaseGenerator())
@@ -511,9 +511,13 @@ class ParameterizedTestCaseInfo : public ParameterizedTestCaseInfoBase {
       : test_case_name_(name), code_location_(code_location) {}
 
   // Test case base name for display purposes.
-  virtual const string& GetTestCaseName() const { return test_case_name_; }
+  virtual const string& GetTestCaseName() const GTEST_OVERRIDE {
+    return test_case_name_;
+  }
   // Test case id to verify identity.
-  virtual TypeId GetTestCaseTypeId() const { return GetTypeId<TestCase>(); }
+  virtual TypeId GetTestCaseTypeId() const GTEST_OVERRIDE {
+    return GetTypeId<TestCase>();
+  }
   // TEST_P macro uses AddTestPattern() to record information
   // about a single test in a LocalTestInfo structure.
   // test_case_name is the base name of the test case (without invocation
@@ -543,7 +547,7 @@ class ParameterizedTestCaseInfo : public ParameterizedTestCaseInfoBase {
   // This method should not be called more then once on any single
   // instance of a ParameterizedTestCaseInfoBase derived class.
   // UnitTest has a guard to prevent from calling this method more then once.
-  virtual void RegisterTests() {
+  virtual void RegisterTests() GTEST_OVERRIDE {
     for (typename TestInfoContainer::iterator test_it = tests_.begin();
          test_it != tests_.end(); ++test_it) {
       linked_ptr<TestInfo> test_info = *test_it;

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -668,6 +668,15 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 #  define GTEST_ENV_HAS_STD_TUPLE_ 1
 # endif
 
+// C++11 allows the override specifier when overriding virtual methods.
+// This is enforced by clang's -Winconsistent-missing-override and gcc's
+// -Wsuggest-override, even if gtest is included with -isystem.
+# if GTEST_LANG_CXX11
+#  define GTEST_OVERRIDE override
+#else
+#  define GTEST_OVERRIDE
+#endif
+
 # if GTEST_ENV_HAS_TR1_TUPLE_ || GTEST_ENV_HAS_STD_TUPLE_
 #  define GTEST_USE_OWN_TR1_TUPLE 0
 # else

--- a/googletest/samples/sample10_unittest.cc
+++ b/googletest/samples/sample10_unittest.cc
@@ -78,12 +78,14 @@ int Water::allocated_ = 0;
 class LeakChecker : public EmptyTestEventListener {
  private:
   // Called before a test starts.
-  virtual void OnTestStart(const TestInfo& /* test_info */) {
+  virtual void OnTestStart(const TestInfo& /* test_info */)
+                                             GTEST_OVERRIDE {
     initially_allocated_ = Water::allocated();
   }
 
   // Called after a test ends.
-  virtual void OnTestEnd(const TestInfo& /* test_info */) {
+  virtual void OnTestEnd(const TestInfo& /* test_info */)
+                                           GTEST_OVERRIDE {
     int difference = Water::allocated() - initially_allocated_;
 
     // You can generate a failure in any event handler except

--- a/googletest/samples/sample9_unittest.cc
+++ b/googletest/samples/sample9_unittest.cc
@@ -52,16 +52,17 @@ namespace {
 class TersePrinter : public EmptyTestEventListener {
  private:
   // Called before any test activity starts.
-  virtual void OnTestProgramStart(const UnitTest& /* unit_test */) {}
+  virtual void OnTestProgramStart(const UnitTest& /* unit_test */)
+                                                    GTEST_OVERRIDE {}
 
   // Called after all test activities have ended.
-  virtual void OnTestProgramEnd(const UnitTest& unit_test) {
+  virtual void OnTestProgramEnd(const UnitTest& unit_test) GTEST_OVERRIDE {
     fprintf(stdout, "TEST %s\n", unit_test.Passed() ? "PASSED" : "FAILED");
     fflush(stdout);
   }
 
   // Called before a test starts.
-  virtual void OnTestStart(const TestInfo& test_info) {
+  virtual void OnTestStart(const TestInfo& test_info) GTEST_OVERRIDE {
     fprintf(stdout,
             "*** Test %s.%s starting.\n",
             test_info.test_case_name(),
@@ -70,7 +71,8 @@ class TersePrinter : public EmptyTestEventListener {
   }
 
   // Called after a failed assertion or a SUCCEED() invocation.
-  virtual void OnTestPartResult(const TestPartResult& test_part_result) {
+  virtual void OnTestPartResult(const TestPartResult& test_part_result)
+                                                         GTEST_OVERRIDE {
     fprintf(stdout,
             "%s in %s:%d\n%s\n",
             test_part_result.failed() ? "*** Failure" : "Success",
@@ -81,7 +83,7 @@ class TersePrinter : public EmptyTestEventListener {
   }
 
   // Called after a test ends.
-  virtual void OnTestEnd(const TestInfo& test_info) {
+  virtual void OnTestEnd(const TestInfo& test_info) GTEST_OVERRIDE {
     fprintf(stdout,
             "*** Test %s.%s ending.\n",
             test_info.test_case_name(),


### PR DESCRIPTION
Fixes #1063

Adds the option gtest_build_samples_cxx11 and fix the problems it exposes.

Tested on ubuntu 16.04 with g++ 5.4 so far.