### PR TITLE
Implement GNUInstallDirs; Add option to skip installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ project( googletest-distribution )
 
 enable_testing()
 
+include(GNUInstallDirs)
+
+option(ENABLE_GOOGLETEST_INSTALL "Turn off to skip installation" ON)
 option(BUILD_GTEST "Builds the googletest subproject" OFF)
 
 #Note that googlemock target already builds googletest

--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -103,10 +103,14 @@ endif()
 ########################################################################
 #
 # Install rules
-install(TARGETS gmock gmock_main
-  DESTINATION lib)
-install(DIRECTORY ${gmock_SOURCE_DIR}/include/gmock
-  DESTINATION include)
+if(ENABLE_GOOGLETEST_INSTALL)
+  install(TARGETS gmock gmock_main
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  install(DIRECTORY ${gmock_SOURCE_DIR}/include/gmock
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif(ENABLE_GOOGLETEST_INSTALL)
 
 ########################################################################
 #

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -102,10 +102,14 @@ endif()
 ########################################################################
 #
 # Install rules
-install(TARGETS gtest gtest_main
-  DESTINATION lib)
-install(DIRECTORY ${gtest_SOURCE_DIR}/include/gtest
-  DESTINATION include)
+if(ENABLE_GOOGLETEST_INSTALL)
+  install(TARGETS gtest gtest_main
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  install(DIRECTORY ${gtest_SOURCE_DIR}/include/gtest
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif(ENABLE_GOOGLETEST_INSTALL)
 
 ########################################################################
 #


### PR DESCRIPTION
using cmake module GNUInstallDirs fixes targeting the wrong directory 'lib' when the real target directory is 'lib64'

Added option to skip installation; added because of chain from 'libshaderc' which uses this.