### PR TITLE
Pick up GTEST_API_ definition in gtest/internal/custom/gtest-port.h.

### DIFF
--- a/googletest/include/gtest/internal/custom/gtest-port.h
+++ b/googletest/include/gtest/internal/custom/gtest-port.h
@@ -61,6 +61,9 @@
 //     GTEST_EXCLUSIVE_LOCK_REQUIRED_(locks)
 //     GTEST_LOCK_EXCLUDED_(locks)
 //
+//   Exporting API symbols:
+//     GTEST_API_ - Specifier for exported symbols.
+//
 // ** Custom implementation starts here **
 
 #ifndef GTEST_INCLUDE_GTEST_INTERNAL_CUSTOM_GTEST_PORT_H_

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -930,6 +930,11 @@ using ::std::tuple_size;
 
 #endif  // GTEST_HAS_SEH
 
+// GTEST_API_ qualifies all symbols that must be exported. The definitions below
+// are guarded by #ifndef to give embedders a chance to define GTEST_API_ in
+// gtest/internal/custom/gtest-port.h
+#ifndef GTEST_API_
+
 #ifdef _MSC_VER
 # if GTEST_LINKED_AS_SHARED_LIBRARY
 #  define GTEST_API_ __declspec(dllimport)
@@ -940,9 +945,11 @@ using ::std::tuple_size;
 # define GTEST_API_ __attribute__((visibility ("default")))
 #endif // _MSC_VER
 
+#endif // GTEST_API_
+
 #ifndef GTEST_API_
 # define GTEST_API_
-#endif
+#endif // GTEST_API_
 
 #ifdef __GNUC__
 // Ask the compiler to never inline a given function.


### PR DESCRIPTION
This makes it possible for a port to define the specifier used for exported symbols without having to change Google Test.

Background: I'm trying to roll Google Test from 1.7.0 to 1.8.0 (or above) into Chromium and I'm running into a crasher in the ThreadLocal destructor for a static variable defined in Google Mock with the GTEST_API_ specifier. Some details are at https://bugs.chromium.org/p/chromium/issues/detail?id=630705#c28 and I can supply more, if it helps.

I realize this PR is not addressing the root cause of the crashes, but being able to replace the GTEST_API_ definition lets me make forward progress, and I can imagine that being able to define GTEST_API_ would come in handy for other projects as well. Will you please consider merging this?