### PR TITLE
Fix background color in ColoredPrintf

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -2979,13 +2979,15 @@ void ColoredPrintf(GTestColor color, const char* fmt, ...) {
   CONSOLE_SCREEN_BUFFER_INFO buffer_info;
   GetConsoleScreenBufferInfo(stdout_handle, &buffer_info);
   const WORD old_color_attrs = buffer_info.wAttributes;
-
+  // Let's reuse the BG
+  const WORD existing_bg = old_color_attrs & 0x00F0;
+  
   // We need to flush the stream buffers into the console before each
   // SetConsoleTextAttribute call lest it affect the text that is already
   // printed but has not yet reached the console.
   fflush(stdout);
   SetConsoleTextAttribute(stdout_handle,
-                          GetColorAttribute(color) | FOREGROUND_INTENSITY);
+                          GetColorAttribute(color) | existing_bg | FOREGROUND_INTENSITY);
   vprintf(fmt, args);
 
   fflush(stdout);

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -2980,7 +2980,8 @@ void ColoredPrintf(GTestColor color, const char* fmt, ...) {
   GetConsoleScreenBufferInfo(stdout_handle, &buffer_info);
   const WORD old_color_attrs = buffer_info.wAttributes;
   // Let's reuse the BG
-  const WORD existing_bg = old_color_attrs & 0x00F0;
+  const WORD background_mask = BACKGROUND_BLUE | BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_INTENSITY;   
+  const WORD existing_bg = old_color_attrs & background_mask;
   
   // We need to flush the stream buffers into the console before each
   // SetConsoleTextAttribute call lest it affect the text that is already

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -2895,7 +2895,7 @@ WORD GetColorAttribute(GTestColor color) {
 }
 
 int GetBgOffset(WORD background_mask) {
-  if (background_mask == 0) return 0; //let's not fall into infinite loop
+  if (background_mask == 0) return 0;
 
   int bitOffset = 0;
   while((background_mask & 1) == 0) {
@@ -2905,6 +2905,16 @@ int GetBgOffset(WORD background_mask) {
   return bitOffset;
 }
 
+int GetFgOffset(WORD foreground_mask) {
+  if (foreground_mask == 0) return 0;
+
+  int bitOffset = 0;
+  while((foreground_mask & 1) == 0) {
+    foreground_mask >>= 1;
+    ++bitOffset;
+  }
+  return bitOffset;
+}
 WORD GetNewColor(GTestColor color, WORD old_color_attrs) {
   // Let's reuse the BG
   static const WORD background_mask = BACKGROUND_BLUE | BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_INTENSITY;
@@ -2912,9 +2922,12 @@ WORD GetNewColor(GTestColor color, WORD old_color_attrs) {
   const WORD existing_bg = old_color_attrs & background_mask;
 
   WORD new_color = GetColorAttribute(color) | existing_bg | FOREGROUND_INTENSITY;
-  static const int bg_bitOffset = GetBgOffset(background_mask); //it does not change 
+  static const int bg_bitOffset = GetBgOffset(background_mask);
+  static const int fg_bitOffset = GetFgOffset(foreground_mask);
 
-  if (((new_color & background_mask) >> bg_bitOffset) == (new_color & foreground_mask)) new_color ^= FOREGROUND_INTENSITY; //revert intensity
+  if (((new_color & background_mask) >> bg_bitOffset) == ((new_color & foreground_mask) >> fg_bitOffset)) {
+    new_color ^= FOREGROUND_INTENSITY; //invert intensity
+  }
   return new_color;
 }
 	

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -2894,27 +2894,17 @@ WORD GetColorAttribute(GTestColor color) {
   }
 }
 
-int GetBgOffset(WORD background_mask) {
-  if (background_mask == 0) return 0;
+int GetBitOffset(WORD color_mask) {
+  if (color_mask == 0) return 0;
 
   int bitOffset = 0;
-  while((background_mask & 1) == 0) {
-    background_mask >>= 1;
+  while((color_mask & 1) == 0) {
+    color_mask >>= 1;
     ++bitOffset;
   }
   return bitOffset;
 }
 
-int GetFgOffset(WORD foreground_mask) {
-  if (foreground_mask == 0) return 0;
-
-  int bitOffset = 0;
-  while((foreground_mask & 1) == 0) {
-    foreground_mask >>= 1;
-    ++bitOffset;
-  }
-  return bitOffset;
-}
 WORD GetNewColor(GTestColor color, WORD old_color_attrs) {
   // Let's reuse the BG
   static const WORD background_mask = BACKGROUND_BLUE | BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_INTENSITY;
@@ -2922,8 +2912,8 @@ WORD GetNewColor(GTestColor color, WORD old_color_attrs) {
   const WORD existing_bg = old_color_attrs & background_mask;
 
   WORD new_color = GetColorAttribute(color) | existing_bg | FOREGROUND_INTENSITY;
-  static const int bg_bitOffset = GetBgOffset(background_mask);
-  static const int fg_bitOffset = GetFgOffset(foreground_mask);
+  static const int bg_bitOffset = GetBitOffset(background_mask);
+  static const int fg_bitOffset = GetBitOffset(foreground_mask);
 
   if (((new_color & background_mask) >> bg_bitOffset) == ((new_color & foreground_mask) >> fg_bitOffset)) {
     new_color ^= FOREGROUND_INTENSITY; //invert intensity

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -2905,7 +2905,7 @@ int GetBgOffset(WORD background_mask) {
   return bitOffset;
 }
 
-WORD GetNewColor(const GTestColor color, const WORD old_color_attrs) {
+WORD GetNewColor(GTestColor color, WORD old_color_attrs) {
   // Let's reuse the BG
   static const WORD background_mask = BACKGROUND_BLUE | BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_INTENSITY;
   static const WORD foreground_mask = FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY;


### PR DESCRIPTION
Re-use existing background color for Widows' console window.
Before fix:
![before](https://user-images.githubusercontent.com/6968100/27320084-823a1908-55cf-11e7-9108-cfce611d4371.PNG)

After fix:
![after](https://user-images.githubusercontent.com/6968100/27320085-825c9b18-55cf-11e7-8edb-07887607798a.PNG)

This fixes a problem where the background color for ColoredPrintf would be BLACK even if the user's console is using a different BG color.