### PR TITLE
Add missing initializers to enable -Weff-c++ warning

### DIFF
--- a/googletest/include/gtest/gtest-test-part.h
+++ b/googletest/include/gtest/gtest-test-part.h
@@ -125,7 +125,7 @@ std::ostream& operator<<(std::ostream& os, const TestPartResult& result);
 // virtual.
 class GTEST_API_ TestPartResultArray {
  public:
-  TestPartResultArray() {}
+  TestPartResultArray() : array_() {}
 
   // Appends the given TestPartResult to the array.
   void Append(const TestPartResult& result);

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -274,7 +274,7 @@ class GTEST_API_ AssertionResult {
       typename internal::EnableIf<
           !internal::ImplicitlyConvertible<T, AssertionResult>::value>::type*
           /*enabler*/ = NULL)
-      : success_(success) {}
+      : success_(success), message_() {}
 
   GTEST_DISABLE_MSC_WARNINGS_POP_()
 
@@ -1676,7 +1676,7 @@ class GTEST_API_ AssertHelper {
 
   // Message assignment is a semantic trick to enable assertion
   // streaming; see the GTEST_MESSAGE_ macro below.
-  void operator=(const Message& message) const;
+  const AssertHelper& operator=(const Message& message) const;
 
  private:
   // We put our data in a struct so that the size of the AssertHelper class can

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -307,7 +307,7 @@ class FloatingPoint {
   // around may change its bits, although the new value is guaranteed
   // to be also a NAN.  Therefore, don't expect this constructor to
   // preserve the bits in x when x is a NAN.
-  explicit FloatingPoint(const RawType& x) { u_.value_ = x; }
+  explicit FloatingPoint(const RawType& x) : u_() { u_.value_ = x; }
 
   // Static methods
 
@@ -547,7 +547,7 @@ GTEST_API_ bool SkipPrefix(const char* prefix, const char** pstr);
 // State of the definition of a type-parameterized test case.
 class GTEST_API_ TypedTestCasePState {
  public:
-  TypedTestCasePState() : registered_(false) {}
+  TypedTestCasePState() : registered_(false), registered_tests_() {}
 
   // Adds the given test name to defined_test_names_ and return true
   // if the test case hasn't been registered; otherwise aborts the

--- a/googletest/include/gtest/internal/gtest-linked_ptr.h
+++ b/googletest/include/gtest/internal/gtest-linked_ptr.h
@@ -149,12 +149,12 @@ class linked_ptr {
 
   // Take over ownership of a raw pointer.  This should happen as soon as
   // possible after the object is created.
-  explicit linked_ptr(T* ptr = NULL) { capture(ptr); }
+  explicit linked_ptr(T* ptr = NULL) : value_(), link_() { capture(ptr); }
   ~linked_ptr() { depart(); }
 
   // Copy an existing linked_ptr<>, adding ourselves to the list of references.
-  template <typename U> linked_ptr(linked_ptr<U> const& ptr) { copy(&ptr); }
-  linked_ptr(linked_ptr const& ptr) {  // NOLINT
+  template <typename U> linked_ptr(linked_ptr<U> const& ptr) : value_(), link_() { copy(&ptr); }
+  linked_ptr(linked_ptr const& ptr) : value_(), link_() {  // NOLINT
     assert(&ptr != this);
     copy(&ptr);
   }

--- a/googletest/include/gtest/internal/gtest-param-util.h
+++ b/googletest/include/gtest/internal/gtest-param-util.h
@@ -310,7 +310,7 @@ class ValuesInIteratorRangeGenerator : public ParamGeneratorInterface<T> {
    public:
     Iterator(const ParamGeneratorInterface<T>* base,
              typename ContainerType::const_iterator iterator)
-        : base_(base), iterator_(iterator) {}
+        : base_(base), iterator_(iterator), value_() {}
     virtual ~Iterator() {}
 
     virtual const ParamGeneratorInterface<T>* BaseGenerator() const {
@@ -346,12 +346,15 @@ class ValuesInIteratorRangeGenerator : public ParamGeneratorInterface<T> {
     }
 
    private:
+    Iterator& operator=(const Iterator&);
+
     Iterator(const Iterator& other)
           // The explicit constructor call suppresses a false warning
           // emitted by gcc when supplied with the -Wextra option.
         : ParamIteratorInterface<T>(),
           base_(other.base_),
-          iterator_(other.iterator_) {}
+          iterator_(other.iterator_),
+          value_() {}
 
     const ParamGeneratorInterface<T>* const base_;
     typename ContainerType::const_iterator iterator_;
@@ -361,6 +364,7 @@ class ValuesInIteratorRangeGenerator : public ParamGeneratorInterface<T> {
     // Use of scoped_ptr helps manage cached value's lifetime,
     // which is bound by the lifespan of the iterator itself.
     mutable scoped_ptr<const T> value_;
+
   };  // class ValuesInIteratorRangeGenerator::Iterator
 
   // No implementation - assignment is unsupported.
@@ -667,7 +671,7 @@ class ParameterizedTestCaseInfo : public ParameterizedTestCaseInfoBase {
 // descriptors.
 class ParameterizedTestCaseRegistry {
  public:
-  ParameterizedTestCaseRegistry() {}
+  ParameterizedTestCaseRegistry() : test_case_infos_() {}
   ~ParameterizedTestCaseRegistry() {
     for (TestCaseInfoContainer::iterator it = test_case_infos_.begin();
          it != test_case_infos_.end(); ++it) {

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -1167,18 +1167,55 @@ class GTEST_API_ RE {
  public:
   // A copy constructor is required by the Standard to initialize object
   // references from r-values.
-  RE(const RE& other) { Init(other.pattern()); }
+  RE(const RE& other) :
+    pattern_(),
+    is_valid_(),
+#if GTEST_USES_POSIX_RE
+    full_regex_(),
+    partial_regex_()
+#else  // GTEST_USES_SIMPLE_RE
+    full_pattern_()
+#endif
+  { Init(other.pattern()); }
 
   // Constructs an RE from a string.
-  RE(const ::std::string& regex) { Init(regex.c_str()); }  // NOLINT
+  RE(const ::std::string& regex) :
+    pattern_(),
+    is_valid_(),
+#if GTEST_USES_POSIX_RE
+    full_regex_(),
+    partial_regex_()
+#else  // GTEST_USES_SIMPLE_RE
+    full_pattern_()
+#endif
+  { Init(regex.c_str()); }  // NOLINT
 
 #if GTEST_HAS_GLOBAL_STRING
 
-  RE(const ::string& regex) { Init(regex.c_str()); }  // NOLINT
+  RE(const ::string& regex) : 
+    pattern_(),
+    is_valid_(),
+#if GTEST_USES_POSIX_RE
+    full_regex_(),
+    partial_regex_()
+#else  // GTEST_USES_SIMPLE_RE
+    full_pattern_()
+#endif
+  { Init(regex.c_str()); }  // NOLINT
 
 #endif  // GTEST_HAS_GLOBAL_STRING
 
-  RE(const char* regex) { Init(regex); }  // NOLINT
+  RE(const char* regex) : 
+    pattern_(),
+    is_valid_(),
+#if GTEST_USES_POSIX_RE
+    full_regex_(),
+    partial_regex_()
+#else  // GTEST_USES_SIMPLE_RE
+    full_pattern_()
+#endif
+  { Init(regex); }  // NOLINT
+
   ~RE();
 
   // Returns the string representation of the regex.
@@ -1474,7 +1511,7 @@ inline void SleepMilliseconds(int n) {
 // use it in user tests, either directly or indirectly.
 class Notification {
  public:
-  Notification() : notified_(false) {
+  Notification() : mutex_(), notified_(false) {
     GTEST_CHECK_POSIX_SUCCESS_(pthread_mutex_init(&mutex_, NULL));
   }
   ~Notification() {
@@ -1930,6 +1967,13 @@ class ThreadLocal : public ThreadLocalBase {
 // MutexBase and Mutex implement mutex on pthreads-based platforms.
 class MutexBase {
  public:
+  MutexBase() : mutex_(), has_owner_(), owner_() { }
+  MutexBase(const pthread_mutex_t& mutex, const bool& has_owner, const pthread_t& owner) :
+    mutex_(mutex),
+    has_owner_(has_owner),
+    owner_(owner)
+  { }
+
   // Acquires this mutex.
   void Lock() {
     GTEST_CHECK_POSIX_SUCCESS_(pthread_mutex_lock(&mutex_));

--- a/googletest/src/gtest-death-test.cc
+++ b/googletest/src/gtest-death-test.cc
@@ -407,6 +407,8 @@ class DeathTestImpl : public DeathTest {
   void ReadAndInterpretStatusByte();
 
  private:
+  DeathTestImpl(const DeathTestImpl&);
+  DeathTestImpl& operator=(const DeathTestImpl&);
   // The textual content of the code this object is testing.  This class
   // doesn't own this string and should not attempt to delete it.
   const char* const statement_;
@@ -893,6 +895,8 @@ class ExecDeathTest : public ForkingDeathTest {
 #  endif  // defined(GTEST_EXTRA_DEATH_TEST_COMMAND_LINE_ARGS_)
     return args;
   }
+  ExecDeathTest& operator=(const ExecDeathTest&);
+  ExecDeathTest(const ExecDeathTest&);
   // The name of the file in which the death test is located.
   const char* const file_;
   // The line number on which the death test is located.
@@ -902,7 +906,7 @@ class ExecDeathTest : public ForkingDeathTest {
 // Utility class for accumulating command-line arguments.
 class Arguments {
  public:
-  Arguments() {
+  Arguments() : args_() {
     args_.push_back(NULL);
   }
 

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -162,25 +162,25 @@ inline int GetNextRandomSeed(int seed) {
 class GTestFlagSaver {
  public:
   // The c'tor.
-  GTestFlagSaver() {
-    also_run_disabled_tests_ = GTEST_FLAG(also_run_disabled_tests);
-    break_on_failure_ = GTEST_FLAG(break_on_failure);
-    catch_exceptions_ = GTEST_FLAG(catch_exceptions);
-    color_ = GTEST_FLAG(color);
-    death_test_style_ = GTEST_FLAG(death_test_style);
-    death_test_use_fork_ = GTEST_FLAG(death_test_use_fork);
-    filter_ = GTEST_FLAG(filter);
-    internal_run_death_test_ = GTEST_FLAG(internal_run_death_test);
-    list_tests_ = GTEST_FLAG(list_tests);
-    output_ = GTEST_FLAG(output);
-    print_time_ = GTEST_FLAG(print_time);
-    random_seed_ = GTEST_FLAG(random_seed);
-    repeat_ = GTEST_FLAG(repeat);
-    shuffle_ = GTEST_FLAG(shuffle);
-    stack_trace_depth_ = GTEST_FLAG(stack_trace_depth);
-    stream_result_to_ = GTEST_FLAG(stream_result_to);
-    throw_on_failure_ = GTEST_FLAG(throw_on_failure);
-  }
+  GTestFlagSaver() :
+    also_run_disabled_tests_(GTEST_FLAG(also_run_disabled_tests)),
+    break_on_failure_(GTEST_FLAG(break_on_failure)),
+    catch_exceptions_(GTEST_FLAG(catch_exceptions)),
+    color_(GTEST_FLAG(color)),
+    death_test_style_(GTEST_FLAG(death_test_style)),
+    death_test_use_fork_(GTEST_FLAG(death_test_use_fork)),
+    filter_(GTEST_FLAG(filter)),
+    internal_run_death_test_(GTEST_FLAG(internal_run_death_test)),
+    list_tests_(GTEST_FLAG(list_tests)),
+    output_(GTEST_FLAG(output)),
+    print_time_(GTEST_FLAG(print_time)),
+    random_seed_(GTEST_FLAG(random_seed)),
+    repeat_(GTEST_FLAG(repeat)),
+    shuffle_(GTEST_FLAG(shuffle)),
+    stack_trace_depth_(GTEST_FLAG(stack_trace_depth)),
+    stream_result_to_(GTEST_FLAG(stream_result_to)),
+    throw_on_failure_(GTEST_FLAG(throw_on_failure))
+  { }
 
   // The d'tor is not virtual.  DO NOT INHERIT FROM THIS CLASS.
   ~GTestFlagSaver() {
@@ -458,6 +458,10 @@ struct TraceInfo {
   const char* file;
   int line;
   std::string message;
+  TraceInfo() : file(), line(), message() { }
+  TraceInfo(const TraceInfo& other) : file(other.file), line(other.line), message(other.message) { }
+ private:
+  TraceInfo& operator=(const TraceInfo&);
 };
 
 // This is the default global test part result reporter used in UnitTestImpl.

--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -933,7 +933,7 @@ GTEST_DISABLE_MSC_WARNINGS_PUSH_(4996)
 class CapturedStream {
  public:
   // The ctor redirects the stream to a temporary file.
-  explicit CapturedStream(int fd) : fd_(fd), uncaptured_fd_(dup(fd)) {
+  explicit CapturedStream(int fd) : fd_(fd), uncaptured_fd_(dup(fd)), filename_() {
 # if GTEST_OS_WINDOWS
     char temp_dir_path[MAX_PATH + 1] = { '\0' };  // NOLINT
     char temp_file_path[MAX_PATH + 1] = { '\0' };  // NOLINT

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -370,7 +370,7 @@ AssertHelper::~AssertHelper() {
 }
 
 // Message assignment, for assertion streaming support.
-void AssertHelper::operator=(const Message& message) const {
+const AssertHelper& AssertHelper::operator=(const Message& message) const {
   UnitTest::GetInstance()->
     AddTestPartResult(data_->type, data_->file, data_->line,
                       AppendUserMessage(data_->message, message),
@@ -378,6 +378,7 @@ void AssertHelper::operator=(const Message& message) const {
                       ->CurrentOsStackTraceExceptTop(1)
                       // Skips the stack frame for this function itself.
                       );  // NOLINT
+  return *this;
 }
 
 // Mutex for linked pointers.
@@ -563,6 +564,7 @@ int UnitTestOptions::GTestShouldProcessSEH(DWORD exception_code) {
 ScopedFakeTestPartResultReporter::ScopedFakeTestPartResultReporter(
     TestPartResultArray* result)
     : intercept_mode_(INTERCEPT_ONLY_CURRENT_THREAD),
+      old_reporter_(),
       result_(result) {
   Init();
 }
@@ -573,6 +575,7 @@ ScopedFakeTestPartResultReporter::ScopedFakeTestPartResultReporter(
 ScopedFakeTestPartResultReporter::ScopedFakeTestPartResultReporter(
     InterceptMode intercept_mode, TestPartResultArray* result)
     : intercept_mode_(intercept_mode),
+      old_reporter_(),
       result_(result) {
   Init();
 }
@@ -1094,6 +1097,7 @@ class InternalStrings {
     return ids_[str] = id;
   }
 
+  InternalStrings() : ids_() { }
  private:
   typedef std::map<std::string, size_t> IdMap;
   IdMap ids_;
@@ -1130,7 +1134,10 @@ class Hunk {
         right_start_(right_start),
         adds_(),
         removes_(),
-        common_() {}
+        common_(),
+        hunk_(),
+        hunk_adds_(),
+        hunk_removes_() {}
 
   void PushLine(char edit, const char* line) {
     switch (edit) {
@@ -2015,7 +2022,10 @@ std::string AppendUserMessage(const std::string& gtest_msg,
 
 // Creates an empty TestResult.
 TestResult::TestResult()
-    : death_test_count_(0),
+    : test_properites_mutex_(),
+      test_part_results_(),
+      test_properties_(),
+      death_test_count_(0),
       elapsed_time_(0) {
 }
 
@@ -2722,10 +2732,13 @@ TestCase::TestCase(const char* a_name, const char* a_type_param,
                    Test::TearDownTestCaseFunc tear_down_tc)
     : name_(a_name),
       type_param_(a_type_param ? new std::string(a_type_param) : NULL),
+      test_info_list_(),
+      test_indices_(),
       set_up_tc_(set_up_tc),
       tear_down_tc_(tear_down_tc),
       should_run_(false),
-      elapsed_time_(0) {
+      elapsed_time_(0),
+      ad_hoc_test_result_() {
 }
 
 // Destructor of TestCase.
@@ -3235,7 +3248,7 @@ void PrettyUnitTestResultPrinter::OnTestIterationEnd(const UnitTest& unit_test,
 // This class forwards events to other event listeners.
 class TestEventRepeater : public TestEventListener {
  public:
-  TestEventRepeater() : forwarding_enabled_(true) {}
+  TestEventRepeater() : forwarding_enabled_(true), listeners_() {}
   virtual ~TestEventRepeater();
   void Append(TestEventListener *listener);
   TestEventListener* Release(TestEventListener* listener);
@@ -4296,7 +4309,7 @@ internal::ParameterizedTestCaseRegistry&
 #endif  // GTEST_HAS_PARAM_TEST
 
 // Creates an empty UnitTest.
-UnitTest::UnitTest() {
+UnitTest::UnitTest() : mutex_(), impl_() {
   impl_ = new internal::UnitTestImpl(this);
 }
 
@@ -4324,14 +4337,19 @@ namespace internal {
 
 UnitTestImpl::UnitTestImpl(UnitTest* parent)
     : parent_(parent),
+      original_working_dir_(),
       GTEST_DISABLE_MSC_WARNINGS_PUSH_(4355 /* using this in initializer */)
       default_global_test_part_result_reporter_(this),
       default_per_thread_test_part_result_reporter_(this),
       GTEST_DISABLE_MSC_WARNINGS_POP_()
       global_test_part_result_repoter_(
           &default_global_test_part_result_reporter_),
+      global_test_part_result_reporter_mutex_(),
       per_thread_test_part_result_reporter_(
           &default_per_thread_test_part_result_reporter_),
+      environments_(),
+      test_cases_(),
+      test_case_indices_(),
 #if GTEST_HAS_PARAM_TEST
       parameterized_test_registry_(),
       parameterized_tests_registered_(false),
@@ -4340,6 +4358,7 @@ UnitTestImpl::UnitTestImpl(UnitTest* parent)
       current_test_case_(NULL),
       current_test_info_(NULL),
       ad_hoc_test_result_(),
+      listeners_(),
       os_stack_trace_getter_(NULL),
       post_flag_parse_init_performed_(false),
       random_seed_(0),  // Will be overridden by the flag before first use.
@@ -4347,8 +4366,10 @@ UnitTestImpl::UnitTestImpl(UnitTest* parent)
       start_timestamp_(0),
       elapsed_time_(0),
 #if GTEST_HAS_DEATH_TEST
+      internal_run_death_test_flag_(),
       death_test_factory_(new DefaultDeathTestFactory),
 #endif
+      gtest_trace_stack_(),
       // Will be overridden by the flag before first use.
       catch_exceptions_(false) {
   listeners()->SetDefaultResultPrinter(new PrettyUnitTestResultPrinter);


### PR DESCRIPTION
Hi

I use -Weff-c++ warning in my project but the rules cannot be applied to Googletest
Actually, there are only few changes required to enable this warning in Googletest builds.

Thanks,
Pavel