### PR TITLE
Allow ASSERT_ macros to be augmented with a return code

### DIFF
--- a/googletest/include/gtest/gtest-message.h
+++ b/googletest/include/gtest/gtest-message.h
@@ -56,6 +56,28 @@ void operator<<(const testing::internal::Secret&, int);
 
 namespace testing {
 
+namespace internal {
+
+template<typename T>
+class ReturnValueAndMessageWrapper {
+public:
+  ReturnValueAndMessageWrapper(const T& v, const Message& msg)
+          : v_(v), message_(msg) {}
+  operator const T&() const { return v_; }
+  const ::testing::Message& message() const { return message_; }
+private:
+  // private and non functional assignement operator to silence warning 4512 on
+  // MSVC < 14.0
+  ReturnValueAndMessageWrapper& operator=(const ReturnValueAndMessageWrapper&) {
+    return *this;
+  }
+  const T& v_;
+  const Message& message_;
+};
+
+} // namespace internal
+
+
 // The Message class works like an ostream repeater.
 //
 // Typical usage:
@@ -155,6 +177,11 @@ class GTEST_API_ Message {
     return *this;
   }
 #endif  // GTEST_OS_SYMBIAN
+
+  template<typename T>
+  internal::ReturnValueAndMessageWrapper<T> operator||(const T& value) {
+    return internal::ReturnValueAndMessageWrapper<T>(value, *this);
+  }
 
   // Since the basic IO manipulators are overloaded for both narrow
   // and wide streams, we have to provide this specialized definition

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1678,6 +1678,16 @@ class GTEST_API_ AssertHelper {
   // streaming; see the GTEST_MESSAGE_ macro below.
   void operator=(const Message& message) const;
 
+  // This overload of operator= allows users of ASSERT_ macros to specify an optional
+  // return value that is returned if the assertion fails. This allows using ASSERT_ macros
+  // in subroutines that return error code to propagate the state of the test execution.
+  // The syntax for returning an error code is
+  // ASSERT_XX(...) [ << <optional message> ] [ || <optional error code> ]
+  template<typename T>
+  const T& operator=(const ReturnValueAndMessageWrapper<T>& wrappedReturnValueAndMessage) const {
+      *this = wrappedReturnValueAndMessage.message();
+      return wrappedReturnValueAndMessage;
+  }
  private:
   // We put our data in a struct so that the size of the AssertHelper class can
   // be as small as possible.  This is important because gcc is incapable of

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -7703,3 +7703,18 @@ TEST(SkipPrefixTest, DoesNotSkipWhenPrefixDoesNotMatch) {
   EXPECT_FALSE(SkipPrefix("world!", &p));
   EXPECT_EQ(str, p);
 }
+
+static bool subroutine1(bool fails) {
+  ASSERT_FALSE(fails) << "with message" || false;
+  return true;
+}
+
+static bool subroutine2(bool fails) {
+  ASSERT_FALSE(fails) /*without message*/ || false;
+  return true;
+}
+
+TEST(SubroutineAssertTest, SubroutineSucceeds) {
+  ASSERT_TRUE(subroutine1(false));
+  ASSERT_TRUE(subroutine2(false));
+}


### PR DESCRIPTION
This patch allows ASSERT_ macros to be used in subroutines
returning an error code for tracking test health.
The syntax for using an ASSERT_ macro that returns <error_code> on
failure is:
ASSERT_(...) || <error_code>
and
ASSERT_(...) << <some_message> || <error_code>