### PR TITLE
gtest-port: use _LIBCPPABI_VERSION instead of _LIBCPP_VERSION

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -951,8 +951,7 @@ using ::std::tuple_size;
 # define GTEST_NO_INLINE_
 #endif
 
-// _LIBCPP_VERSION is defined by the libc++ library from the LLVM project.
-#if defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
+#if defined(__GLIBCXX__)
 # define GTEST_HAS_CXXABI_H_ 1
 #else
 # define GTEST_HAS_CXXABI_H_ 0


### PR DESCRIPTION
The cxxabi.h header is from libc++abi, not libc++.  The presence of
libc++abi can be predicated on `_LIBCPPABI_VERSION`, while
`_LIBCPP_VERSION` indicates the version for libc++.