### PR TITLE
rvalue-only object streaming to Message

### DIFF
--- a/googletest/include/gtest/gtest-message.h
+++ b/googletest/include/gtest/gtest-message.h
@@ -154,6 +154,25 @@ class GTEST_API_ Message {
     }
     return *this;
   }
+
+#if __cplusplus >= 201103L
+  // Streams a non-pointer rvalue to this object.
+  //
+  // This is so that objects which can only be streamed as rvalue-references
+  // work.
+  template <typename T>
+  inline Message& operator <<(const T&& val) {
+    using ::operator <<;
+    *ss_ << std::move(val);
+    return *this;
+  }
+
+  // Streams a pointer rvalue to this object.
+  template <typename T>
+  inline Message& operator <<(T* const&& pointer) {
+    return *this << pointer;
+  }
+#endif  // __cplusplus >= 201103L
 #endif  // GTEST_OS_SYMBIAN
 
   // Since the basic IO manipulators are overloaded for both narrow

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -5266,6 +5266,26 @@ TEST(MessageTest, NullPointers) {
                msg.GetString().c_str());
 }
 
+#if __cplusplus >= 201103L
+namespace {
+  struct rvalue_streamable {};
+  std::ostream& operator<<(std::ostream& os, rvalue_streamable const&&) {
+    os << "rvalue";
+    return os;
+  }
+  std::ostream& operator<<(std::ostream&& os, rvalue_streamable const&& x) {
+    return os << std::move(x);
+  }
+} // anonymous namespace
+// Tests streaming NULL pointers to testing::Message.
+TEST(MessageTest, RvalueStreaming) {
+  Message msg;
+
+  msg << rvalue_streamable();
+  ASSERT_STREQ("rvalue", msg.GetString().c_str());
+}
+#endif
+
 // Tests streaming wide strings to testing::Message.
 TEST(MessageTest, WideStrings) {
   // Streams a NULL of type const wchar_t*.


### PR DESCRIPTION
Some objects are designed to exist only as temporaries while a single statement is evaluated. They typically capture constructor parameters by reference and do other things which are not safe for long-lived objects.

One way to make it more difficult for these objects to be used incorrectly is to define all the public methods/operators/etc such that only `&&` and `const&&` parameters are permitted. In this case the expected streaming operator declaration for such a `Type` is `std::ostream& operator<<(std::ostream&, Type const&&)`. For correctness, `std::ostream& operator<<(std::ostream&, Type const&)` would not be implemented.

This change allows such objects to be used with googletest Message objects.