### PR TITLE
rename "test case" to "test suite"

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -2820,7 +2820,7 @@ static std::string FormatTestCount(int test_count) {
 
 // Formats the count of test cases.
 static std::string FormatTestCaseCount(int test_case_count) {
-  return FormatCountableNoun(test_case_count, "test case", "test cases");
+  return FormatCountableNoun(test_case_count, "test suite", "test suites");
 }
 
 // Converts a TestPartResult::Type enum to human-friendly string

--- a/googletest/test/gtest_output_test_golden_lin.txt
+++ b/googletest/test/gtest_output_test_golden_lin.txt
@@ -7,7 +7,7 @@ Expected: true
 gtest_output_test_.cc:#: Failure
       Expected: 2
 To be equal to: 3
-[0;32m[==========] [mRunning 66 tests from 29 test cases.
+[0;32m[==========] [mRunning 66 tests from 29 test suites.
 [0;32m[----------] [mGlobal test environment set-up.
 FooEnvironment::SetUp() called.
 BarEnvironment::SetUp() called.
@@ -620,7 +620,7 @@ FooEnvironment::TearDown() called.
 gtest_output_test_.cc:#: Failure
 Failed
 Expected fatal failure.
-[0;32m[==========] [m66 tests from 29 test cases ran.
+[0;32m[==========] [m66 tests from 29 test suites ran.
 [0;32m[  PASSED  ] [m22 tests.
 [0;31m[  FAILED  ] [m44 tests, listed below:
 [0;31m[  FAILED  ] [mNonfatalFailureTest.EscapesStringOperands
@@ -672,7 +672,7 @@ Expected fatal failure.
 [0;33m  YOU HAVE 1 DISABLED TEST
 
 [mNote: Google Test filter = FatalFailureTest.*:LoggingTest.*
-[==========] Running 4 tests from 2 test cases.
+[==========] Running 4 tests from 2 test suites.
 [----------] Global test environment set-up.
 [----------] 3 tests from FatalFailureTest
 [ RUN      ] FatalFailureTest.FatalFailureInSubroutine
@@ -713,7 +713,7 @@ Expected: (3) >= (a[i]), actual: 3 vs 6
 [----------] 1 test from LoggingTest (? ms total)
 
 [----------] Global test environment tear-down
-[==========] 4 tests from 2 test cases ran. (? ms total)
+[==========] 4 tests from 2 test suites ran. (? ms total)
 [  PASSED  ] 0 tests.
 [  FAILED  ] 4 tests, listed below:
 [  FAILED  ] FatalFailureTest.FatalFailureInSubroutine
@@ -723,21 +723,21 @@ Expected: (3) >= (a[i]), actual: 3 vs 6
 
  4 FAILED TESTS
 Note: Google Test filter = *DISABLED_*
-[==========] Running 1 test from 1 test case.
+[==========] Running 1 test from 1 test suite.
 [----------] Global test environment set-up.
 [----------] 1 test from DisabledTestsWarningTest
 [ RUN      ] DisabledTestsWarningTest.DISABLED_AlsoRunDisabledTestsFlagSuppressesWarning
 [       OK ] DisabledTestsWarningTest.DISABLED_AlsoRunDisabledTestsFlagSuppressesWarning
 [----------] Global test environment tear-down
-[==========] 1 test from 1 test case ran.
+[==========] 1 test from 1 test suite ran.
 [  PASSED  ] 1 test.
 Note: Google Test filter = PassingTest.*
 Note: This is test shard 2 of 2.
-[==========] Running 1 test from 1 test case.
+[==========] Running 1 test from 1 test suite.
 [----------] Global test environment set-up.
 [----------] 1 test from PassingTest
 [ RUN      ] PassingTest.PassingTest2
 [       OK ] PassingTest.PassingTest2
 [----------] Global test environment tear-down
-[==========] 1 test from 1 test case ran.
+[==========] 1 test from 1 test suite ran.
 [  PASSED  ] 1 test.


### PR DESCRIPTION
Unfortunately, googletest is using the term "test case" for a collection of
several tests, which is usually named "test suite" - while the usual use of
"test case" is to describe the single test.

So when googletest says "Running x tests from y test cases", several other
test environments would say "Running x test cases from y test suites".

To avoid confusion, I just changed "test case" to "test suite" in the startup
message.