### PR TITLE
 Fix library install destinations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,22 @@ project( googletest-distribution )
 
 enable_testing()
 
+include(CMakeDependentOption)
+if (CMAKE_VERSION VERSION_LESS 2.8.5)
+  set(CMAKE_INSTALL_BINDIR "bin" CACHE STRING "User executables (bin)")
+  set(CMAKE_INSTALL_LIBDIR "lib${LIB_SUFFIX}" CACHE STRING "Object code libraries (lib)")
+  set(CMAKE_INSTALL_INCLUDEDIR "include" CACHE STRING "C header files (include)")
+  mark_as_advanced(CMAKE_INSTALL_BINDIR CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_INCLUDEDIR)
+else()
+  include(GNUInstallDirs)
+endif()
+
 option(BUILD_GTEST "Builds the googletest subproject" OFF)
+cmake_dependent_option(INSTALL_GTEST "Enable installation of googletest. (Projects embedding googletest may want to turn this OFF.)" ON "BUILD_GTEST OR BUILD_GMOCK" OFF)
 
 #Note that googlemock target already builds googletest
 option(BUILD_GMOCK "Builds the googlemock subproject" ON)
+cmake_dependent_option(INSTALL_GMOCK "Enable installation of googlemock. (Projects embedding googlemock may want to turn this OFF.)" ON "BUILD_GMOCK" OFF)
 
 if(BUILD_GMOCK)
   add_subdirectory( googlemock )

--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -103,10 +103,14 @@ endif()
 ########################################################################
 #
 # Install rules
-install(TARGETS gmock gmock_main
-  DESTINATION lib)
-install(DIRECTORY ${gmock_SOURCE_DIR}/include/gmock
-  DESTINATION include)
+if(INSTALL_GMOCK)
+  install(TARGETS gmock gmock_main
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  install(DIRECTORY ${gmock_SOURCE_DIR}/include/gmock
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()
 
 ########################################################################
 #

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -102,10 +102,14 @@ endif()
 ########################################################################
 #
 # Install rules
-install(TARGETS gtest gtest_main
-  DESTINATION lib)
-install(DIRECTORY ${gtest_SOURCE_DIR}/include/gtest
-  DESTINATION include)
+if(INSTALL_GTEST)
+  install(TARGETS gtest gtest_main
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  install(DIRECTORY ${gtest_SOURCE_DIR}/include/gtest
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()
 
 ########################################################################
 #


### PR DESCRIPTION
Modify library install destinations to install .dll's to the correct location (`bin`, not `lib`), and to install other artifacts to the correct platform-dependent location by honoring `LIB_SUFFIX`. This is required for some distributions (e.g. Fedora) and will fix an issue that otherwise requires those distributions to patch the upstream sources.

Fixes #1161.
