### PR TITLE
Add function name to exception if there's no default action

### DIFF
--- a/googlemock/src/gmock-spec-builders.cc
+++ b/googlemock/src/gmock-spec-builders.cc
@@ -364,7 +364,7 @@ UntypedFunctionMockerBase::UntypedInvokeWith(const void* const untyped_args)
 
     if (!need_to_report_uninteresting_call) {
       // Perform the action without printing the call information.
-      return this->UntypedPerformDefaultAction(untyped_args, "");
+      return this->UntypedPerformDefaultAction(untyped_args, "Function call: " + std::string(Name()));
     }
 
     // Warns about the uninteresting call.


### PR DESCRIPTION
Adds the name of the mocked method to the exception that is thrown on NiceMock objects if there is no default action for the return type.