### PR TITLE
Use std::string and ::string explicitly in gtest and gmock code.

### DIFF
--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -186,7 +186,7 @@ class StringMatchResultListener : public MatchResultListener {
   StringMatchResultListener() : MatchResultListener(&ss_) {}
 
   // Returns the explanation accumulated so far.
-  internal::string str() const { return ss_.str(); }
+  std::string str() const { return ss_.str(); }
 
   // Clears the explanation accumulated so far.
   void Clear() { ss_.str(""); }
@@ -675,7 +675,7 @@ Matcher<T> A();
 namespace internal {
 
 // If the explanation is not empty, prints it to the ostream.
-inline void PrintIfNotEmpty(const internal::string& explanation,
+inline void PrintIfNotEmpty(const std::string& explanation,
                             ::std::ostream* os) {
   if (explanation != "" && os != NULL) {
     *os << ", " << explanation;
@@ -685,11 +685,11 @@ inline void PrintIfNotEmpty(const internal::string& explanation,
 // Returns true if the given type name is easy to read by a human.
 // This is used to decide whether printing the type of a value might
 // be helpful.
-inline bool IsReadableTypeName(const string& type_name) {
+inline bool IsReadableTypeName(const std::string& type_name) {
   // We consider a type name readable if it's short or doesn't contain
   // a template or function type.
   return (type_name.length() <= 20 ||
-          type_name.find_first_of("<(") == string::npos);
+          type_name.find_first_of("<(") == std::string::npos);
 }
 
 // Matches the value against the given matcher, prints the value and explains
@@ -711,7 +711,7 @@ bool MatchPrintAndExplain(Value& value, const Matcher<T>& matcher,
 
   UniversalPrint(value, listener->stream());
 #if GTEST_HAS_RTTI
-  const string& type_name = GetTypeName<Value>();
+  const std::string& type_name = GetTypeName<Value>();
   if (IsReadableTypeName(type_name))
     *listener->stream() << " (of type " << type_name << ")";
 #endif
@@ -1335,17 +1335,17 @@ class MatchesRegexMatcher {
   //   wchar_t*
   template <typename CharType>
   bool MatchAndExplain(CharType* s, MatchResultListener* listener) const {
-    return s != NULL && MatchAndExplain(internal::string(s), listener);
+    return s != NULL && MatchAndExplain(std::string(s), listener);
   }
 
-  // Matches anything that can convert to internal::string.
+  // Matches anything that can convert to std::string.
   //
-  // This is a template, not just a plain function with const internal::string&,
+  // This is a template, not just a plain function with const std::string&,
   // because StringPiece has some interfering non-explicit constructors.
   template <class MatcheeStringType>
   bool MatchAndExplain(const MatcheeStringType& s,
                        MatchResultListener* /* listener */) const {
-    const internal::string& s2(s);
+    const std::string& s2(s);
     return full_match_ ? RE::FullMatch(s2, *regex_) :
         RE::PartialMatch(s2, *regex_);
   }
@@ -1353,13 +1353,13 @@ class MatchesRegexMatcher {
   void DescribeTo(::std::ostream* os) const {
     *os << (full_match_ ? "matches" : "contains")
         << " regular expression ";
-    UniversalPrinter<internal::string>::Print(regex_->pattern(), os);
+    UniversalPrinter<std::string>::Print(regex_->pattern(), os);
   }
 
   void DescribeNegationTo(::std::ostream* os) const {
     *os << "doesn't " << (full_match_ ? "match" : "contain")
         << " regular expression ";
-    UniversalPrinter<internal::string>::Print(regex_->pattern(), os);
+    UniversalPrinter<std::string>::Print(regex_->pattern(), os);
   }
 
  private:
@@ -1526,8 +1526,8 @@ class BothOfMatcherImpl : public MatcherInterface<T> {
     }
 
     // Otherwise we need to explain why *both* of them match.
-    const internal::string s1 = listener1.str();
-    const internal::string s2 = listener2.str();
+    const std::string s1 = listener1.str();
+    const std::string s2 = listener2.str();
 
     if (s1 == "") {
       *listener << s2;
@@ -1698,8 +1698,8 @@ class EitherOfMatcherImpl : public MatcherInterface<T> {
     }
 
     // Otherwise we need to explain why *both* of them fail.
-    const internal::string s1 = listener1.str();
-    const internal::string s2 = listener2.str();
+    const std::string s1 = listener1.str();
+    const std::string s2 = listener2.str();
 
     if (s1 == "") {
       *listener << s2;
@@ -2123,7 +2123,7 @@ class WhenDynamicCastToMatcherBase {
  protected:
   const Matcher<To> matcher_;
 
-  static string GetToName() {
+  static std::string GetToName() {
 #if GTEST_HAS_RTTI
     return GetTypeName<To>();
 #else  // GTEST_HAS_RTTI
@@ -2953,7 +2953,7 @@ class KeyMatcherImpl : public MatcherInterface<PairType> {
     StringMatchResultListener inner_listener;
     const bool match = inner_matcher_.MatchAndExplain(key_value.first,
                                                       &inner_listener);
-    const internal::string explanation = inner_listener.str();
+    const std::string explanation = inner_listener.str();
     if (explanation != "") {
       *listener << "whose first field is a value " << explanation;
     }
@@ -3058,8 +3058,8 @@ class PairMatcherImpl : public MatcherInterface<PairType> {
   }
 
  private:
-  void ExplainSuccess(const internal::string& first_explanation,
-                      const internal::string& second_explanation,
+  void ExplainSuccess(const std::string& first_explanation,
+                      const std::string& second_explanation,
                       MatchResultListener* listener) const {
     *listener << "whose both fields match";
     if (first_explanation != "") {
@@ -3166,7 +3166,7 @@ class ElementsAreMatcherImpl : public MatcherInterface<Container> {
     const bool listener_interested = listener->IsInterested();
 
     // explanations[i] is the explanation of the element at index i.
-    ::std::vector<internal::string> explanations(count());
+    ::std::vector<std::string> explanations(count());
     StlContainerReference stl_container = View::ConstReference(container);
     typename StlContainer::const_iterator it = stl_container.begin();
     size_t exam_pos = 0;
@@ -3225,7 +3225,7 @@ class ElementsAreMatcherImpl : public MatcherInterface<Container> {
     if (listener_interested) {
       bool reason_printed = false;
       for (size_t i = 0; i != count(); ++i) {
-        const internal::string& s = explanations[i];
+        const std::string& s = explanations[i];
         if (!s.empty()) {
           if (reason_printed) {
             *listener << ",\nand ";
@@ -3278,7 +3278,7 @@ class GTEST_API_ MatchMatrix {
 
   void Randomize();
 
-  string DebugString() const;
+  std::string DebugString() const;
 
  private:
   size_t SpaceIndex(size_t ilhs, size_t irhs) const {
@@ -3322,9 +3322,8 @@ class GTEST_API_ UnorderedElementsAreMatcherImplBase {
   void DescribeNegationToImpl(::std::ostream* os) const;
 
   bool VerifyAllElementsAndMatchersAreMatched(
-      const ::std::vector<string>& element_printouts,
-      const MatchMatrix& matrix,
-      MatchResultListener* listener) const;
+      const ::std::vector<std::string>& element_printouts,
+      const MatchMatrix& matrix, MatchResultListener* listener) const;
 
   MatcherDescriberVec& matcher_describers() {
     return matcher_describers_;
@@ -3376,7 +3375,7 @@ class UnorderedElementsAreMatcherImpl
   virtual bool MatchAndExplain(Container container,
                                MatchResultListener* listener) const {
     StlContainerReference stl_container = View::ConstReference(container);
-    ::std::vector<string> element_printouts;
+    ::std::vector<std::string> element_printouts;
     MatchMatrix matrix = AnalyzeElements(stl_container.begin(),
                                          stl_container.end(),
                                          &element_printouts,
@@ -3407,7 +3406,7 @@ class UnorderedElementsAreMatcherImpl
 
   template <typename ElementIter>
   MatchMatrix AnalyzeElements(ElementIter elem_first, ElementIter elem_last,
-                              ::std::vector<string>* element_printouts,
+                              ::std::vector<std::string>* element_printouts,
                               MatchResultListener* listener) const {
     element_printouts->clear();
     ::std::vector<char> did_match;
@@ -3619,9 +3618,9 @@ BoundSecondMatcher<Tuple2Matcher, Second> MatcherBindSecond(
 // 'negation' is false; otherwise returns the description of the
 // negation of the matcher.  'param_values' contains a list of strings
 // that are the print-out of the matcher's parameters.
-GTEST_API_ string FormatMatcherDescription(bool negation,
-                                           const char* matcher_name,
-                                           const Strings& param_values);
+GTEST_API_ std::string FormatMatcherDescription(bool negation,
+                                                const char* matcher_name,
+                                                const Strings& param_values);
 
 }  // namespace internal
 
@@ -3951,53 +3950,52 @@ internal::ResultOfMatcher<Callable> ResultOf(
 // String matchers.
 
 // Matches a string equal to str.
-inline PolymorphicMatcher<internal::StrEqualityMatcher<internal::string> >
-    StrEq(const internal::string& str) {
-  return MakePolymorphicMatcher(internal::StrEqualityMatcher<internal::string>(
-      str, true, true));
+inline PolymorphicMatcher<internal::StrEqualityMatcher<std::string> > StrEq(
+    const std::string& str) {
+  return MakePolymorphicMatcher(
+      internal::StrEqualityMatcher<std::string>(str, true, true));
 }
 
 // Matches a string not equal to str.
-inline PolymorphicMatcher<internal::StrEqualityMatcher<internal::string> >
-    StrNe(const internal::string& str) {
-  return MakePolymorphicMatcher(internal::StrEqualityMatcher<internal::string>(
-      str, false, true));
+inline PolymorphicMatcher<internal::StrEqualityMatcher<std::string> > StrNe(
+    const std::string& str) {
+  return MakePolymorphicMatcher(
+      internal::StrEqualityMatcher<std::string>(str, false, true));
 }
 
 // Matches a string equal to str, ignoring case.
-inline PolymorphicMatcher<internal::StrEqualityMatcher<internal::string> >
-    StrCaseEq(const internal::string& str) {
-  return MakePolymorphicMatcher(internal::StrEqualityMatcher<internal::string>(
-      str, true, false));
+inline PolymorphicMatcher<internal::StrEqualityMatcher<std::string> > StrCaseEq(
+    const std::string& str) {
+  return MakePolymorphicMatcher(
+      internal::StrEqualityMatcher<std::string>(str, true, false));
 }
 
 // Matches a string not equal to str, ignoring case.
-inline PolymorphicMatcher<internal::StrEqualityMatcher<internal::string> >
-    StrCaseNe(const internal::string& str) {
-  return MakePolymorphicMatcher(internal::StrEqualityMatcher<internal::string>(
-      str, false, false));
+inline PolymorphicMatcher<internal::StrEqualityMatcher<std::string> > StrCaseNe(
+    const std::string& str) {
+  return MakePolymorphicMatcher(
+      internal::StrEqualityMatcher<std::string>(str, false, false));
 }
 
 // Creates a matcher that matches any string, std::string, or C string
 // that contains the given substring.
-inline PolymorphicMatcher<internal::HasSubstrMatcher<internal::string> >
-    HasSubstr(const internal::string& substring) {
-  return MakePolymorphicMatcher(internal::HasSubstrMatcher<internal::string>(
-      substring));
+inline PolymorphicMatcher<internal::HasSubstrMatcher<std::string> > HasSubstr(
+    const std::string& substring) {
+  return MakePolymorphicMatcher(
+      internal::HasSubstrMatcher<std::string>(substring));
 }
 
 // Matches a string that starts with 'prefix' (case-sensitive).
-inline PolymorphicMatcher<internal::StartsWithMatcher<internal::string> >
-    StartsWith(const internal::string& prefix) {
-  return MakePolymorphicMatcher(internal::StartsWithMatcher<internal::string>(
-      prefix));
+inline PolymorphicMatcher<internal::StartsWithMatcher<std::string> > StartsWith(
+    const std::string& prefix) {
+  return MakePolymorphicMatcher(
+      internal::StartsWithMatcher<std::string>(prefix));
 }
 
 // Matches a string that ends with 'suffix' (case-sensitive).
-inline PolymorphicMatcher<internal::EndsWithMatcher<internal::string> >
-    EndsWith(const internal::string& suffix) {
-  return MakePolymorphicMatcher(internal::EndsWithMatcher<internal::string>(
-      suffix));
+inline PolymorphicMatcher<internal::EndsWithMatcher<std::string> > EndsWith(
+    const std::string& suffix) {
+  return MakePolymorphicMatcher(internal::EndsWithMatcher<std::string>(suffix));
 }
 
 // Matches a string that fully matches regular expression 'regex'.
@@ -4007,7 +4005,7 @@ inline PolymorphicMatcher<internal::MatchesRegexMatcher> MatchesRegex(
   return MakePolymorphicMatcher(internal::MatchesRegexMatcher(regex, true));
 }
 inline PolymorphicMatcher<internal::MatchesRegexMatcher> MatchesRegex(
-    const internal::string& regex) {
+    const std::string& regex) {
   return MatchesRegex(new internal::RE(regex));
 }
 
@@ -4018,7 +4016,7 @@ inline PolymorphicMatcher<internal::MatchesRegexMatcher> ContainsRegex(
   return MakePolymorphicMatcher(internal::MatchesRegexMatcher(regex, false));
 }
 inline PolymorphicMatcher<internal::MatchesRegexMatcher> ContainsRegex(
-    const internal::string& regex) {
+    const std::string& regex) {
   return ContainsRegex(new internal::RE(regex));
 }
 

--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -148,8 +148,7 @@ class GTEST_API_ UntypedFunctionMockerBase {
   // action fails.
   // L = *
   virtual UntypedActionResultHolderBase* UntypedPerformDefaultAction(
-      const void* untyped_args,
-      const string& call_description) const = 0;
+      const void* untyped_args, const std::string& call_description) const = 0;
 
   // Performs the given action with the given arguments and returns
   // the action's result.
@@ -263,12 +262,14 @@ class UntypedOnCallSpecBase {
   };
 
   // Asserts that the ON_CALL() statement has a certain property.
-  void AssertSpecProperty(bool property, const string& failure_message) const {
+  void AssertSpecProperty(bool property,
+                          const std::string& failure_message) const {
     Assert(property, file_, line_, failure_message);
   }
 
   // Expects that the ON_CALL() statement has a certain property.
-  void ExpectSpecProperty(bool property, const string& failure_message) const {
+  void ExpectSpecProperty(bool property,
+                          const std::string& failure_message) const {
     Expect(property, file_, line_, failure_message);
   }
 
@@ -690,7 +691,7 @@ GTEST_API_ extern ThreadLocal<Sequence*> g_gmock_implicit_sequence;
 class GTEST_API_ ExpectationBase {
  public:
   // source_text is the EXPECT_CALL(...) source that created this Expectation.
-  ExpectationBase(const char* file, int line, const string& source_text);
+  ExpectationBase(const char* file, int line, const std::string& source_text);
 
   virtual ~ExpectationBase();
 
@@ -738,12 +739,14 @@ class GTEST_API_ ExpectationBase {
   virtual Expectation GetHandle() = 0;
 
   // Asserts that the EXPECT_CALL() statement has the given property.
-  void AssertSpecProperty(bool property, const string& failure_message) const {
+  void AssertSpecProperty(bool property,
+                          const std::string& failure_message) const {
     Assert(property, file_, line_, failure_message);
   }
 
   // Expects that the EXPECT_CALL() statement has the given property.
-  void ExpectSpecProperty(bool property, const string& failure_message) const {
+  void ExpectSpecProperty(bool property,
+                          const std::string& failure_message) const {
     Expect(property, file_, line_, failure_message);
   }
 
@@ -845,7 +848,7 @@ class GTEST_API_ ExpectationBase {
   // an EXPECT_CALL() statement finishes.
   const char* file_;          // The file that contains the expectation.
   int line_;                  // The line number of the expectation.
-  const string source_text_;  // The EXPECT_CALL(...) source text.
+  const std::string source_text_;  // The EXPECT_CALL(...) source text.
   // True iff the cardinality is specified explicitly.
   bool cardinality_specified_;
   Cardinality cardinality_;            // The cardinality of the expectation.
@@ -880,8 +883,8 @@ class TypedExpectation : public ExpectationBase {
   typedef typename Function<F>::ArgumentMatcherTuple ArgumentMatcherTuple;
   typedef typename Function<F>::Result Result;
 
-  TypedExpectation(FunctionMockerBase<F>* owner,
-                   const char* a_file, int a_line, const string& a_source_text,
+  TypedExpectation(FunctionMockerBase<F>* owner, const char* a_file, int a_line,
+                   const std::string& a_source_text,
                    const ArgumentMatcherTuple& m)
       : ExpectationBase(a_file, a_line, a_source_text),
         owner_(owner),
@@ -1240,7 +1243,7 @@ class TypedExpectation : public ExpectationBase {
 // Logs a message including file and line number information.
 GTEST_API_ void LogWithLocation(testing::internal::LogSeverity severity,
                                 const char* file, int line,
-                                const string& message);
+                                const std::string& message);
 
 template <typename F>
 class MockSpec {
@@ -1259,7 +1262,7 @@ class MockSpec {
   internal::OnCallSpec<F>& InternalDefaultActionSetAt(
       const char* file, int line, const char* obj, const char* call) {
     LogWithLocation(internal::kInfo, file, line,
-        string("ON_CALL(") + obj + ", " + call + ") invoked");
+                    std::string("ON_CALL(") + obj + ", " + call + ") invoked");
     return function_mocker_->AddNewOnCallSpec(file, line, matchers_);
   }
 
@@ -1267,7 +1270,8 @@ class MockSpec {
   // the newly created spec.
   internal::TypedExpectation<F>& InternalExpectedAt(
       const char* file, int line, const char* obj, const char* call) {
-    const string source_text(string("EXPECT_CALL(") + obj + ", " + call + ")");
+    const std::string source_text(std::string("EXPECT_CALL(") + obj + ", " +
+                                  call + ")");
     LogWithLocation(internal::kInfo, file, line, source_text + " invoked");
     return function_mocker_->AddNewExpectation(
         file, line, source_text, matchers_);
@@ -1389,7 +1393,7 @@ class ActionResultHolder : public UntypedActionResultHolderBase {
   static ActionResultHolder* PerformDefaultAction(
       const FunctionMockerBase<F>* func_mocker,
       const typename Function<F>::ArgumentTuple& args,
-      const string& call_description) {
+      const std::string& call_description) {
     return new ActionResultHolder(Wrapper(
         func_mocker->PerformDefaultAction(args, call_description)));
   }
@@ -1429,7 +1433,7 @@ class ActionResultHolder<void> : public UntypedActionResultHolderBase {
   static ActionResultHolder* PerformDefaultAction(
       const FunctionMockerBase<F>* func_mocker,
       const typename Function<F>::ArgumentTuple& args,
-      const string& call_description) {
+      const std::string& call_description) {
     func_mocker->PerformDefaultAction(args, call_description);
     return new ActionResultHolder;
   }
@@ -1496,13 +1500,14 @@ class FunctionMockerBase : public UntypedFunctionMockerBase {
   // without locking.
   // L = *
   Result PerformDefaultAction(const ArgumentTuple& args,
-                              const string& call_description) const {
+                              const std::string& call_description) const {
     const OnCallSpec<F>* const spec =
         this->FindOnCallSpec(args);
     if (spec != NULL) {
       return spec->GetAction().Perform(args);
     }
-    const string message = call_description +
+    const std::string message =
+        call_description +
         "\n    The mock function has no default action "
         "set, and its return type has no default value set.";
 #if GTEST_HAS_EXCEPTIONS
@@ -1522,7 +1527,7 @@ class FunctionMockerBase : public UntypedFunctionMockerBase {
   // L = *
   virtual UntypedActionResultHolderBase* UntypedPerformDefaultAction(
       const void* untyped_args,  // must point to an ArgumentTuple
-      const string& call_description) const {
+      const std::string& call_description) const {
     const ArgumentTuple& args =
         *static_cast<const ArgumentTuple*>(untyped_args);
     return ResultHolder::PerformDefaultAction(this, args, call_description);
@@ -1598,12 +1603,10 @@ class FunctionMockerBase : public UntypedFunctionMockerBase {
   }
 
   // Adds and returns an expectation spec for this mock function.
-  TypedExpectation<F>& AddNewExpectation(
-      const char* file,
-      int line,
-      const string& source_text,
-      const ArgumentMatcherTuple& m)
-          GTEST_LOCK_EXCLUDED_(g_gmock_mutex) {
+  TypedExpectation<F>& AddNewExpectation(const char* file, int line,
+                                         const std::string& source_text,
+                                         const ArgumentMatcherTuple& m)
+      GTEST_LOCK_EXCLUDED_(g_gmock_mutex) {
     Mock::RegisterUseByOnCallOrExpectCall(MockObject(), file, line);
     TypedExpectation<F>* const expectation =
         new TypedExpectation<F>(this, file, line, source_text, m);
@@ -1796,7 +1799,7 @@ class FunctionMockerBase : public UntypedFunctionMockerBase {
 
 // Reports an uninteresting call (whose description is in msg) in the
 // manner specified by 'reaction'.
-void ReportUninterestingCall(CallReaction reaction, const string& msg);
+void ReportUninterestingCall(CallReaction reaction, const std::string& msg);
 
 }  // namespace internal
 

--- a/googlemock/include/gmock/internal/gmock-internal-utils.h
+++ b/googlemock/include/gmock/internal/gmock-internal-utils.h
@@ -267,7 +267,7 @@ class FailureReporterInterface {
 
   // Reports a failure that occurred at the given source file location.
   virtual void ReportFailure(FailureType type, const char* file, int line,
-                             const string& message) = 0;
+                             const std::string& message) = 0;
 };
 
 // Returns the failure reporter used by Google Mock.
@@ -279,7 +279,7 @@ GTEST_API_ FailureReporterInterface* GetFailureReporter();
 // inline this function to prevent it from showing up in the stack
 // trace.
 inline void Assert(bool condition, const char* file, int line,
-                   const string& msg) {
+                   const std::string& msg) {
   if (!condition) {
     GetFailureReporter()->ReportFailure(FailureReporterInterface::kFatal,
                                         file, line, msg);
@@ -292,7 +292,7 @@ inline void Assert(bool condition, const char* file, int line) {
 // Verifies that condition is true; generates a non-fatal failure if
 // condition is false.
 inline void Expect(bool condition, const char* file, int line,
-                   const string& msg) {
+                   const std::string& msg) {
   if (!condition) {
     GetFailureReporter()->ReportFailure(FailureReporterInterface::kNonfatal,
                                         file, line, msg);
@@ -328,8 +328,7 @@ GTEST_API_ bool LogIsVisible(LogSeverity severity);
 // stack_frames_to_skip is treated as 0, since we don't know which
 // function calls will be inlined by the compiler and need to be
 // conservative.
-GTEST_API_ void Log(LogSeverity severity,
-                    const string& message,
+GTEST_API_ void Log(LogSeverity severity, const std::string& message,
                     int stack_frames_to_skip);
 
 // TODO(wan@google.com): group all type utilities together.

--- a/googlemock/src/gmock-cardinalities.cc
+++ b/googlemock/src/gmock-cardinalities.cc
@@ -92,7 +92,7 @@ class BetweenCardinalityImpl : public CardinalityInterface {
 };
 
 // Formats "n times" in a human-friendly way.
-inline internal::string FormatTimes(int n) {
+inline std::string FormatTimes(int n) {
   if (n == 1) {
     return "once";
   } else if (n == 2) {

--- a/googlemock/src/gmock-internal-utils.cc
+++ b/googlemock/src/gmock-internal-utils.cc
@@ -76,7 +76,7 @@ GTEST_API_ string ConvertIdentifierNameToWords(const char* id_name) {
 class GoogleTestFailureReporter : public FailureReporterInterface {
  public:
   virtual void ReportFailure(FailureType type, const char* file, int line,
-                             const string& message) {
+                             const std::string& message) {
     AssertHelper(type == kFatal ?
                  TestPartResult::kFatalFailure :
                  TestPartResult::kNonFatalFailure,
@@ -128,8 +128,7 @@ GTEST_API_ bool LogIsVisible(LogSeverity severity) {
 // stack_frames_to_skip is treated as 0, since we don't know which
 // function calls will be inlined by the compiler and need to be
 // conservative.
-GTEST_API_ void Log(LogSeverity severity,
-                    const string& message,
+GTEST_API_ void Log(LogSeverity severity, const std::string& message,
                     int stack_frames_to_skip) {
   if (!LogIsVisible(severity))
     return;

--- a/googlemock/src/gmock-matchers.cc
+++ b/googlemock/src/gmock-matchers.cc
@@ -379,7 +379,7 @@ void MatchMatrix::Randomize() {
   }
 }
 
-string MatchMatrix::DebugString() const {
+std::string MatchMatrix::DebugString() const {
   ::std::stringstream ss;
   const char *sep = "";
   for (size_t i = 0; i < LhsSize(); ++i) {
@@ -441,10 +441,9 @@ void UnorderedElementsAreMatcherImplBase::DescribeNegationToImpl(
 // Returns false, writing an explanation to 'listener', if and only
 // if the success criteria are not met.
 bool UnorderedElementsAreMatcherImplBase::
-VerifyAllElementsAndMatchersAreMatched(
-    const ::std::vector<string>& element_printouts,
-    const MatchMatrix& matrix,
-    MatchResultListener* listener) const {
+    VerifyAllElementsAndMatchersAreMatched(
+        const ::std::vector<std::string>& element_printouts,
+        const MatchMatrix& matrix, MatchResultListener* listener) const {
   bool result = true;
   ::std::vector<char> element_matched(matrix.LhsSize(), 0);
   ::std::vector<char> matcher_matched(matrix.RhsSize(), 0);

--- a/googlemock/src/gmock-spec-builders.cc
+++ b/googlemock/src/gmock-spec-builders.cc
@@ -58,16 +58,15 @@ GTEST_API_ GTEST_DEFINE_STATIC_MUTEX_(g_gmock_mutex);
 // Logs a message including file and line number information.
 GTEST_API_ void LogWithLocation(testing::internal::LogSeverity severity,
                                 const char* file, int line,
-                                const string& message) {
+                                const std::string& message) {
   ::std::ostringstream s;
   s << file << ":" << line << ": " << message << ::std::endl;
   Log(severity, s.str(), 0);
 }
 
 // Constructs an ExpectationBase object.
-ExpectationBase::ExpectationBase(const char* a_file,
-                                 int a_line,
-                                 const string& a_source_text)
+ExpectationBase::ExpectationBase(const char* a_file, int a_line,
+                                 const std::string& a_source_text)
     : file_(a_file),
       line_(a_line),
       source_text_(a_source_text),
@@ -244,7 +243,7 @@ GTEST_API_ ThreadLocal<Sequence*> g_gmock_implicit_sequence;
 
 // Reports an uninteresting call (whose description is in msg) in the
 // manner specified by 'reaction'.
-void ReportUninterestingCall(CallReaction reaction, const string& msg) {
+void ReportUninterestingCall(CallReaction reaction, const std::string& msg) {
   // Include a stack trace only if --gmock_verbose=info is specified.
   const int stack_frames_to_skip =
       GMOCK_FLAG(verbose) == kInfoVerbosity ? 3 : -1;

--- a/googlemock/test/gmock-generated-actions_test.cc
+++ b/googlemock/test/gmock-generated-actions_test.cc
@@ -81,12 +81,12 @@ bool Unary(int x) { return x < 0; }
 
 const char* Plus1(const char* s) { return s + 1; }
 
-bool ByConstRef(const string& s) { return s == "Hi"; }
+bool ByConstRef(const std::string& s) { return s == "Hi"; }
 
 const double g_double = 0;
 bool ReferencesGlobalDouble(const double& x) { return &x == &g_double; }
 
-string ByNonConstRef(string& s) { return s += "+"; }  // NOLINT
+std::string ByNonConstRef(std::string& s) { return s += "+"; }  // NOLINT
 
 struct UnaryFunctor {
   int operator()(bool x) { return x ? 1 : -1; }
@@ -102,9 +102,9 @@ void VoidTernary(int, char, bool) { g_done = true; }
 
 int SumOf4(int a, int b, int c, int d) { return a + b + c + d; }
 
-string Concat4(const char* s1, const char* s2, const char* s3,
-               const char* s4) {
-  return string(s1) + s2 + s3 + s4;
+std::string Concat4(const char* s1, const char* s2, const char* s3,
+                    const char* s4) {
+  return std::string(s1) + s2 + s3 + s4;
 }
 
 int SumOf5(int a, int b, int c, int d, int e) { return a + b + c + d + e; }
@@ -115,9 +115,9 @@ struct SumOf5Functor {
   }
 };
 
-string Concat5(const char* s1, const char* s2, const char* s3,
-               const char* s4, const char* s5) {
-  return string(s1) + s2 + s3 + s4 + s5;
+std::string Concat5(const char* s1, const char* s2, const char* s3,
+                    const char* s4, const char* s5) {
+  return std::string(s1) + s2 + s3 + s4 + s5;
 }
 
 int SumOf6(int a, int b, int c, int d, int e, int f) {
@@ -130,34 +130,34 @@ struct SumOf6Functor {
   }
 };
 
-string Concat6(const char* s1, const char* s2, const char* s3,
-               const char* s4, const char* s5, const char* s6) {
-  return string(s1) + s2 + s3 + s4 + s5 + s6;
+std::string Concat6(const char* s1, const char* s2, const char* s3,
+                    const char* s4, const char* s5, const char* s6) {
+  return std::string(s1) + s2 + s3 + s4 + s5 + s6;
 }
 
-string Concat7(const char* s1, const char* s2, const char* s3,
-               const char* s4, const char* s5, const char* s6,
-               const char* s7) {
-  return string(s1) + s2 + s3 + s4 + s5 + s6 + s7;
+std::string Concat7(const char* s1, const char* s2, const char* s3,
+                    const char* s4, const char* s5, const char* s6,
+                    const char* s7) {
+  return std::string(s1) + s2 + s3 + s4 + s5 + s6 + s7;
 }
 
-string Concat8(const char* s1, const char* s2, const char* s3,
-               const char* s4, const char* s5, const char* s6,
-               const char* s7, const char* s8) {
-  return string(s1) + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+std::string Concat8(const char* s1, const char* s2, const char* s3,
+                    const char* s4, const char* s5, const char* s6,
+                    const char* s7, const char* s8) {
+  return std::string(s1) + s2 + s3 + s4 + s5 + s6 + s7 + s8;
 }
 
-string Concat9(const char* s1, const char* s2, const char* s3,
-               const char* s4, const char* s5, const char* s6,
-               const char* s7, const char* s8, const char* s9) {
-  return string(s1) + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9;
+std::string Concat9(const char* s1, const char* s2, const char* s3,
+                    const char* s4, const char* s5, const char* s6,
+                    const char* s7, const char* s8, const char* s9) {
+  return std::string(s1) + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9;
 }
 
-string Concat10(const char* s1, const char* s2, const char* s3,
-                const char* s4, const char* s5, const char* s6,
-                const char* s7, const char* s8, const char* s9,
-                const char* s10) {
-  return string(s1) + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10;
+std::string Concat10(const char* s1, const char* s2, const char* s3,
+                     const char* s4, const char* s5, const char* s6,
+                     const char* s7, const char* s8, const char* s9,
+                     const char* s10) {
+  return std::string(s1) + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10;
 }
 
 // A helper that turns the type of a C-string literal from const
@@ -208,38 +208,37 @@ TEST(InvokeArgumentTest, Functor6) {
 
 // Tests using InvokeArgument with a 7-ary function.
 TEST(InvokeArgumentTest, Function7) {
-  Action<string(string(*)(const char*, const char*, const char*,
-                          const char*, const char*, const char*,
-                          const char*))> a =
-      InvokeArgument<0>("1", "2", "3", "4", "5", "6", "7");
+  Action<std::string(std::string(*)(const char*, const char*, const char*,
+                                    const char*, const char*, const char*,
+                                    const char*))>
+      a = InvokeArgument<0>("1", "2", "3", "4", "5", "6", "7");
   EXPECT_EQ("1234567", a.Perform(make_tuple(&Concat7)));
 }
 
 // Tests using InvokeArgument with a 8-ary function.
 TEST(InvokeArgumentTest, Function8) {
-  Action<string(string(*)(const char*, const char*, const char*,
-                          const char*, const char*, const char*,
-                          const char*, const char*))> a =
-      InvokeArgument<0>("1", "2", "3", "4", "5", "6", "7", "8");
+  Action<std::string(std::string(*)(const char*, const char*, const char*,
+                                    const char*, const char*, const char*,
+                                    const char*, const char*))>
+      a = InvokeArgument<0>("1", "2", "3", "4", "5", "6", "7", "8");
   EXPECT_EQ("12345678", a.Perform(make_tuple(&Concat8)));
 }
 
 // Tests using InvokeArgument with a 9-ary function.
 TEST(InvokeArgumentTest, Function9) {
-  Action<string(string(*)(const char*, const char*, const char*,
-                          const char*, const char*, const char*,
-                          const char*, const char*, const char*))> a =
-      InvokeArgument<0>("1", "2", "3", "4", "5", "6", "7", "8", "9");
+  Action<std::string(std::string(*)(const char*, const char*, const char*,
+                                    const char*, const char*, const char*,
+                                    const char*, const char*, const char*))>
+      a = InvokeArgument<0>("1", "2", "3", "4", "5", "6", "7", "8", "9");
   EXPECT_EQ("123456789", a.Perform(make_tuple(&Concat9)));
 }
 
 // Tests using InvokeArgument with a 10-ary function.
 TEST(InvokeArgumentTest, Function10) {
-  Action<string(string(*)(const char*, const char*, const char*,
-                          const char*, const char*, const char*,
-                          const char*, const char*, const char*,
-                          const char*))> a =
-      InvokeArgument<0>("1", "2", "3", "4", "5", "6", "7", "8", "9", "0");
+  Action<std::string(std::string(*)(
+      const char*, const char*, const char*, const char*, const char*,
+      const char*, const char*, const char*, const char*, const char*))>
+      a = InvokeArgument<0>("1", "2", "3", "4", "5", "6", "7", "8", "9", "0");
   EXPECT_EQ("1234567890", a.Perform(make_tuple(&Concat10)));
 }
 
@@ -260,8 +259,8 @@ TEST(InvokeArgumentTest, FunctionWithCStringLiteral) {
 
 // Tests using InvokeArgument with a function that takes a const reference.
 TEST(InvokeArgumentTest, ByConstReferenceFunction) {
-  Action<bool(bool(*function)(const string& s))> a =  // NOLINT
-      InvokeArgument<0>(string("Hi"));
+  Action<bool(bool (*function)(const std::string& s))> a =  // NOLINT
+      InvokeArgument<0>(std::string("Hi"));
   // When action 'a' is constructed, it makes a copy of the temporary
   // string object passed to it, so it's OK to use 'a' later, when the
   // temporary object has already died.
@@ -305,17 +304,18 @@ TEST(WithArgsTest, ThreeArgs) {
 
 // Tests using WithArgs with an action that takes 4 arguments.
 TEST(WithArgsTest, FourArgs) {
-  Action<string(const char*, const char*, double, const char*, const char*)> a =
-      WithArgs<4, 3, 1, 0>(Invoke(Concat4));
+  Action<std::string(const char*, const char*, double, const char*,
+                     const char*)>
+      a = WithArgs<4, 3, 1, 0>(Invoke(Concat4));
   EXPECT_EQ("4310", a.Perform(make_tuple(CharPtr("0"), CharPtr("1"), 2.5,
                                          CharPtr("3"), CharPtr("4"))));
 }
 
 // Tests using WithArgs with an action that takes 5 arguments.
 TEST(WithArgsTest, FiveArgs) {
-  Action<string(const char*, const char*, const char*,
-                const char*, const char*)> a =
-      WithArgs<4, 3, 2, 1, 0>(Invoke(Concat5));
+  Action<std::string(const char*, const char*, const char*, const char*,
+                     const char*)>
+      a = WithArgs<4, 3, 2, 1, 0>(Invoke(Concat5));
   EXPECT_EQ("43210",
             a.Perform(make_tuple(CharPtr("0"), CharPtr("1"), CharPtr("2"),
                                  CharPtr("3"), CharPtr("4"))));
@@ -323,7 +323,7 @@ TEST(WithArgsTest, FiveArgs) {
 
 // Tests using WithArgs with an action that takes 6 arguments.
 TEST(WithArgsTest, SixArgs) {
-  Action<string(const char*, const char*, const char*)> a =
+  Action<std::string(const char*, const char*, const char*)> a =
       WithArgs<0, 1, 2, 2, 1, 0>(Invoke(Concat6));
   EXPECT_EQ("012210",
             a.Perform(make_tuple(CharPtr("0"), CharPtr("1"), CharPtr("2"))));
@@ -331,7 +331,7 @@ TEST(WithArgsTest, SixArgs) {
 
 // Tests using WithArgs with an action that takes 7 arguments.
 TEST(WithArgsTest, SevenArgs) {
-  Action<string(const char*, const char*, const char*, const char*)> a =
+  Action<std::string(const char*, const char*, const char*, const char*)> a =
       WithArgs<0, 1, 2, 3, 2, 1, 0>(Invoke(Concat7));
   EXPECT_EQ("0123210",
             a.Perform(make_tuple(CharPtr("0"), CharPtr("1"), CharPtr("2"),
@@ -340,7 +340,7 @@ TEST(WithArgsTest, SevenArgs) {
 
 // Tests using WithArgs with an action that takes 8 arguments.
 TEST(WithArgsTest, EightArgs) {
-  Action<string(const char*, const char*, const char*, const char*)> a =
+  Action<std::string(const char*, const char*, const char*, const char*)> a =
       WithArgs<0, 1, 2, 3, 0, 1, 2, 3>(Invoke(Concat8));
   EXPECT_EQ("01230123",
             a.Perform(make_tuple(CharPtr("0"), CharPtr("1"), CharPtr("2"),
@@ -349,7 +349,7 @@ TEST(WithArgsTest, EightArgs) {
 
 // Tests using WithArgs with an action that takes 9 arguments.
 TEST(WithArgsTest, NineArgs) {
-  Action<string(const char*, const char*, const char*, const char*)> a =
+  Action<std::string(const char*, const char*, const char*, const char*)> a =
       WithArgs<0, 1, 2, 3, 1, 2, 3, 2, 3>(Invoke(Concat9));
   EXPECT_EQ("012312323",
             a.Perform(make_tuple(CharPtr("0"), CharPtr("1"), CharPtr("2"),
@@ -358,7 +358,7 @@ TEST(WithArgsTest, NineArgs) {
 
 // Tests using WithArgs with an action that takes 10 arguments.
 TEST(WithArgsTest, TenArgs) {
-  Action<string(const char*, const char*, const char*, const char*)> a =
+  Action<std::string(const char*, const char*, const char*, const char*)> a =
       WithArgs<0, 1, 2, 3, 2, 1, 0, 1, 2, 3>(Invoke(Concat10));
   EXPECT_EQ("0123210123",
             a.Perform(make_tuple(CharPtr("0"), CharPtr("1"), CharPtr("2"),

--- a/googlemock/test/gmock-generated-function-mockers_test.cc
+++ b/googlemock/test/gmock-generated-function-mockers_test.cc
@@ -57,7 +57,6 @@
 namespace testing {
 namespace gmock_generated_function_mockers_test {
 
-using testing::internal::string;
 using testing::_;
 using testing::A;
 using testing::An;
@@ -82,11 +81,11 @@ class FooInterface {
   virtual bool Unary(int x) = 0;
   virtual long Binary(short x, int y) = 0;  // NOLINT
   virtual int Decimal(bool b, char c, short d, int e, long f,  // NOLINT
-                      float g, double h, unsigned i, char* j, const string& k)
-      = 0;
+                      float g, double h, unsigned i, char* j,
+                      const std::string& k) = 0;
 
   virtual bool TakesNonConstReference(int& n) = 0;  // NOLINT
-  virtual string TakesConstReference(const int& n) = 0;
+  virtual std::string TakesConstReference(const int& n) = 0;
 #ifdef GMOCK_ALLOWS_CONST_PARAM_FUNCTIONS
   virtual bool TakesConst(const int x) = 0;
 #endif  // GMOCK_ALLOWS_CONST_PARAM_FUNCTIONS
@@ -101,13 +100,14 @@ class FooInterface {
   virtual char OverloadedOnConstness() const = 0;
 
   virtual int TypeWithHole(int (*func)()) = 0;
-  virtual int TypeWithComma(const std::map<int, string>& a_map) = 0;
+  virtual int TypeWithComma(const std::map<int, std::string>& a_map) = 0;
 
 #if GTEST_OS_WINDOWS
   STDMETHOD_(int, CTNullary)() = 0;
   STDMETHOD_(bool, CTUnary)(int x) = 0;
-  STDMETHOD_(int, CTDecimal)(bool b, char c, short d, int e, long f,  // NOLINT
-      float g, double h, unsigned i, char* j, const string& k) = 0;
+  STDMETHOD_(int, CTDecimal)
+  (bool b, char c, short d, int e, long f,  // NOLINT
+   float g, double h, unsigned i, char* j, const std::string& k) = 0;
   STDMETHOD_(char, CTConst)(int x) const = 0;
 #endif  // GTEST_OS_WINDOWS
 };
@@ -133,19 +133,19 @@ class MockFoo : public FooInterface {
   MOCK_METHOD1(Unary, bool(int));  // NOLINT
   MOCK_METHOD2(Binary, long(short, int));  // NOLINT
   MOCK_METHOD10(Decimal, int(bool, char, short, int, long, float,  // NOLINT
-                             double, unsigned, char*, const string& str));
+                             double, unsigned, char*, const std::string& str));
 
   MOCK_METHOD1(TakesNonConstReference, bool(int&));  // NOLINT
-  MOCK_METHOD1(TakesConstReference, string(const int&));
+  MOCK_METHOD1(TakesConstReference, std::string(const int&));
 
 #ifdef GMOCK_ALLOWS_CONST_PARAM_FUNCTIONS
   MOCK_METHOD1(TakesConst, bool(const int));  // NOLINT
 #endif
 
   // Tests that the function return type can contain unprotected comma.
-  MOCK_METHOD0(ReturnTypeWithComma, std::map<int, string>());
+  MOCK_METHOD0(ReturnTypeWithComma, std::map<int, std::string>());
   MOCK_CONST_METHOD1(ReturnTypeWithComma,
-                     std::map<int, string>(int));  // NOLINT
+                     std::map<int, std::string>(int));  // NOLINT
 
   MOCK_METHOD0(OverloadedOnArgumentNumber, int());  // NOLINT
   MOCK_METHOD1(OverloadedOnArgumentNumber, int(int));  // NOLINT
@@ -157,19 +157,21 @@ class MockFoo : public FooInterface {
   MOCK_CONST_METHOD0(OverloadedOnConstness, char());  // NOLINT
 
   MOCK_METHOD1(TypeWithHole, int(int (*)()));  // NOLINT
-  MOCK_METHOD1(TypeWithComma, int(const std::map<int, string>&));  // NOLINT
+  MOCK_METHOD1(TypeWithComma,
+               int(const std::map<int, std::string>&));  // NOLINT
 
 #if GTEST_OS_WINDOWS
   MOCK_METHOD0_WITH_CALLTYPE(STDMETHODCALLTYPE, CTNullary, int());
   MOCK_METHOD1_WITH_CALLTYPE(STDMETHODCALLTYPE, CTUnary, bool(int));
-  MOCK_METHOD10_WITH_CALLTYPE(STDMETHODCALLTYPE, CTDecimal, int(bool b, char c,
-      short d, int e, long f, float g, double h, unsigned i, char* j,
-      const string& k));
+  MOCK_METHOD10_WITH_CALLTYPE(STDMETHODCALLTYPE, CTDecimal,
+                              int(bool b, char c, short d, int e, long f,
+                                  float g, double h, unsigned i, char* j,
+                                  const std::string& k));
   MOCK_CONST_METHOD1_WITH_CALLTYPE(STDMETHODCALLTYPE, CTConst, char(int));
 
   // Tests that the function return type can contain unprotected comma.
   MOCK_METHOD0_WITH_CALLTYPE(STDMETHODCALLTYPE, CTReturnTypeWithComma,
-                             std::map<int, string>());
+                             std::map<int, std::string>());
 #endif  // GTEST_OS_WINDOWS
 
  private:
@@ -291,7 +293,7 @@ TEST_F(FunctionMockerTest, MocksFunctionsOverloadedOnConstnessOfThis) {
 }
 
 TEST_F(FunctionMockerTest, MocksReturnTypeWithComma) {
-  const std::map<int, string> a_map;
+  const std::map<int, std::string> a_map;
   EXPECT_CALL(mock_foo_, ReturnTypeWithComma())
       .WillOnce(Return(a_map));
   EXPECT_CALL(mock_foo_, ReturnTypeWithComma(42))
@@ -341,7 +343,7 @@ TEST_F(FunctionMockerTest, MocksFunctionsConstFunctionWithCallType) {
 }
 
 TEST_F(FunctionMockerTest, MocksReturnTypeWithCommaAndCallType) {
-  const std::map<int, string> a_map;
+  const std::map<int, std::string> a_map;
   EXPECT_CALL(mock_foo_, CTReturnTypeWithComma())
       .WillOnce(Return(a_map));
 

--- a/googlemock/test/gmock-generated-matchers_test.cc
+++ b/googlemock/test/gmock-generated-matchers_test.cc
@@ -79,11 +79,10 @@ using testing::StaticAssertTypeEq;
 using testing::StrEq;
 using testing::Value;
 using testing::internal::ElementsAreArrayMatcher;
-using testing::internal::string;
 
 // Returns the description of the given matcher.
 template <typename T>
-string Describe(const Matcher<T>& m) {
+std::string Describe(const Matcher<T>& m) {
   stringstream ss;
   m.DescribeTo(&ss);
   return ss.str();
@@ -91,7 +90,7 @@ string Describe(const Matcher<T>& m) {
 
 // Returns the description of the negation of the given matcher.
 template <typename T>
-string DescribeNegation(const Matcher<T>& m) {
+std::string DescribeNegation(const Matcher<T>& m) {
   stringstream ss;
   m.DescribeNegationTo(&ss);
   return ss.str();
@@ -99,7 +98,7 @@ string DescribeNegation(const Matcher<T>& m) {
 
 // Returns the reason why x matches, or doesn't match, m.
 template <typename MatcherType, typename Value>
-string Explain(const MatcherType& m, const Value& x) {
+std::string Explain(const MatcherType& m, const Value& x) {
   stringstream ss;
   m.ExplainMatchResultTo(x, &ss);
   return ss.str();
@@ -296,7 +295,7 @@ TEST(ElementsAreTest, CanDescribeExpectingOneElement) {
 }
 
 TEST(ElementsAreTest, CanDescribeExpectingManyElements) {
-  Matcher<list<string> > m = ElementsAre(StrEq("one"), "two");
+  Matcher<list<std::string> > m = ElementsAre(StrEq("one"), "two");
   EXPECT_EQ("has 2 elements where\n"
             "element #0 is equal to \"one\",\n"
             "element #1 is equal to \"two\"", Describe(m));
@@ -314,7 +313,7 @@ TEST(ElementsAreTest, CanDescribeNegationOfExpectingOneElment) {
 }
 
 TEST(ElementsAreTest, CanDescribeNegationOfExpectingManyElements) {
-  Matcher<const list<string>& > m = ElementsAre("one", "two");
+  Matcher<const list<std::string>&> m = ElementsAre("one", "two");
   EXPECT_EQ("doesn't have 2 elements, or\n"
             "element #0 isn't equal to \"one\", or\n"
             "element #1 isn't equal to \"two\"", DescribeNegation(m));
@@ -365,21 +364,21 @@ TEST(ElementsAreTest, CanExplainMismatchRightSize) {
 }
 
 TEST(ElementsAreTest, MatchesOneElementVector) {
-  vector<string> test_vector;
+  vector<std::string> test_vector;
   test_vector.push_back("test string");
 
   EXPECT_THAT(test_vector, ElementsAre(StrEq("test string")));
 }
 
 TEST(ElementsAreTest, MatchesOneElementList) {
-  list<string> test_list;
+  list<std::string> test_list;
   test_list.push_back("test string");
 
   EXPECT_THAT(test_list, ElementsAre("test string"));
 }
 
 TEST(ElementsAreTest, MatchesThreeElementVector) {
-  vector<string> test_vector;
+  vector<std::string> test_vector;
   test_vector.push_back("one");
   test_vector.push_back("two");
   test_vector.push_back("three");
@@ -428,30 +427,30 @@ TEST(ElementsAreTest, MatchesTenElementVector) {
 }
 
 TEST(ElementsAreTest, DoesNotMatchWrongSize) {
-  vector<string> test_vector;
+  vector<std::string> test_vector;
   test_vector.push_back("test string");
   test_vector.push_back("test string");
 
-  Matcher<vector<string> > m = ElementsAre(StrEq("test string"));
+  Matcher<vector<std::string> > m = ElementsAre(StrEq("test string"));
   EXPECT_FALSE(m.Matches(test_vector));
 }
 
 TEST(ElementsAreTest, DoesNotMatchWrongValue) {
-  vector<string> test_vector;
+  vector<std::string> test_vector;
   test_vector.push_back("other string");
 
-  Matcher<vector<string> > m = ElementsAre(StrEq("test string"));
+  Matcher<vector<std::string> > m = ElementsAre(StrEq("test string"));
   EXPECT_FALSE(m.Matches(test_vector));
 }
 
 TEST(ElementsAreTest, DoesNotMatchWrongOrder) {
-  vector<string> test_vector;
+  vector<std::string> test_vector;
   test_vector.push_back("one");
   test_vector.push_back("three");
   test_vector.push_back("two");
 
-  Matcher<vector<string> > m = ElementsAre(
-    StrEq("one"), StrEq("two"), StrEq("three"));
+  Matcher<vector<std::string> > m =
+      ElementsAre(StrEq("one"), StrEq("two"), StrEq("three"));
   EXPECT_FALSE(m.Matches(test_vector));
 }
 
@@ -527,7 +526,7 @@ TEST(ElementsAreTest, WorksWithTwoDimensionalNativeArray) {
 }
 
 TEST(ElementsAreTest, AcceptsStringLiteral) {
-  string array[] = { "hi", "one", "two" };
+  std::string array[] = {"hi", "one", "two"};
   EXPECT_THAT(array, ElementsAre("hi", "one", "two"));
   EXPECT_THAT(array, Not(ElementsAre("hi", "one", "too")));
 }
@@ -546,10 +545,10 @@ TEST(ElementsAreTest, AcceptsArrayWithUnknownSize) {
   // The size of kHi is not known in this test, but ElementsAre() should
   // still accept it.
 
-  string array1[] = { "hi" };
+  std::string array1[] = {"hi"};
   EXPECT_THAT(array1, ElementsAre(kHi));
 
-  string array2[] = { "ho" };
+  std::string array2[] = {"ho"};
   EXPECT_THAT(array2, Not(ElementsAre(kHi)));
 }
 
@@ -589,7 +588,7 @@ TEST(ElementsAreArrayTest, CanBeCreatedWithValueArray) {
 TEST(ElementsAreArrayTest, CanBeCreatedWithArraySize) {
   const char* a[] = { "one", "two", "three" };
 
-  vector<string> test_vector(a, a + GTEST_ARRAY_SIZE_(a));
+  vector<std::string> test_vector(a, a + GTEST_ARRAY_SIZE_(a));
   EXPECT_THAT(test_vector, ElementsAreArray(a, GTEST_ARRAY_SIZE_(a)));
 
   const char** p = a;
@@ -600,7 +599,7 @@ TEST(ElementsAreArrayTest, CanBeCreatedWithArraySize) {
 TEST(ElementsAreArrayTest, CanBeCreatedWithoutArraySize) {
   const char* a[] = { "one", "two", "three" };
 
-  vector<string> test_vector(a, a + GTEST_ARRAY_SIZE_(a));
+  vector<std::string> test_vector(a, a + GTEST_ARRAY_SIZE_(a));
   EXPECT_THAT(test_vector, ElementsAreArray(a));
 
   test_vector[0] = "1";
@@ -608,10 +607,10 @@ TEST(ElementsAreArrayTest, CanBeCreatedWithoutArraySize) {
 }
 
 TEST(ElementsAreArrayTest, CanBeCreatedWithMatcherArray) {
-  const Matcher<string> kMatcherArray[] =
-    { StrEq("one"), StrEq("two"), StrEq("three") };
+  const Matcher<std::string> kMatcherArray[] = {StrEq("one"), StrEq("two"),
+                                                StrEq("three")};
 
-  vector<string> test_vector;
+  vector<std::string> test_vector;
   test_vector.push_back("one");
   test_vector.push_back("two");
   test_vector.push_back("three");
@@ -640,7 +639,7 @@ TEST(ElementsAreArrayTest, TakesInitializerList) {
 }
 
 TEST(ElementsAreArrayTest, TakesInitializerListOfCStrings) {
-  const string a[5] = { "a", "b", "c", "d", "e" };
+  const std::string a[5] = {"a", "b", "c", "d", "e"};
   EXPECT_THAT(a, ElementsAreArray({ "a", "b", "c", "d", "e" }));
   EXPECT_THAT(a, Not(ElementsAreArray({ "a", "b", "c", "e", "d" })));
   EXPECT_THAT(a, Not(ElementsAreArray({ "a", "b", "c", "d", "ef" })));
@@ -751,9 +750,9 @@ MATCHER(IsEven2, negation ? "is odd" : "is even") {
 
 // This also tests that the description string can reference matcher
 // parameters.
-MATCHER_P2(EqSumOf, x, y,
-           string(negation ? "doesn't equal" : "equals") + " the sum of " +
-           PrintToString(x) + " and " + PrintToString(y)) {
+MATCHER_P2(EqSumOf, x, y, std::string(negation ? "doesn't equal" : "equals") +
+                              " the sum of " + PrintToString(x) + " and " +
+                              PrintToString(y)) {
   if (arg == (x + y)) {
     *result_listener << "OK";
     return true;
@@ -1117,12 +1116,12 @@ TEST(ContainsTest, ListMatchesWhenElementIsInContainer) {
   EXPECT_THAT(some_list, Contains(Gt(2.5)));
   EXPECT_THAT(some_list, Contains(Eq(2.0f)));
 
-  list<string> another_list;
+  list<std::string> another_list;
   another_list.push_back("fee");
   another_list.push_back("fie");
   another_list.push_back("foe");
   another_list.push_back("fum");
-  EXPECT_THAT(another_list, Contains(string("fee")));
+  EXPECT_THAT(another_list, Contains(std::string("fee")));
 }
 
 TEST(ContainsTest, ListDoesNotMatchWhenElementIsNotInContainer) {
@@ -1146,7 +1145,7 @@ TEST(ContainsTest, SetMatchesWhenElementIsInContainer) {
   another_set.insert("fie");
   another_set.insert("foe");
   another_set.insert("fum");
-  EXPECT_THAT(another_set, Contains(Eq(string("fum"))));
+  EXPECT_THAT(another_set, Contains(Eq(std::string("fum"))));
 }
 
 TEST(ContainsTest, SetDoesNotMatchWhenElementIsNotInContainer) {
@@ -1157,7 +1156,7 @@ TEST(ContainsTest, SetDoesNotMatchWhenElementIsNotInContainer) {
 
   set<const char*> c_string_set;
   c_string_set.insert("hello");
-  EXPECT_THAT(c_string_set, Not(Contains(string("hello").c_str())));
+  EXPECT_THAT(c_string_set, Not(Contains(std::string("hello").c_str())));
 }
 
 TEST(ContainsTest, ExplainsMatchResultCorrectly) {
@@ -1189,13 +1188,14 @@ TEST(ContainsTest, MapMatchesWhenElementIsInContainer) {
   my_map[bar] = 2;
   EXPECT_THAT(my_map, Contains(pair<const char* const, int>(bar, 2)));
 
-  map<string, int> another_map;
+  map<std::string, int> another_map;
   another_map["fee"] = 1;
   another_map["fie"] = 2;
   another_map["foe"] = 3;
   another_map["fum"] = 4;
-  EXPECT_THAT(another_map, Contains(pair<const string, int>(string("fee"), 1)));
-  EXPECT_THAT(another_map, Contains(pair<const string, int>("fie", 2)));
+  EXPECT_THAT(another_map,
+              Contains(pair<const std::string, int>(std::string("fee"), 1)));
+  EXPECT_THAT(another_map, Contains(pair<const std::string, int>("fie", 2)));
 }
 
 TEST(ContainsTest, MapDoesNotMatchWhenElementIsNotInContainer) {
@@ -1207,7 +1207,7 @@ TEST(ContainsTest, MapDoesNotMatchWhenElementIsNotInContainer) {
 
 TEST(ContainsTest, ArrayMatchesWhenElementIsInContainer) {
   const char* string_array[] = { "fee", "fie", "foe", "fum" };
-  EXPECT_THAT(string_array, Contains(Eq(string("fum"))));
+  EXPECT_THAT(string_array, Contains(Eq(std::string("fum"))));
 }
 
 TEST(ContainsTest, ArrayDoesNotMatchWhenElementIsNotInContainer) {

--- a/googlemock/test/gmock-internal-utils_test.cc
+++ b/googlemock/test/gmock-internal-utils_test.cc
@@ -319,11 +319,10 @@ TEST(TupleMatchesTest, WorksForSize2) {
 
 TEST(TupleMatchesTest, WorksForSize5) {
   tuple<Matcher<int>, Matcher<char>, Matcher<bool>, Matcher<long>,  // NOLINT
-      Matcher<string> >
+        Matcher<std::string> >
       matchers(Eq(1), Eq('a'), Eq(true), Eq(2L), Eq("hi"));
-  tuple<int, char, bool, long, string>  // NOLINT
-      values1(1, 'a', true, 2L, "hi"),
-      values2(1, 'a', true, 2L, "hello"),
+  tuple<int, char, bool, long, std::string>  // NOLINT
+      values1(1, 'a', true, 2L, "hi"), values2(1, 'a', true, 2L, "hello"),
       values3(2, 'a', true, 2L, "hi");
 
   EXPECT_TRUE(TupleMatches(matchers, values1));
@@ -375,7 +374,7 @@ class LogIsVisibleTest : public ::testing::Test {
 
   virtual void TearDown() { GMOCK_FLAG(verbose) = original_verbose_; }
 
-  string original_verbose_;
+  std::string original_verbose_;
 };
 
 TEST_F(LogIsVisibleTest, AlwaysReturnsTrueIfVerbosityIsInfo) {
@@ -402,9 +401,9 @@ TEST_F(LogIsVisibleTest, WorksWhenVerbosityIsWarning) {
 
 // Verifies that Log() behaves correctly for the given verbosity level
 // and log severity.
-void TestLogWithSeverity(const string& verbosity, LogSeverity severity,
+void TestLogWithSeverity(const std::string& verbosity, LogSeverity severity,
                          bool should_print) {
-  const string old_flag = GMOCK_FLAG(verbose);
+  const std::string old_flag = GMOCK_FLAG(verbose);
   GMOCK_FLAG(verbose) = verbosity;
   CaptureStdout();
   Log(severity, "Test log.\n", 0);
@@ -423,7 +422,7 @@ void TestLogWithSeverity(const string& verbosity, LogSeverity severity,
 // Tests that when the stack_frames_to_skip parameter is negative,
 // Log() doesn't include the stack trace in the output.
 TEST(LogTest, NoStackTraceWhenStackFramesToSkipIsNegative) {
-  const string saved_flag = GMOCK_FLAG(verbose);
+  const std::string saved_flag = GMOCK_FLAG(verbose);
   GMOCK_FLAG(verbose) = kInfoVerbosity;
   CaptureStdout();
   Log(kInfo, "Test log.\n", -1);
@@ -432,7 +431,7 @@ TEST(LogTest, NoStackTraceWhenStackFramesToSkipIsNegative) {
 }
 
 struct MockStackTraceGetter : testing::internal::OsStackTraceGetterInterface {
-  virtual string CurrentStackTrace(int max_depth, int skip_count) {
+  virtual std::string CurrentStackTrace(int max_depth, int skip_count) {
     return (testing::Message() << max_depth << "::" << skip_count << "\n")
         .GetString();
   }
@@ -447,11 +446,11 @@ TEST(LogTest, NoSkippingStackFrameInOptMode) {
 
   CaptureStdout();
   Log(kWarning, "Test log.\n", 100);
-  const string log = GetCapturedStdout();
+  const std::string log = GetCapturedStdout();
 
-  string expected_trace =
+  std::string expected_trace =
       (testing::Message() << GTEST_FLAG(stack_trace_depth) << "::").GetString();
-  string expected_message =
+  std::string expected_message =
       "\nGMOCK WARNING:\n"
       "Test log.\n"
       "Stack trace:\n" +
@@ -547,7 +546,7 @@ TEST(TypeTraitsTest, remove_reference) {
 // Verifies that Log() behaves correctly for the given verbosity level
 // and log severity.
 std::string GrabOutput(void(*logger)(), const char* verbosity) {
-  const string saved_flag = GMOCK_FLAG(verbose);
+  const std::string saved_flag = GMOCK_FLAG(verbose);
   GMOCK_FLAG(verbose) = verbosity;
   CaptureStdout();
   logger();

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -189,7 +189,7 @@ Matcher<int> GreaterThan(int n) {
   return MakeMatcher(new GreaterThanMatcher(n));
 }
 
-string OfType(const string& type_name) {
+std::string OfType(const std::string& type_name) {
 #if GTEST_HAS_RTTI
   return " (of type " + type_name + ")";
 #else
@@ -199,7 +199,7 @@ string OfType(const string& type_name) {
 
 // Returns the description of the given matcher.
 template <typename T>
-string Describe(const Matcher<T>& m) {
+std::string Describe(const Matcher<T>& m) {
   stringstream ss;
   m.DescribeTo(&ss);
   return ss.str();
@@ -207,7 +207,7 @@ string Describe(const Matcher<T>& m) {
 
 // Returns the description of the negation of the given matcher.
 template <typename T>
-string DescribeNegation(const Matcher<T>& m) {
+std::string DescribeNegation(const Matcher<T>& m) {
   stringstream ss;
   m.DescribeNegationTo(&ss);
   return ss.str();
@@ -215,7 +215,7 @@ string DescribeNegation(const Matcher<T>& m) {
 
 // Returns the reason why x matches, or doesn't match, m.
 template <typename MatcherType, typename Value>
-string Explain(const MatcherType& m, const Value& x) {
+std::string Explain(const MatcherType& m, const Value& x) {
   StringMatchResultListener listener;
   ExplainMatchResult(m, x, &listener);
   return listener.str();
@@ -973,7 +973,7 @@ TEST(LeTest, CanDescribeSelf) {
 
 // Tests that Lt(v) matches anything < v.
 TEST(LtTest, ImplementsLessThan) {
-  Matcher<const string&> m1 = Lt("Hello");
+  Matcher<const std::string&> m1 = Lt("Hello");
   EXPECT_TRUE(m1.Matches("Abc"));
   EXPECT_FALSE(m1.Matches("Hello"));
   EXPECT_FALSE(m1.Matches("Hello, world!"));
@@ -1125,7 +1125,7 @@ TEST(RefTest, CanDescribeSelf) {
   Matcher<int&> m = Ref(n);
   stringstream ss;
   ss << "references the variable @" << &n << " 5";
-  EXPECT_EQ(string(ss.str()), Describe(m));
+  EXPECT_EQ(ss.str(), Describe(m));
 }
 
 // Test that Ref(non_const_varialbe) can be used as a matcher for a
@@ -1169,27 +1169,27 @@ TEST(RefTest, ExplainsResult) {
 // Tests string comparison matchers.
 
 TEST(StrEqTest, MatchesEqualString) {
-  Matcher<const char*> m = StrEq(string("Hello"));
+  Matcher<const char*> m = StrEq(std::string("Hello"));
   EXPECT_TRUE(m.Matches("Hello"));
   EXPECT_FALSE(m.Matches("hello"));
   EXPECT_FALSE(m.Matches(NULL));
 
-  Matcher<const string&> m2 = StrEq("Hello");
+  Matcher<const std::string&> m2 = StrEq("Hello");
   EXPECT_TRUE(m2.Matches("Hello"));
   EXPECT_FALSE(m2.Matches("Hi"));
 }
 
 TEST(StrEqTest, CanDescribeSelf) {
-  Matcher<string> m = StrEq("Hi-\'\"?\\\a\b\f\n\r\t\v\xD3");
+  Matcher<std::string> m = StrEq("Hi-\'\"?\\\a\b\f\n\r\t\v\xD3");
   EXPECT_EQ("is equal to \"Hi-\'\\\"?\\\\\\a\\b\\f\\n\\r\\t\\v\\xD3\"",
       Describe(m));
 
-  string str("01204500800");
+  std::string str("01204500800");
   str[3] = '\0';
-  Matcher<string> m2 = StrEq(str);
+  Matcher<std::string> m2 = StrEq(str);
   EXPECT_EQ("is equal to \"012\\04500800\"", Describe(m2));
   str[0] = str[6] = str[7] = str[9] = str[10] = '\0';
-  Matcher<string> m3 = StrEq(str);
+  Matcher<std::string> m3 = StrEq(str);
   EXPECT_EQ("is equal to \"\\012\\045\\0\\08\\0\\0\"", Describe(m3));
 }
 
@@ -1199,7 +1199,7 @@ TEST(StrNeTest, MatchesUnequalString) {
   EXPECT_TRUE(m.Matches(NULL));
   EXPECT_FALSE(m.Matches("Hello"));
 
-  Matcher<string> m2 = StrNe(string("Hello"));
+  Matcher<std::string> m2 = StrNe(std::string("Hello"));
   EXPECT_TRUE(m2.Matches("hello"));
   EXPECT_FALSE(m2.Matches("Hello"));
 }
@@ -1222,32 +1222,32 @@ TEST(StrCaseEqTest, MatchesEqualStringIgnoringCase) {
 }
 
 TEST(StrCaseEqTest, MatchesEqualStringWith0IgnoringCase) {
-  string str1("oabocdooeoo");
-  string str2("OABOCDOOEOO");
-  Matcher<const string&> m0 = StrCaseEq(str1);
-  EXPECT_FALSE(m0.Matches(str2 + string(1, '\0')));
+  std::string str1("oabocdooeoo");
+  std::string str2("OABOCDOOEOO");
+  Matcher<const std::string&> m0 = StrCaseEq(str1);
+  EXPECT_FALSE(m0.Matches(str2 + std::string(1, '\0')));
 
   str1[3] = str2[3] = '\0';
-  Matcher<const string&> m1 = StrCaseEq(str1);
+  Matcher<const std::string&> m1 = StrCaseEq(str1);
   EXPECT_TRUE(m1.Matches(str2));
 
   str1[0] = str1[6] = str1[7] = str1[10] = '\0';
   str2[0] = str2[6] = str2[7] = str2[10] = '\0';
-  Matcher<const string&> m2 = StrCaseEq(str1);
+  Matcher<const std::string&> m2 = StrCaseEq(str1);
   str1[9] = str2[9] = '\0';
   EXPECT_FALSE(m2.Matches(str2));
 
-  Matcher<const string&> m3 = StrCaseEq(str1);
+  Matcher<const std::string&> m3 = StrCaseEq(str1);
   EXPECT_TRUE(m3.Matches(str2));
 
   EXPECT_FALSE(m3.Matches(str2 + "x"));
   str2.append(1, '\0');
   EXPECT_FALSE(m3.Matches(str2));
-  EXPECT_FALSE(m3.Matches(string(str2, 0, 9)));
+  EXPECT_FALSE(m3.Matches(std::string(str2, 0, 9)));
 }
 
 TEST(StrCaseEqTest, CanDescribeSelf) {
-  Matcher<string> m = StrCaseEq("Hi");
+  Matcher<std::string> m = StrCaseEq("Hi");
   EXPECT_EQ("is equal to (ignoring case) \"Hi\"", Describe(m));
 }
 
@@ -1258,7 +1258,7 @@ TEST(StrCaseNeTest, MatchesUnequalStringIgnoringCase) {
   EXPECT_FALSE(m.Matches("Hello"));
   EXPECT_FALSE(m.Matches("hello"));
 
-  Matcher<string> m2 = StrCaseNe(string("Hello"));
+  Matcher<std::string> m2 = StrCaseNe(std::string("Hello"));
   EXPECT_TRUE(m2.Matches(""));
   EXPECT_FALSE(m2.Matches("Hello"));
 }
@@ -1270,9 +1270,9 @@ TEST(StrCaseNeTest, CanDescribeSelf) {
 
 // Tests that HasSubstr() works for matching string-typed values.
 TEST(HasSubstrTest, WorksForStringClasses) {
-  const Matcher<string> m1 = HasSubstr("foo");
-  EXPECT_TRUE(m1.Matches(string("I love food.")));
-  EXPECT_FALSE(m1.Matches(string("tofo")));
+  const Matcher<std::string> m1 = HasSubstr("foo");
+  EXPECT_TRUE(m1.Matches(std::string("I love food.")));
+  EXPECT_FALSE(m1.Matches(std::string("tofo")));
 
   const Matcher<const std::string&> m2 = HasSubstr("foo");
   EXPECT_TRUE(m2.Matches(std::string("I love food.")));
@@ -1294,7 +1294,7 @@ TEST(HasSubstrTest, WorksForCStrings) {
 
 // Tests that HasSubstr(s) describes itself properly.
 TEST(HasSubstrTest, CanDescribeSelf) {
-  Matcher<string> m = HasSubstr("foo\n\"");
+  Matcher<std::string> m = HasSubstr("foo\n\"");
   EXPECT_EQ("has substring \"foo\\n\\\"\"", Describe(m));
 }
 
@@ -1460,12 +1460,12 @@ TEST(PairTest, InsideContainsUsingMap) {
 // Tests StartsWith(s).
 
 TEST(StartsWithTest, MatchesStringWithGivenPrefix) {
-  const Matcher<const char*> m1 = StartsWith(string(""));
+  const Matcher<const char*> m1 = StartsWith(std::string(""));
   EXPECT_TRUE(m1.Matches("Hi"));
   EXPECT_TRUE(m1.Matches(""));
   EXPECT_FALSE(m1.Matches(NULL));
 
-  const Matcher<const string&> m2 = StartsWith("Hi");
+  const Matcher<const std::string&> m2 = StartsWith("Hi");
   EXPECT_TRUE(m2.Matches("Hi"));
   EXPECT_TRUE(m2.Matches("Hi Hi!"));
   EXPECT_TRUE(m2.Matches("High"));
@@ -1507,14 +1507,14 @@ TEST(MatchesRegexTest, MatchesStringMatchingGivenRegex) {
   EXPECT_TRUE(m1.Matches("abcz"));
   EXPECT_FALSE(m1.Matches(NULL));
 
-  const Matcher<const string&> m2 = MatchesRegex(new RE("a.*z"));
+  const Matcher<const std::string&> m2 = MatchesRegex(new RE("a.*z"));
   EXPECT_TRUE(m2.Matches("azbz"));
   EXPECT_FALSE(m2.Matches("az1"));
   EXPECT_FALSE(m2.Matches("1az"));
 }
 
 TEST(MatchesRegexTest, CanDescribeSelf) {
-  Matcher<const std::string> m1 = MatchesRegex(string("Hi.*"));
+  Matcher<const std::string> m1 = MatchesRegex(std::string("Hi.*"));
   EXPECT_EQ("matches regular expression \"Hi.*\"", Describe(m1));
 
   Matcher<const char*> m2 = MatchesRegex(new RE("a.*"));
@@ -1524,12 +1524,12 @@ TEST(MatchesRegexTest, CanDescribeSelf) {
 // Tests ContainsRegex().
 
 TEST(ContainsRegexTest, MatchesStringContainingGivenRegex) {
-  const Matcher<const char*> m1 = ContainsRegex(string("a.*z"));
+  const Matcher<const char*> m1 = ContainsRegex(std::string("a.*z"));
   EXPECT_TRUE(m1.Matches("az"));
   EXPECT_TRUE(m1.Matches("0abcz1"));
   EXPECT_FALSE(m1.Matches(NULL));
 
-  const Matcher<const string&> m2 = ContainsRegex(new RE("a.*z"));
+  const Matcher<const std::string&> m2 = ContainsRegex(new RE("a.*z"));
   EXPECT_TRUE(m2.Matches("azbz"));
   EXPECT_TRUE(m2.Matches("az1"));
   EXPECT_FALSE(m2.Matches("1a"));
@@ -2685,9 +2685,9 @@ TEST(MatcherAssertionTest, WorksForMonomorphicMatcher) {
   Matcher<const char*> starts_with_he = StartsWith("he");
   ASSERT_THAT("hello", starts_with_he);
 
-  Matcher<const string&> ends_with_ok = EndsWith("ok");
+  Matcher<const std::string&> ends_with_ok = EndsWith("ok");
   ASSERT_THAT("book", ends_with_ok);
-  const string bad = "bad";
+  const std::string bad = "bad";
   EXPECT_NONFATAL_FAILURE(EXPECT_THAT(bad, ends_with_ok),
                           "Value of: bad\n"
                           "Expected: ends with \"ok\"\n"
@@ -3099,7 +3099,8 @@ TEST_F(DoubleNearTest, ExplainsResultWhenMatchFails) {
   EXPECT_EQ("which is 0.2 from 2", Explain(DoubleNear(2.0, 0.1), 2.2));
   EXPECT_EQ("which is -0.3 from 2", Explain(DoubleNear(2.0, 0.1), 1.7));
 
-  const string explanation = Explain(DoubleNear(2.1, 1e-10), 2.1 + 1.2e-10);
+  const std::string explanation =
+      Explain(DoubleNear(2.1, 1e-10), 2.1 + 1.2e-10);
   // Different C++ implementations may print floating-point numbers
   // slightly differently.
   EXPECT_TRUE(explanation == "which is 1.2e-10 from 2.1" ||  // GCC
@@ -3337,9 +3338,9 @@ TEST(PointeeTest, CanDescribeSelf) {
 }
 
 TEST(PointeeTest, CanExplainMatchResult) {
-  const Matcher<const string*> m = Pointee(StartsWith("Hi"));
+  const Matcher<const std::string*> m = Pointee(StartsWith("Hi"));
 
-  EXPECT_EQ("", Explain(m, static_cast<const string*>(NULL)));
+  EXPECT_EQ("", Explain(m, static_cast<const std::string*>(NULL)));
 
   const Matcher<long*> m2 = Pointee(GreaterThan(1));  // NOLINT
   long n = 3;  // NOLINT
@@ -3585,15 +3586,15 @@ class AClass {
   void set_n(int new_n) { n_ = new_n; }
 
   // A getter that returns a reference to const.
-  const string& s() const { return s_; }
+  const std::string& s() const { return s_; }
 
-  void set_s(const string& new_s) { s_ = new_s; }
+  void set_s(const std::string& new_s) { s_ = new_s; }
 
   // A getter that returns a reference to non-const.
   double& x() const { return x_; }
  private:
   int n_;
-  string s_;
+  std::string s_;
 
   static double x_;
 };
@@ -3799,10 +3800,12 @@ TEST(PropertyForPointerTest, CanExplainMatchResult) {
 
 // Tests that ResultOf(f, ...) compiles and works as expected when f is a
 // function pointer.
-string IntToStringFunction(int input) { return input == 1 ? "foo" : "bar"; }
+std::string IntToStringFunction(int input) {
+  return input == 1 ? "foo" : "bar";
+}
 
 TEST(ResultOfTest, WorksForFunctionPointers) {
-  Matcher<int> matcher = ResultOf(&IntToStringFunction, Eq(string("foo")));
+  Matcher<int> matcher = ResultOf(&IntToStringFunction, Eq(std::string("foo")));
 
   EXPECT_TRUE(matcher.Matches(1));
   EXPECT_FALSE(matcher.Matches(2));
@@ -3868,12 +3871,12 @@ TEST(ResultOfTest, WorksForReferenceToNonConstResults) {
 
 // Tests that ResultOf(f, ...) compiles and works as expected when f(x)
 // returns a reference to const.
-const string& StringFunction(const string& input) { return input; }
+const std::string& StringFunction(const std::string& input) { return input; }
 
 TEST(ResultOfTest, WorksForReferenceToConstResults) {
-  string s = "foo";
-  string s2 = s;
-  Matcher<const string&> matcher = ResultOf(&StringFunction, Ref(s));
+  std::string s = "foo";
+  std::string s2 = s;
+  Matcher<const std::string&> matcher = ResultOf(&StringFunction, Ref(s));
 
   EXPECT_TRUE(matcher.Matches(s));
   EXPECT_FALSE(matcher.Matches(s2));
@@ -3893,8 +3896,9 @@ TEST(ResultOfTest, WorksForCompatibleMatcherTypes) {
 // a NULL function pointer.
 TEST(ResultOfDeathTest, DiesOnNullFunctionPointers) {
   EXPECT_DEATH_IF_SUPPORTED(
-      ResultOf(static_cast<string(*)(int dummy)>(NULL), Eq(string("foo"))),
-               "NULL function pointer is passed into ResultOf\\(\\)\\.");
+      ResultOf(static_cast<std::string (*)(int dummy)>(NULL),
+               Eq(std::string("foo"))),
+      "NULL function pointer is passed into ResultOf\\(\\)\\.");
 }
 
 // Tests that ResultOf(f, ...) compiles and works as expected when f is a
@@ -3907,14 +3911,14 @@ TEST(ResultOfTest, WorksForFunctionReferences) {
 
 // Tests that ResultOf(f, ...) compiles and works as expected when f is a
 // function object.
-struct Functor : public ::std::unary_function<int, string> {
+struct Functor : public ::std::unary_function<int, std::string> {
   result_type operator()(argument_type input) const {
     return IntToStringFunction(input);
   }
 };
 
 TEST(ResultOfTest, WorksForFunctors) {
-  Matcher<int> matcher = ResultOf(Functor(), Eq(string("foo")));
+  Matcher<int> matcher = ResultOf(Functor(), Eq(std::string("foo")));
 
   EXPECT_TRUE(matcher.Matches(1));
   EXPECT_FALSE(matcher.Matches(2));
@@ -4080,11 +4084,11 @@ TEST(IsEmptyTest, ImplementsIsEmpty) {
 }
 
 TEST(IsEmptyTest, WorksWithString) {
-  string text;
+  std::string text;
   EXPECT_THAT(text, IsEmpty());
   text = "foo";
   EXPECT_THAT(text, Not(IsEmpty()));
-  text = string("\0", 1);
+  text = std::string("\0", 1);
   EXPECT_THAT(text, Not(IsEmpty()));
 }
 
@@ -4115,7 +4119,7 @@ TEST(SizeIsTest, ImplementsSizeIs) {
 }
 
 TEST(SizeIsTest, WorksWithMap) {
-  map<string, int> container;
+  map<std::string, int> container;
   EXPECT_THAT(container, SizeIs(0));
   EXPECT_THAT(container, Not(SizeIs(1)));
   container.insert(make_pair("foo", 1));
@@ -4380,13 +4384,13 @@ TEST(WhenSortedByTest, WorksForNonEmptyContainer) {
 }
 
 TEST(WhenSortedByTest, WorksForNonVectorContainer) {
-  list<string> words;
+  list<std::string> words;
   words.push_back("say");
   words.push_back("hello");
   words.push_back("world");
-  EXPECT_THAT(words, WhenSortedBy(less<string>(),
+  EXPECT_THAT(words, WhenSortedBy(less<std::string>(),
                                   ElementsAre("hello", "say", "world")));
-  EXPECT_THAT(words, Not(WhenSortedBy(less<string>(),
+  EXPECT_THAT(words, Not(WhenSortedBy(less<std::string>(),
                                       ElementsAre("say", "hello", "world"))));
 }
 
@@ -4429,7 +4433,7 @@ TEST(WhenSortedTest, WorksForEmptyContainer) {
 }
 
 TEST(WhenSortedTest, WorksForNonEmptyContainer) {
-  list<string> words;
+  list<std::string> words;
   words.push_back("3");
   words.push_back("1");
   words.push_back("2");
@@ -4439,14 +4443,16 @@ TEST(WhenSortedTest, WorksForNonEmptyContainer) {
 }
 
 TEST(WhenSortedTest, WorksForMapTypes) {
-    map<string, int> word_counts;
-    word_counts["and"] = 1;
-    word_counts["the"] = 1;
-    word_counts["buffalo"] = 2;
-    EXPECT_THAT(word_counts, WhenSorted(ElementsAre(
-            Pair("and", 1), Pair("buffalo", 2), Pair("the", 1))));
-    EXPECT_THAT(word_counts, Not(WhenSorted(ElementsAre(
-            Pair("and", 1), Pair("the", 1), Pair("buffalo", 2)))));
+  map<std::string, int> word_counts;
+  word_counts["and"] = 1;
+  word_counts["the"] = 1;
+  word_counts["buffalo"] = 2;
+  EXPECT_THAT(word_counts,
+              WhenSorted(ElementsAre(Pair("and", 1), Pair("buffalo", 2),
+                                     Pair("the", 1))));
+  EXPECT_THAT(word_counts,
+              Not(WhenSorted(ElementsAre(Pair("and", 1), Pair("the", 1),
+                                         Pair("buffalo", 2)))));
 }
 
 TEST(WhenSortedTest, WorksForMultiMapTypes) {
@@ -4763,7 +4769,7 @@ TEST(UnorderedElementsAreArrayTest, TakesInitializerList) {
 }
 
 TEST(UnorderedElementsAreArrayTest, TakesInitializerListOfCStrings) {
-  const string a[5] = {"a", "b", "c", "d", "e"};
+  const std::string a[5] = {"a", "b", "c", "d", "e"};
   EXPECT_THAT(a, UnorderedElementsAreArray({"a", "b", "c", "d", "e"}));
   EXPECT_THAT(a, Not(UnorderedElementsAreArray({"a", "b", "c", "d", "ef"})));
 }
@@ -4937,7 +4943,7 @@ TEST_F(UnorderedElementsAreTest, FailMessageUnmatchedMatcherAndElement) {
 }
 
 // Test helper for formatting element, matcher index pairs in expectations.
-static string EMString(int element, int matcher) {
+static std::string EMString(int element, int matcher) {
   stringstream ss;
   ss << "(element #" << element << ", matcher #" << matcher << ")";
   return ss.str();
@@ -4946,7 +4952,7 @@ static string EMString(int element, int matcher) {
 TEST_F(UnorderedElementsAreTest, FailMessageImperfectMatchOnly) {
   // A situation where all elements and matchers have a match
   // associated with them, but the max matching is not perfect.
-  std::vector<string> v;
+  std::vector<std::string> v;
   v.push_back("a");
   v.push_back("b");
   v.push_back("c");
@@ -4955,7 +4961,7 @@ TEST_F(UnorderedElementsAreTest, FailMessageImperfectMatchOnly) {
       UnorderedElementsAre("a", "a", AnyOf("b", "c")), v, &listener))
       << listener.str();
 
-  string prefix =
+  std::string prefix =
       "where no permutation of the elements can satisfy all matchers, "
       "and the closest match is 2 of 3 matchers with the "
       "pairings:\n";
@@ -5366,13 +5372,13 @@ TEST(EachTest, MatchesVectorWhenAllElementsMatch) {
   EXPECT_THAT(some_vector, Not(Each(3)));
   EXPECT_THAT(some_vector, Each(Lt(3.5)));
 
-  vector<string> another_vector;
+  vector<std::string> another_vector;
   another_vector.push_back("fee");
-  EXPECT_THAT(another_vector, Each(string("fee")));
+  EXPECT_THAT(another_vector, Each(std::string("fee")));
   another_vector.push_back("fie");
   another_vector.push_back("foe");
   another_vector.push_back("fum");
-  EXPECT_THAT(another_vector, Not(Each(string("fee"))));
+  EXPECT_THAT(another_vector, Not(Each(std::string("fee"))));
 }
 
 TEST(EachTest, MatchesMapWhenAllElementsMatch) {
@@ -5381,15 +5387,15 @@ TEST(EachTest, MatchesMapWhenAllElementsMatch) {
   my_map[bar] = 2;
   EXPECT_THAT(my_map, Each(make_pair(bar, 2)));
 
-  map<string, int> another_map;
-  EXPECT_THAT(another_map, Each(make_pair(string("fee"), 1)));
+  map<std::string, int> another_map;
+  EXPECT_THAT(another_map, Each(make_pair(std::string("fee"), 1)));
   another_map["fee"] = 1;
-  EXPECT_THAT(another_map, Each(make_pair(string("fee"), 1)));
+  EXPECT_THAT(another_map, Each(make_pair(std::string("fee"), 1)));
   another_map["fie"] = 2;
   another_map["foe"] = 3;
   another_map["fum"] = 4;
-  EXPECT_THAT(another_map, Not(Each(make_pair(string("fee"), 1))));
-  EXPECT_THAT(another_map, Not(Each(make_pair(string("fum"), 1))));
+  EXPECT_THAT(another_map, Not(Each(make_pair(std::string("fee"), 1))));
+  EXPECT_THAT(another_map, Not(Each(make_pair(std::string("fum"), 1))));
   EXPECT_THAT(another_map, Each(Pair(_, Gt(0))));
 }
 

--- a/googlemock/test/gmock-more-actions_test.cc
+++ b/googlemock/test/gmock-more-actions_test.cc
@@ -94,12 +94,12 @@ const char* Plus1(const char* s) { return s + 1; }
 
 void VoidUnary(int /* n */) { g_done = true; }
 
-bool ByConstRef(const string& s) { return s == "Hi"; }
+bool ByConstRef(const std::string& s) { return s == "Hi"; }
 
 const double g_double = 0;
 bool ReferencesGlobalDouble(const double& x) { return &x == &g_double; }
 
-string ByNonConstRef(string& s) { return s += "+"; }  // NOLINT
+std::string ByNonConstRef(std::string& s) { return s += "+"; }  // NOLINT
 
 struct UnaryFunctor {
   int operator()(bool x) { return x ? 1 : -1; }
@@ -119,9 +119,9 @@ int SumOfFirst2(int a, int b, Unused, Unused) { return a + b; }
 
 void VoidFunctionWithFourArguments(char, int, float, double) { g_done = true; }
 
-string Concat4(const char* s1, const char* s2, const char* s3,
-               const char* s4) {
-  return string(s1) + s2 + s3 + s4;
+std::string Concat4(const char* s1, const char* s2, const char* s3,
+                    const char* s4) {
+  return std::string(s1) + s2 + s3 + s4;
 }
 
 int SumOf5(int a, int b, int c, int d, int e) { return a + b + c + d + e; }
@@ -132,9 +132,9 @@ struct SumOf5Functor {
   }
 };
 
-string Concat5(const char* s1, const char* s2, const char* s3,
-               const char* s4, const char* s5) {
-  return string(s1) + s2 + s3 + s4 + s5;
+std::string Concat5(const char* s1, const char* s2, const char* s3,
+                    const char* s4, const char* s5) {
+  return std::string(s1) + s2 + s3 + s4 + s5;
 }
 
 int SumOf6(int a, int b, int c, int d, int e, int f) {
@@ -147,34 +147,34 @@ struct SumOf6Functor {
   }
 };
 
-string Concat6(const char* s1, const char* s2, const char* s3,
-               const char* s4, const char* s5, const char* s6) {
-  return string(s1) + s2 + s3 + s4 + s5 + s6;
+std::string Concat6(const char* s1, const char* s2, const char* s3,
+                    const char* s4, const char* s5, const char* s6) {
+  return std::string(s1) + s2 + s3 + s4 + s5 + s6;
 }
 
-string Concat7(const char* s1, const char* s2, const char* s3,
-               const char* s4, const char* s5, const char* s6,
-               const char* s7) {
-  return string(s1) + s2 + s3 + s4 + s5 + s6 + s7;
+std::string Concat7(const char* s1, const char* s2, const char* s3,
+                    const char* s4, const char* s5, const char* s6,
+                    const char* s7) {
+  return std::string(s1) + s2 + s3 + s4 + s5 + s6 + s7;
 }
 
-string Concat8(const char* s1, const char* s2, const char* s3,
-               const char* s4, const char* s5, const char* s6,
-               const char* s7, const char* s8) {
-  return string(s1) + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+std::string Concat8(const char* s1, const char* s2, const char* s3,
+                    const char* s4, const char* s5, const char* s6,
+                    const char* s7, const char* s8) {
+  return std::string(s1) + s2 + s3 + s4 + s5 + s6 + s7 + s8;
 }
 
-string Concat9(const char* s1, const char* s2, const char* s3,
-               const char* s4, const char* s5, const char* s6,
-               const char* s7, const char* s8, const char* s9) {
-  return string(s1) + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9;
+std::string Concat9(const char* s1, const char* s2, const char* s3,
+                    const char* s4, const char* s5, const char* s6,
+                    const char* s7, const char* s8, const char* s9) {
+  return std::string(s1) + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9;
 }
 
-string Concat10(const char* s1, const char* s2, const char* s3,
-                const char* s4, const char* s5, const char* s6,
-                const char* s7, const char* s8, const char* s9,
-                const char* s10) {
-  return string(s1) + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10;
+std::string Concat10(const char* s1, const char* s2, const char* s3,
+                     const char* s4, const char* s5, const char* s6,
+                     const char* s7, const char* s8, const char* s9,
+                     const char* s10) {
+  return std::string(s1) + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10;
 }
 
 class Foo {
@@ -185,7 +185,7 @@ class Foo {
 
   short Unary(long x) { return static_cast<short>(value_ + x); }  // NOLINT
 
-  string Binary(const string& str, char c) const { return str + c; }
+  std::string Binary(const std::string& str, char c) const { return str + c; }
 
   int Ternary(int x, bool y, char z) { return value_ + x + y*z; }
 
@@ -201,29 +201,29 @@ class Foo {
     return a + b + c + d + e + f;
   }
 
-  string Concat7(const char* s1, const char* s2, const char* s3,
-                 const char* s4, const char* s5, const char* s6,
-                 const char* s7) {
-    return string(s1) + s2 + s3 + s4 + s5 + s6 + s7;
+  std::string Concat7(const char* s1, const char* s2, const char* s3,
+                      const char* s4, const char* s5, const char* s6,
+                      const char* s7) {
+    return std::string(s1) + s2 + s3 + s4 + s5 + s6 + s7;
   }
 
-  string Concat8(const char* s1, const char* s2, const char* s3,
-                 const char* s4, const char* s5, const char* s6,
-                 const char* s7, const char* s8) {
-    return string(s1) + s2 + s3 + s4 + s5 + s6 + s7 + s8;
+  std::string Concat8(const char* s1, const char* s2, const char* s3,
+                      const char* s4, const char* s5, const char* s6,
+                      const char* s7, const char* s8) {
+    return std::string(s1) + s2 + s3 + s4 + s5 + s6 + s7 + s8;
   }
 
-  string Concat9(const char* s1, const char* s2, const char* s3,
-                 const char* s4, const char* s5, const char* s6,
-                 const char* s7, const char* s8, const char* s9) {
-    return string(s1) + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9;
+  std::string Concat9(const char* s1, const char* s2, const char* s3,
+                      const char* s4, const char* s5, const char* s6,
+                      const char* s7, const char* s8, const char* s9) {
+    return std::string(s1) + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9;
   }
 
-  string Concat10(const char* s1, const char* s2, const char* s3,
-                  const char* s4, const char* s5, const char* s6,
-                  const char* s7, const char* s8, const char* s9,
-                  const char* s10) {
-    return string(s1) + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10;
+  std::string Concat10(const char* s1, const char* s2, const char* s3,
+                       const char* s4, const char* s5, const char* s6,
+                       const char* s7, const char* s8, const char* s9,
+                       const char* s10) {
+    return std::string(s1) + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10;
   }
 
  private:
@@ -280,9 +280,9 @@ inline const char* CharPtr(const char* s) { return s; }
 
 // Tests using Invoke() with a 7-argument function.
 TEST(InvokeTest, FunctionThatTakes7Arguments) {
-  Action<string(const char*, const char*, const char*, const char*,
-                const char*, const char*, const char*)> a =
-      Invoke(Concat7);
+  Action<std::string(const char*, const char*, const char*, const char*,
+                     const char*, const char*, const char*)>
+      a = Invoke(Concat7);
   EXPECT_EQ("1234567",
             a.Perform(make_tuple(CharPtr("1"), CharPtr("2"), CharPtr("3"),
                                  CharPtr("4"), CharPtr("5"), CharPtr("6"),
@@ -291,9 +291,9 @@ TEST(InvokeTest, FunctionThatTakes7Arguments) {
 
 // Tests using Invoke() with a 8-argument function.
 TEST(InvokeTest, FunctionThatTakes8Arguments) {
-  Action<string(const char*, const char*, const char*, const char*,
-                const char*, const char*, const char*, const char*)> a =
-      Invoke(Concat8);
+  Action<std::string(const char*, const char*, const char*, const char*,
+                     const char*, const char*, const char*, const char*)>
+      a = Invoke(Concat8);
   EXPECT_EQ("12345678",
             a.Perform(make_tuple(CharPtr("1"), CharPtr("2"), CharPtr("3"),
                                  CharPtr("4"), CharPtr("5"), CharPtr("6"),
@@ -302,9 +302,10 @@ TEST(InvokeTest, FunctionThatTakes8Arguments) {
 
 // Tests using Invoke() with a 9-argument function.
 TEST(InvokeTest, FunctionThatTakes9Arguments) {
-  Action<string(const char*, const char*, const char*, const char*,
-                const char*, const char*, const char*, const char*,
-                const char*)> a = Invoke(Concat9);
+  Action<std::string(const char*, const char*, const char*, const char*,
+                     const char*, const char*, const char*, const char*,
+                     const char*)>
+      a = Invoke(Concat9);
   EXPECT_EQ("123456789",
             a.Perform(make_tuple(CharPtr("1"), CharPtr("2"), CharPtr("3"),
                                  CharPtr("4"), CharPtr("5"), CharPtr("6"),
@@ -313,9 +314,10 @@ TEST(InvokeTest, FunctionThatTakes9Arguments) {
 
 // Tests using Invoke() with a 10-argument function.
 TEST(InvokeTest, FunctionThatTakes10Arguments) {
-  Action<string(const char*, const char*, const char*, const char*,
-                const char*, const char*, const char*, const char*,
-                const char*, const char*)> a = Invoke(Concat10);
+  Action<std::string(const char*, const char*, const char*, const char*,
+                     const char*, const char*, const char*, const char*,
+                     const char*, const char*)>
+      a = Invoke(Concat10);
   EXPECT_EQ("1234567890",
             a.Perform(make_tuple(CharPtr("1"), CharPtr("2"), CharPtr("3"),
                                  CharPtr("4"), CharPtr("5"), CharPtr("6"),
@@ -339,8 +341,7 @@ TEST(InvokeTest, FunctionWithUnusedParameters) {
 // Tests using Invoke() with methods with parameters declared as Unused.
 TEST(InvokeTest, MethodWithUnusedParameters) {
   Foo foo;
-  Action<int(string, bool, int, int)> a1 =
-      Invoke(&foo, &Foo::SumOfLast2);
+  Action<int(std::string, bool, int, int)> a1 = Invoke(&foo, &Foo::SumOfLast2);
   EXPECT_EQ(12, a1.Perform(make_tuple(CharPtr("hi"), true, 10, 2)));
 
   Action<int(char, double, int, int)> a2 =
@@ -417,9 +418,9 @@ TEST(InvokeMethodTest, MethodThatTakes6Arguments) {
 // Tests using Invoke() with a 7-argument method.
 TEST(InvokeMethodTest, MethodThatTakes7Arguments) {
   Foo foo;
-  Action<string(const char*, const char*, const char*, const char*,
-                const char*, const char*, const char*)> a =
-      Invoke(&foo, &Foo::Concat7);
+  Action<std::string(const char*, const char*, const char*, const char*,
+                     const char*, const char*, const char*)>
+      a = Invoke(&foo, &Foo::Concat7);
   EXPECT_EQ("1234567",
             a.Perform(make_tuple(CharPtr("1"), CharPtr("2"), CharPtr("3"),
                                  CharPtr("4"), CharPtr("5"), CharPtr("6"),
@@ -429,9 +430,9 @@ TEST(InvokeMethodTest, MethodThatTakes7Arguments) {
 // Tests using Invoke() with a 8-argument method.
 TEST(InvokeMethodTest, MethodThatTakes8Arguments) {
   Foo foo;
-  Action<string(const char*, const char*, const char*, const char*,
-                const char*, const char*, const char*, const char*)> a =
-      Invoke(&foo, &Foo::Concat8);
+  Action<std::string(const char*, const char*, const char*, const char*,
+                     const char*, const char*, const char*, const char*)>
+      a = Invoke(&foo, &Foo::Concat8);
   EXPECT_EQ("12345678",
             a.Perform(make_tuple(CharPtr("1"), CharPtr("2"), CharPtr("3"),
                                  CharPtr("4"), CharPtr("5"), CharPtr("6"),
@@ -441,9 +442,10 @@ TEST(InvokeMethodTest, MethodThatTakes8Arguments) {
 // Tests using Invoke() with a 9-argument method.
 TEST(InvokeMethodTest, MethodThatTakes9Arguments) {
   Foo foo;
-  Action<string(const char*, const char*, const char*, const char*,
-                const char*, const char*, const char*, const char*,
-                const char*)> a = Invoke(&foo, &Foo::Concat9);
+  Action<std::string(const char*, const char*, const char*, const char*,
+                     const char*, const char*, const char*, const char*,
+                     const char*)>
+      a = Invoke(&foo, &Foo::Concat9);
   EXPECT_EQ("123456789",
             a.Perform(make_tuple(CharPtr("1"), CharPtr("2"), CharPtr("3"),
                                  CharPtr("4"), CharPtr("5"), CharPtr("6"),
@@ -453,9 +455,10 @@ TEST(InvokeMethodTest, MethodThatTakes9Arguments) {
 // Tests using Invoke() with a 10-argument method.
 TEST(InvokeMethodTest, MethodThatTakes10Arguments) {
   Foo foo;
-  Action<string(const char*, const char*, const char*, const char*,
-                const char*, const char*, const char*, const char*,
-                const char*, const char*)> a = Invoke(&foo, &Foo::Concat10);
+  Action<std::string(const char*, const char*, const char*, const char*,
+                     const char*, const char*, const char*, const char*,
+                     const char*, const char*)>
+      a = Invoke(&foo, &Foo::Concat10);
   EXPECT_EQ("1234567890",
             a.Perform(make_tuple(CharPtr("1"), CharPtr("2"), CharPtr("3"),
                                  CharPtr("4"), CharPtr("5"), CharPtr("6"),
@@ -495,8 +498,8 @@ TEST(ReturnArgActionTest, WorksForMultiArgBoolArg0) {
 }
 
 TEST(ReturnArgActionTest, WorksForMultiArgStringArg2) {
-  const Action<string(int, int, string, int)> a = ReturnArg<2>();
-  EXPECT_EQ("seven", a.Perform(make_tuple(5, 6, string("seven"), 8)));
+  const Action<std::string(int, int, std::string, int)> a = ReturnArg<2>();
+  EXPECT_EQ("seven", a.Perform(make_tuple(5, 6, std::string("seven"), 8)));
 }
 
 TEST(SaveArgActionTest, WorksForSameType) {

--- a/googlemock/test/gmock-nice-strict_test.cc
+++ b/googlemock/test/gmock-nice-strict_test.cc
@@ -51,7 +51,6 @@ class Mock {
 namespace testing {
 namespace gmock_nice_strict_test {
 
-using testing::internal::string;
 using testing::GMOCK_FLAG(verbose);
 using testing::HasSubstr;
 using testing::NaggyMock;
@@ -87,23 +86,23 @@ class MockFoo : public Foo {
 
 class MockBar {
  public:
-  explicit MockBar(const string& s) : str_(s) {}
+  explicit MockBar(const std::string& s) : str_(s) {}
 
-  MockBar(char a1, char a2, string a3, string a4, int a5, int a6,
-          const string& a7, const string& a8, bool a9, bool a10) {
-    str_ = string() + a1 + a2 + a3 + a4 + static_cast<char>(a5) +
+  MockBar(char a1, char a2, std::string a3, std::string a4, int a5, int a6,
+          const std::string& a7, const std::string& a8, bool a9, bool a10) {
+    str_ = std::string() + a1 + a2 + a3 + a4 + static_cast<char>(a5) +
         static_cast<char>(a6) + a7 + a8 + (a9 ? 'T' : 'F') + (a10 ? 'T' : 'F');
   }
 
   virtual ~MockBar() {}
 
-  const string& str() const { return str_; }
+  const std::string& str() const { return str_; }
 
   MOCK_METHOD0(This, int());
-  MOCK_METHOD2(That, string(int, bool));
+  MOCK_METHOD2(That, std::string(int, bool));
 
  private:
-  string str_;
+  std::string str_;
 
   GTEST_DISALLOW_COPY_AND_ASSIGN_(MockBar);
 };
@@ -112,7 +111,7 @@ class MockBar {
 
 // Tests that a raw mock generates warnings for uninteresting calls.
 TEST(RawMockTest, WarningForUninterestingCall) {
-  const string saved_flag = GMOCK_FLAG(verbose);
+  const std::string saved_flag = GMOCK_FLAG(verbose);
   GMOCK_FLAG(verbose) = "warning";
 
   MockFoo raw_foo;
@@ -129,7 +128,7 @@ TEST(RawMockTest, WarningForUninterestingCall) {
 // Tests that a raw mock generates warnings for uninteresting calls
 // that delete the mock object.
 TEST(RawMockTest, WarningForUninterestingCallAfterDeath) {
-  const string saved_flag = GMOCK_FLAG(verbose);
+  const std::string saved_flag = GMOCK_FLAG(verbose);
   GMOCK_FLAG(verbose) = "warning";
 
   MockFoo* const raw_foo = new MockFoo;
@@ -150,7 +149,7 @@ TEST(RawMockTest, WarningForUninterestingCallAfterDeath) {
 TEST(RawMockTest, InfoForUninterestingCall) {
   MockFoo raw_foo;
 
-  const string saved_flag = GMOCK_FLAG(verbose);
+  const std::string saved_flag = GMOCK_FLAG(verbose);
   GMOCK_FLAG(verbose) = "info";
   CaptureStdout();
   raw_foo.DoThis();
@@ -188,7 +187,7 @@ TEST(NiceMockTest, NoWarningForUninterestingCallAfterDeath) {
 TEST(NiceMockTest, InfoForUninterestingCall) {
   NiceMock<MockFoo> nice_foo;
 
-  const string saved_flag = GMOCK_FLAG(verbose);
+  const std::string saved_flag = GMOCK_FLAG(verbose);
   GMOCK_FLAG(verbose) = "info";
   CaptureStdout();
   nice_foo.DoThis();
@@ -257,7 +256,7 @@ TEST(NiceMockTest, AcceptsClassNamedMock) {
 
 // Tests that a naggy mock generates warnings for uninteresting calls.
 TEST(NaggyMockTest, WarningForUninterestingCall) {
-  const string saved_flag = GMOCK_FLAG(verbose);
+  const std::string saved_flag = GMOCK_FLAG(verbose);
   GMOCK_FLAG(verbose) = "warning";
 
   NaggyMock<MockFoo> naggy_foo;
@@ -274,7 +273,7 @@ TEST(NaggyMockTest, WarningForUninterestingCall) {
 // Tests that a naggy mock generates a warning for an uninteresting call
 // that deletes the mock object.
 TEST(NaggyMockTest, WarningForUninterestingCallAfterDeath) {
-  const string saved_flag = GMOCK_FLAG(verbose);
+  const std::string saved_flag = GMOCK_FLAG(verbose);
   GMOCK_FLAG(verbose) = "warning";
 
   NaggyMock<MockFoo>* const naggy_foo = new NaggyMock<MockFoo>;

--- a/googlemock/test/gmock-spec-builders_test.cc
+++ b/googlemock/test/gmock-spec-builders_test.cc
@@ -97,7 +97,6 @@ using testing::internal::kErrorVerbosity;
 using testing::internal::kInfoVerbosity;
 using testing::internal::kWarningVerbosity;
 using testing::internal::linked_ptr;
-using testing::internal::string;
 
 #if GTEST_HAS_STREAM_REDIRECTION
 using testing::HasSubstr;
@@ -1954,7 +1953,7 @@ class MockC {
  public:
   MockC() {}
 
-  MOCK_METHOD6(VoidMethod, void(bool cond, int n, string s, void* p,
+  MOCK_METHOD6(VoidMethod, void(bool cond, int n, std::string s, void* p,
                                 const Printable& x, Unprintable y));
   MOCK_METHOD0(NonVoidMethod, int());  // NOLINT
 
@@ -1970,7 +1969,7 @@ class VerboseFlagPreservingFixture : public testing::Test {
   ~VerboseFlagPreservingFixture() { GMOCK_FLAG(verbose) = saved_verbose_flag_; }
 
  private:
-  const string saved_verbose_flag_;
+  const std::string saved_verbose_flag_;
 
   GTEST_DISALLOW_COPY_AND_ASSIGN_(VerboseFlagPreservingFixture);
 };
@@ -2062,8 +2061,8 @@ class GMockVerboseFlagTest : public VerboseFlagPreservingFixture {
   // contain the given function name in the stack trace.  When it's
   // false, the output should be empty.)
   void VerifyOutput(const std::string& output, bool should_print,
-                    const string& expected_substring,
-                    const string& function_name) {
+                    const std::string& expected_substring,
+                    const std::string& function_name) {
     if (should_print) {
       EXPECT_THAT(output.c_str(), HasSubstr(expected_substring));
 # ifndef NDEBUG
@@ -2113,7 +2112,7 @@ class GMockVerboseFlagTest : public VerboseFlagPreservingFixture {
   // Tests how the flag affects uninteresting calls on a naggy mock.
   void TestUninterestingCallOnNaggyMock(bool should_print) {
     NaggyMock<MockA> a;
-    const string note =
+    const std::string note =
         "NOTE: You can safely ignore the above warning unless this "
         "call should not happen.  Do not suppress it by blindly adding "
         "an EXPECT_CALL() if you don't mean to enforce the call.  "

--- a/googlemock/test/gmock_stress_test.cc
+++ b/googlemock/test/gmock_stress_test.cc
@@ -51,7 +51,7 @@ const int kRepeat = 50;
 class MockFoo {
  public:
   MOCK_METHOD1(Bar, int(int n));  // NOLINT
-  MOCK_METHOD2(Baz, char(const char* s1, const internal::string& s2));  // NOLINT
+  MOCK_METHOD2(Baz, char(const char* s1, const std::string& s2));  // NOLINT
 };
 
 // Helper for waiting for the given thread to finish and then deleting it.

--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -151,10 +151,10 @@ template <typename T>
 class TypeWithoutFormatter<T, kProtobuf> {
  public:
   static void PrintValue(const T& value, ::std::ostream* os) {
-    const ::testing::internal::string short_str = value.ShortDebugString();
-    const ::testing::internal::string pretty_str =
-        short_str.length() <= kProtobufOneLinerMaxLength ?
-        short_str : ("\n" + value.DebugString());
+    std::string pretty_str = value.ShortDebugString();
+    if (pretty_str.length() > kProtobufOneLinerMaxLength) {
+      pretty_str = "\n" + value.DebugString();
+    }
     *os << ("<" + pretty_str + ">");
   }
 };
@@ -805,7 +805,7 @@ class UniversalTersePrinter<const char*> {
     if (str == NULL) {
       *os << "NULL";
     } else {
-      UniversalPrint(string(str), os);
+      UniversalPrint(std::string(str), os);
     }
   }
 };

--- a/googletest/include/gtest/gtest-spi.h
+++ b/googletest/include/gtest/gtest-spi.h
@@ -97,13 +97,12 @@ class GTEST_API_ SingleFailureChecker {
  public:
   // The constructor remembers the arguments.
   SingleFailureChecker(const TestPartResultArray* results,
-                       TestPartResult::Type type,
-                       const string& substr);
+                       TestPartResult::Type type, const std::string& substr);
   ~SingleFailureChecker();
  private:
   const TestPartResultArray* const results_;
   const TestPartResult::Type type_;
-  const string substr_;
+  const std::string substr_;
 
   GTEST_DISALLOW_COPY_AND_ASSIGN_(SingleFailureChecker);
 };

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -502,9 +502,10 @@ typedef void (*SetUpTestCaseFunc)();
 typedef void (*TearDownTestCaseFunc)();
 
 struct CodeLocation {
-  CodeLocation(const string& a_file, int a_line) : file(a_file), line(a_line) {}
+  CodeLocation(const std::string& a_file, int a_line)
+      : file(a_file), line(a_line) {}
 
-  string file;
+  std::string file;
   int line;
 };
 

--- a/googletest/include/gtest/internal/gtest-param-util.h
+++ b/googletest/include/gtest/internal/gtest-param-util.h
@@ -472,7 +472,7 @@ class ParameterizedTestCaseInfoBase {
   virtual ~ParameterizedTestCaseInfoBase() {}
 
   // Base part of test case name for display purposes.
-  virtual const string& GetTestCaseName() const = 0;
+  virtual const std::string& GetTestCaseName() const = 0;
   // Test case id to verify identity.
   virtual TypeId GetTestCaseTypeId() const = 0;
   // UnitTest class invokes this method to register tests in this
@@ -511,7 +511,7 @@ class ParameterizedTestCaseInfo : public ParameterizedTestCaseInfoBase {
       : test_case_name_(name), code_location_(code_location) {}
 
   // Test case base name for display purposes.
-  virtual const string& GetTestCaseName() const { return test_case_name_; }
+  virtual const std::string& GetTestCaseName() const { return test_case_name_; }
   // Test case id to verify identity.
   virtual TypeId GetTestCaseTypeId() const { return GetTypeId<TestCase>(); }
   // TEST_P macro uses AddTestPattern() to record information
@@ -529,11 +529,10 @@ class ParameterizedTestCaseInfo : public ParameterizedTestCaseInfoBase {
   }
   // INSTANTIATE_TEST_CASE_P macro uses AddGenerator() to record information
   // about a generator.
-  int AddTestCaseInstantiation(const string& instantiation_name,
+  int AddTestCaseInstantiation(const std::string& instantiation_name,
                                GeneratorCreationFunc* func,
                                ParamNameGeneratorFunc* name_func,
-                               const char* file,
-                               int line) {
+                               const char* file, int line) {
     instantiations_.push_back(
         InstantiationInfo(instantiation_name, func, name_func, file, line));
     return 0;  // Return value used only to run this method in namespace scope.
@@ -550,13 +549,13 @@ class ParameterizedTestCaseInfo : public ParameterizedTestCaseInfoBase {
       for (typename InstantiationContainer::iterator gen_it =
                instantiations_.begin(); gen_it != instantiations_.end();
                ++gen_it) {
-        const string& instantiation_name = gen_it->name;
+        const std::string& instantiation_name = gen_it->name;
         ParamGenerator<ParamType> generator((*gen_it->generator)());
         ParamNameGeneratorFunc* name_func = gen_it->name_func;
         const char* file = gen_it->file;
         int line = gen_it->line;
 
-        string test_case_name;
+        std::string test_case_name;
         if ( !instantiation_name.empty() )
           test_case_name = instantiation_name + "/";
         test_case_name += test_info->test_case_base_name;
@@ -609,8 +608,8 @@ class ParameterizedTestCaseInfo : public ParameterizedTestCaseInfoBase {
         test_base_name(a_test_base_name),
         test_meta_factory(a_test_meta_factory) {}
 
-    const string test_case_base_name;
-    const string test_base_name;
+    const std::string test_case_base_name;
+    const std::string test_base_name;
     const scoped_ptr<TestMetaFactoryBase<ParamType> > test_meta_factory;
   };
   typedef ::std::vector<linked_ptr<TestInfo> > TestInfoContainer;
@@ -651,7 +650,7 @@ class ParameterizedTestCaseInfo : public ParameterizedTestCaseInfoBase {
     return true;
   }
 
-  const string test_case_name_;
+  const std::string test_case_name_;
   CodeLocation code_location_;
   TestInfoContainer tests_;
   InstantiationContainer instantiations_;

--- a/googletest/src/gtest-death-test.cc
+++ b/googletest/src/gtest-death-test.cc
@@ -883,11 +883,10 @@ class ExecDeathTest : public ForkingDeathTest {
       ForkingDeathTest(a_statement, a_regex), file_(file), line_(line) { }
   virtual TestRole AssumeRole();
  private:
-  static ::std::vector<testing::internal::string>
-  GetArgvsForDeathTestChildProcess() {
-    ::std::vector<testing::internal::string> args = GetInjectableArgvs();
+  static ::std::vector<std::string> GetArgvsForDeathTestChildProcess() {
+    ::std::vector<std::string> args = GetInjectableArgvs();
 #  if defined(GTEST_EXTRA_DEATH_TEST_COMMAND_LINE_ARGS_)
-    ::std::vector<testing::internal::string> extra_args =
+    ::std::vector<std::string> extra_args =
         GTEST_EXTRA_DEATH_TEST_COMMAND_LINE_ARGS_();
     args.insert(args.end(), extra_args.begin(), extra_args.end());
 #  endif  // defined(GTEST_EXTRA_DEATH_TEST_COMMAND_LINE_ARGS_)

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -426,7 +426,7 @@ class OsStackTraceGetterInterface {
   //                in the trace.
   //   skip_count - the number of top frames to be skipped; doesn't count
   //                against max_depth.
-  virtual string CurrentStackTrace(int max_depth, int skip_count) = 0;
+  virtual std::string CurrentStackTrace(int max_depth, int skip_count) = 0;
 
   // UponLeavingGTest() should be called immediately before Google Test calls
   // user code. It saves some information about the current stack that
@@ -446,7 +446,7 @@ class OsStackTraceGetter : public OsStackTraceGetterInterface {
  public:
   OsStackTraceGetter() {}
 
-  virtual string CurrentStackTrace(int max_depth, int skip_count);
+  virtual std::string CurrentStackTrace(int max_depth, int skip_count);
   virtual void UponLeavingGTest();
 
  private:
@@ -1040,21 +1040,19 @@ class GTEST_API_ StreamingListener : public EmptyTestEventListener {
     virtual ~AbstractSocketWriter() {}
 
     // Sends a string to the socket.
-    virtual void Send(const string& message) = 0;
+    virtual void Send(const std::string& message) = 0;
 
     // Closes the socket.
     virtual void CloseConnection() {}
 
     // Sends a string and a newline to the socket.
-    void SendLn(const string& message) {
-      Send(message + "\n");
-    }
+    void SendLn(const std::string& message) { Send(message + "\n"); }
   };
 
   // Concrete class for actually writing strings to a socket.
   class SocketWriter : public AbstractSocketWriter {
    public:
-    SocketWriter(const string& host, const string& port)
+    SocketWriter(const std::string& host, const std::string& port)
         : sockfd_(-1), host_name_(host), port_num_(port) {
       MakeConnection();
     }
@@ -1065,7 +1063,7 @@ class GTEST_API_ StreamingListener : public EmptyTestEventListener {
     }
 
     // Sends a string to the socket.
-    virtual void Send(const string& message) {
+    virtual void Send(const std::string& message) {
       GTEST_CHECK_(sockfd_ != -1)
           << "Send() can be called only when there is a connection.";
 
@@ -1091,17 +1089,19 @@ class GTEST_API_ StreamingListener : public EmptyTestEventListener {
     }
 
     int sockfd_;  // socket file descriptor
-    const string host_name_;
-    const string port_num_;
+    const std::string host_name_;
+    const std::string port_num_;
 
     GTEST_DISALLOW_COPY_AND_ASSIGN_(SocketWriter);
   };  // class SocketWriter
 
   // Escapes '=', '&', '%', and '\n' characters in str as "%xx".
-  static string UrlEncode(const char* str);
+  static std::string UrlEncode(const char* str);
 
-  StreamingListener(const string& host, const string& port)
-      : socket_writer_(new SocketWriter(host, port)) { Start(); }
+  StreamingListener(const std::string& host, const std::string& port)
+      : socket_writer_(new SocketWriter(host, port)) {
+    Start();
+  }
 
   explicit StreamingListener(AbstractSocketWriter* socket_writer)
       : socket_writer_(socket_writer) { Start(); }
@@ -1162,13 +1162,13 @@ class GTEST_API_ StreamingListener : public EmptyTestEventListener {
 
  private:
   // Sends the given message and a newline to the socket.
-  void SendLn(const string& message) { socket_writer_->SendLn(message); }
+  void SendLn(const std::string& message) { socket_writer_->SendLn(message); }
 
   // Called at the start of streaming to notify the receiver what
   // protocol we are using.
   void Start() { SendLn("gtest_streaming_protocol_version=1.0"); }
 
-  string FormatBool(bool value) { return value ? "1" : "0"; }
+  std::string FormatBool(bool value) { return value ? "1" : "0"; }
 
   const scoped_ptr<AbstractSocketWriter> socket_writer_;
 

--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -93,7 +93,7 @@ const int kStdErrFileno = STDERR_FILENO;
 
 namespace {
 template <typename T>
-T ReadProcFileField(const string& filename, int field) {
+T ReadProcFileField(const std::string& filename, int field) {
   std::string dummy;
   std::ifstream file(filename.c_str());
   while (field-- > 0) {
@@ -107,7 +107,7 @@ T ReadProcFileField(const string& filename, int field) {
 
 // Returns the number of active threads, or 0 when there is an error.
 size_t GetThreadCount() {
-  const string filename =
+  const std::string filename =
       (Message() << "/proc/" << getpid() << "/stat").GetString();
   return ReadProcFileField<int>(filename, 19);
 }

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -633,7 +633,7 @@ AssertionResult HasOneFailure(const char* /* results_expr */,
                               const char* /* substr_expr */,
                               const TestPartResultArray& results,
                               TestPartResult::Type type,
-                              const string& substr) {
+                              const std::string& substr) {
   const std::string expected(type == TestPartResult::kFatalFailure ?
                         "1 fatal failure" :
                         "1 non-fatal failure");
@@ -667,13 +667,10 @@ AssertionResult HasOneFailure(const char* /* results_expr */,
 // The constructor of SingleFailureChecker remembers where to look up
 // test part results, what type of failure we expect, and what
 // substring the failure message should contain.
-SingleFailureChecker:: SingleFailureChecker(
-    const TestPartResultArray* results,
-    TestPartResult::Type type,
-    const string& substr)
-    : results_(results),
-      type_(type),
-      substr_(substr) {}
+SingleFailureChecker::SingleFailureChecker(const TestPartResultArray* results,
+                                           TestPartResult::Type type,
+                                           const std::string& substr)
+    : results_(results), type_(type), substr_(substr) {}
 
 // The destructor of SingleFailureChecker verifies that the given
 // TestPartResultArray contains exactly one failure that has the given
@@ -3654,13 +3651,14 @@ void XmlUnitTestResultPrinter::OutputXmlTestInfo(::std::ostream* stream,
       if (++failures == 1) {
         *stream << ">\n";
       }
-      const string location = internal::FormatCompilerIndependentFileLocation(
-          part.file_name(), part.line_number());
-      const string summary = location + "\n" + part.summary();
+      const std::string location =
+          internal::FormatCompilerIndependentFileLocation(part.file_name(),
+                                                          part.line_number());
+      const std::string summary = location + "\n" + part.summary();
       *stream << "      <failure message=\""
               << EscapeXmlAttribute(summary.c_str())
               << "\" type=\"\">";
-      const string detail = location + "\n" + part.message();
+      const std::string detail = location + "\n" + part.message();
       OutputXmlCDataSection(stream, RemoveInvalidXmlCharacters(detail).c_str());
       *stream << "</failure>\n";
     }
@@ -3759,8 +3757,8 @@ std::string XmlUnitTestResultPrinter::TestPropertiesAsXmlAttributes(
 // example, replaces "=" with "%3D".  This algorithm is O(strlen(str))
 // in both time and space -- important as the input str may contain an
 // arbitrarily long test failure message and stack trace.
-string StreamingListener::UrlEncode(const char* str) {
-  string result;
+std::string StreamingListener::UrlEncode(const char* str) {
+  std::string result;
   result.reserve(strlen(str) + 1);
   for (char ch = *str; ch != '\0'; ch = *++str) {
     switch (ch) {
@@ -3848,8 +3846,8 @@ ScopedTrace::~ScopedTrace()
 const char* const OsStackTraceGetterInterface::kElidedFramesMarker =
     "... " GTEST_NAME_ " internal frames ...";
 
-string OsStackTraceGetter::CurrentStackTrace(int /*max_depth*/,
-                                             int /*skip_count*/) {
+std::string OsStackTraceGetter::CurrentStackTrace(int /*max_depth*/,
+                                                  int /*skip_count*/) {
   return "";
 }
 

--- a/googletest/test/gtest-death-test_test.cc
+++ b/googletest/test/gtest-death-test_test.cc
@@ -505,7 +505,7 @@ TEST_F(TestForDeathTest, AcceptsAnythingConvertibleToRE) {
 
 # if GTEST_HAS_GLOBAL_STRING
 
-  const string regex_str(regex_c_str);
+  const ::string regex_str(regex_c_str);
   EXPECT_DEATH(GlobalFunction(), regex_str);
 
 # endif  // GTEST_HAS_GLOBAL_STRING

--- a/googletest/test/gtest-printers_test.cc
+++ b/googletest/test/gtest-printers_test.cc
@@ -236,7 +236,7 @@ using ::stdext::hash_multiset;
 // Prints a value to a string using the universal value printer.  This
 // is a helper for testing UniversalPrinter<T>::Print() for various types.
 template <typename T>
-string Print(const T& value) {
+std::string Print(const T& value) {
   ::std::stringstream ss;
   UniversalPrinter<T>::Print(value, &ss);
   return ss.str();
@@ -246,7 +246,7 @@ string Print(const T& value) {
 // value printer.  This is a helper for testing
 // UniversalPrinter<T&>::Print() for various types.
 template <typename T>
-string PrintByRef(const T& value) {
+std::string PrintByRef(const T& value) {
   ::std::stringstream ss;
   UniversalPrinter<T&>::Print(value, &ss);
   return ss.str();
@@ -383,7 +383,7 @@ TEST(PrintBuiltInTypeTest, FloatingPoints) {
 // Since ::std::stringstream::operator<<(const void *) formats the pointer
 // output differently with different compilers, we have to create the expected
 // output first and use it as our expectation.
-static string PrintPointer(const void *p) {
+static std::string PrintPointer(const void* p) {
   ::std::stringstream expected_result_stream;
   expected_result_stream << p;
   return expected_result_stream.str();
@@ -596,7 +596,7 @@ TEST(PrintPointerTest, MemberFunctionPointer) {
 // The difference between this and Print() is that it ensures that the
 // argument is a reference to an array.
 template <typename T, size_t N>
-string PrintArrayHelper(T (&a)[N]) {
+std::string PrintArrayHelper(T (&a)[N]) {
   return Print(a);
 }
 
@@ -649,7 +649,7 @@ TEST(PrintArrayTest, WConstCharArrayWithTerminatingNul) {
 
 // Array of objects.
 TEST(PrintArrayTest, ObjectArray) {
-  string a[3] = { "Hi", "Hello", "Ni hao" };
+  std::string a[3] = {"Hi", "Hello", "Ni hao"};
   EXPECT_EQ("{ \"Hi\", \"Hello\", \"Ni hao\" }", PrintArrayHelper(a));
 }
 
@@ -831,7 +831,7 @@ TEST(PrintStlContainerTest, HashMultiMap) {
   map1.insert(make_pair(5, false));
 
   // Elements of hash_multimap can be printed in any order.
-  const string result = Print(map1);
+  const std::string result = Print(map1);
   EXPECT_TRUE(result == "{ (5, true), (5, false) }" ||
               result == "{ (5, false), (5, true) }")
                   << " where Print(map1) returns \"" << result << "\".";
@@ -842,9 +842,9 @@ TEST(PrintStlContainerTest, HashMultiMap) {
 #if GTEST_HAS_HASH_SET_
 
 TEST(PrintStlContainerTest, HashSet) {
-  hash_set<string> set1;
-  set1.insert("hello");
-  EXPECT_EQ("{ \"hello\" }", Print(set1));
+  hash_set<int> set1;
+  set1.insert(1);
+  EXPECT_EQ("{ 1 }", Print(set1));
 }
 
 TEST(PrintStlContainerTest, HashMultiSet) {
@@ -853,8 +853,8 @@ TEST(PrintStlContainerTest, HashMultiSet) {
   hash_multiset<int> set1(a, a + kSize);
 
   // Elements of hash_multiset can be printed in any order.
-  const string result = Print(set1);
-  const string expected_pattern = "{ d, d, d, d, d }";  // d means a digit.
+  const std::string result = Print(set1);
+  const std::string expected_pattern = "{ d, d, d, d, d }";  // d means a digit.
 
   // Verifies the result matches the expected pattern; also extracts
   // the numbers in the result.
@@ -879,11 +879,8 @@ TEST(PrintStlContainerTest, HashMultiSet) {
 #endif  // GTEST_HAS_HASH_SET_
 
 TEST(PrintStlContainerTest, List) {
-  const string a[] = {
-    "hello",
-    "world"
-  };
-  const list<string> strings(a, a + 2);
+  const std::string a[] = {"hello", "world"};
+  const list<std::string> strings(a, a + 2);
   EXPECT_EQ("{ \"hello\", \"world\" }", Print(strings));
 }
 
@@ -1039,9 +1036,10 @@ TEST(PrintTr1TupleTest, VariousSizes) {
   // VC++ 2010's implementation of tuple of C++0x is deficient, requiring
   // an explicit type cast of NULL to be used.
   ::std::tr1::tuple<bool, char, short, testing::internal::Int32,  // NOLINT
-      testing::internal::Int64, float, double, const char*, void*, string>
-      t10(false, 'a', 3, 4, 5, 1.5F, -2.5, str,
-          ImplicitCast_<void*>(NULL), "10");
+                    testing::internal::Int64, float, double, const char*, void*,
+                    std::string>
+      t10(false, 'a', 3, 4, 5, 1.5F, -2.5, str, ImplicitCast_<void*>(NULL),
+          "10");
   EXPECT_EQ("(false, 'a' (97, 0x61), 3, 4, 5, 1.5, -2.5, " + PrintPointer(str) +
             " pointing to \"8\", NULL, \"10\")",
             Print(t10));
@@ -1098,9 +1096,10 @@ TEST(PrintStdTupleTest, VariousSizes) {
   // VC++ 2010's implementation of tuple of C++0x is deficient, requiring
   // an explicit type cast of NULL to be used.
   ::std::tuple<bool, char, short, testing::internal::Int32,  // NOLINT
-      testing::internal::Int64, float, double, const char*, void*, string>
-      t10(false, 'a', 3, 4, 5, 1.5F, -2.5, str,
-          ImplicitCast_<void*>(NULL), "10");
+               testing::internal::Int64, float, double, const char*, void*,
+               std::string>
+      t10(false, 'a', 3, 4, 5, 1.5F, -2.5, str, ImplicitCast_<void*>(NULL),
+          "10");
   EXPECT_EQ("(false, 'a' (97, 0x61), 3, 4, 5, 1.5, -2.5, " + PrintPointer(str) +
             " pointing to \"8\", NULL, \"10\")",
             Print(t10));
@@ -1204,13 +1203,13 @@ TEST(PrintReferenceTest, PrintsAddressAndValue) {
 // reference.
 TEST(PrintReferenceTest, HandlesFunctionPointer) {
   void (*fp)(int n) = &MyFunction;
-  const string fp_pointer_string =
+  const std::string fp_pointer_string =
       PrintPointer(reinterpret_cast<const void*>(&fp));
   // We cannot directly cast &MyFunction to const void* because the
   // standard disallows casting between pointers to functions and
   // pointers to objects, and some compilers (e.g. GCC 3.4) enforce
   // this limitation.
-  const string fp_string = PrintPointer(reinterpret_cast<const void*>(
+  const std::string fp_string = PrintPointer(reinterpret_cast<const void*>(
       reinterpret_cast<internal::BiggestInt>(fp)));
   EXPECT_EQ("@" + fp_pointer_string + " " + fp_string,
             PrintByRef(fp));
@@ -1542,12 +1541,12 @@ TEST(UniversalPrintTest, WorksForCString) {
   const char* s1 = "abc";
   ::std::stringstream ss1;
   UniversalPrint(s1, &ss1);
-  EXPECT_EQ(PrintPointer(s1) + " pointing to \"abc\"", string(ss1.str()));
+  EXPECT_EQ(PrintPointer(s1) + " pointing to \"abc\"", std::string(ss1.str()));
 
   char* s2 = const_cast<char*>(s1);
   ::std::stringstream ss2;
   UniversalPrint(s2, &ss2);
-  EXPECT_EQ(PrintPointer(s2) + " pointing to \"abc\"", string(ss2.str()));
+  EXPECT_EQ(PrintPointer(s2) + " pointing to \"abc\"", std::string(ss2.str()));
 
   const char* s3 = NULL;
   ::std::stringstream ss3;
@@ -1636,4 +1635,3 @@ TEST(UniversalTersePrintTupleFieldsToStringsTestWithStd, PrintsTersely) {
 
 }  // namespace gtest_printers_test
 }  // namespace testing
-

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -86,9 +86,9 @@ class StreamingListenerTest : public Test {
   class FakeSocketWriter : public StreamingListener::AbstractSocketWriter {
    public:
     // Sends a string to the socket.
-    virtual void Send(const string& message) { output_ += message; }
+    virtual void Send(const std::string& message) { output_ += message; }
 
-    string output_;
+    std::string output_;
   };
 
   StreamingListenerTest()
@@ -98,7 +98,7 @@ class StreamingListenerTest : public Test {
                        CodeLocation(__FILE__, __LINE__), 0, NULL) {}
 
  protected:
-  string* output() { return &(fake_sock_writer_->output_); }
+  std::string* output() { return &(fake_sock_writer_->output_); }
 
   FakeSocketWriter* const fake_sock_writer_;
   StreamingListener streamer_;
@@ -7703,4 +7703,3 @@ TEST(SkipPrefixTest, DoesNotSkipWhenPrefixDoesNotMatch) {
   EXPECT_FALSE(SkipPrefix("world!", &p));
   EXPECT_EQ(str, p);
 }
-


### PR DESCRIPTION
This merges a Google-internal change (117235625).

Original CL description:
This CL was created manually in about an hour with sed, a Python script
to find all the places unqualified 'string' was mentioned, and some help
from Emacs to add the "std::" qualifications, plus a few manual tweaks.