### PR TITLE
Use NEW settings for CMP0063 policy

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -40,6 +40,10 @@ endif()
 project(gmock CXX C)
 cmake_minimum_required(VERSION 2.6.4)
 
+if (POLICY CMP0063)
+  cmake_policy(SET CMP0063 NEW)
+endif()
+
 if (COMMAND set_up_hermetic_build)
   set_up_hermetic_build()
 endif()

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -47,6 +47,10 @@ endif()
 project(gtest CXX C)
 cmake_minimum_required(VERSION 2.6.4)
 
+if (POLICY CMP0063)
+  cmake_policy(SET CMP0063 NEW)
+endif()
+
 if (COMMAND set_up_hermetic_build)
   set_up_hermetic_build()
 endif()


### PR DESCRIPTION
This removes warnings when using CMake >= 3.3 if you have symbol visibility set.