### PR TITLE
[Fix 546] Added general macros MOCK_QUALIFIED_METHOD*. (--rebased--)

### DIFF
--- a/googlemock/include/gmock/gmock-generated-function-mockers.h
+++ b/googlemock/include/gmock/gmock-generated-function-mockers.h
@@ -320,6 +320,16 @@ class FunctionMocker<R(A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)> : public
   }
 };
 
+
+template <typename T>
+T& RemoveVolatileCast(T& v) {
+  return v;
+}
+template <typename T>
+T& RemoveVolatileCast(T volatile& v) {
+  return const_cast<T&>(v);
+}
+
 }  // namespace internal
 
 // The style guide prohibits "using" statements in a namespace scope
@@ -349,165 +359,203 @@ using internal::FunctionMocker;
 
 // The variable for mocking the given method.
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_MOCKER_(arity, constness, Method) \
-    GTEST_CONCAT_TOKEN_(gmock##constness##arity##_##Method##_, __LINE__)
+#define GMOCK_MOCKER_(arity, Method) \
+    GTEST_CONCAT_TOKEN_(gmock##arity##_##Method##_, __LINE__)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD0_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD0_(tn, qualifiers, ct, Method, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
-      ) constness { \
+      ) qualifiers { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 0), \
         this_method_does_not_take_0_arguments); \
-    GMOCK_MOCKER_(0, constness, Method).SetOwnerAndName(this, #Method); \
-    return GMOCK_MOCKER_(0, constness, Method).Invoke(); \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(0, Method) \
+        .SetOwnerAndName(& ::testing::internal::RemoveVolatileCast(*this), #Method); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(0, Method) \
+        .Invoke(); \
   } \
-  ::testing::MockSpec<__VA_ARGS__>& \
-      gmock_##Method() constness { \
-    GMOCK_MOCKER_(0, constness, Method).RegisterOwner(this); \
-    return GMOCK_MOCKER_(0, constness, Method).With(); \
+  ::testing::MockSpec<__VA_ARGS__>& gmock_##Method() qualifiers { \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(0, Method) \
+        .RegisterOwner(& ::testing::internal::RemoveVolatileCast(*this)); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(0, Method) \
+        .With(); \
   } \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(0, constness, \
-      Method)
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(0, Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD1_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD1_(tn, qualifiers, ct, Method, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
-      GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1) constness { \
+      GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1) qualifiers { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 1), \
         this_method_does_not_take_1_argument); \
-    GMOCK_MOCKER_(1, constness, Method).SetOwnerAndName(this, #Method); \
-    return GMOCK_MOCKER_(1, constness, Method).Invoke(gmock_a1); \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(1, Method) \
+        .SetOwnerAndName(& ::testing::internal::RemoveVolatileCast(*this), #Method); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(1, Method) \
+        .Invoke(gmock_a1); \
   } \
   ::testing::MockSpec<__VA_ARGS__>& \
-      gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1) constness { \
-    GMOCK_MOCKER_(1, constness, Method).RegisterOwner(this); \
-    return GMOCK_MOCKER_(1, constness, Method).With(gmock_a1); \
+      gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1) qualifiers { \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(1, Method) \
+        .RegisterOwner(& ::testing::internal::RemoveVolatileCast(*this)); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(1, Method) \
+        .With(gmock_a1); \
   } \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(1, constness, \
-      Method)
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(1, Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD2_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD2_(tn, qualifiers, ct, Method, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
-      GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2) constness { \
+      GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2) qualifiers { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 2), \
         this_method_does_not_take_2_arguments); \
-    GMOCK_MOCKER_(2, constness, Method).SetOwnerAndName(this, #Method); \
-    return GMOCK_MOCKER_(2, constness, Method).Invoke(gmock_a1, gmock_a2); \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(2, Method) \
+        .SetOwnerAndName(& ::testing::internal::RemoveVolatileCast(*this), #Method); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(2, Method) \
+        .Invoke(gmock_a1, gmock_a2); \
   } \
   ::testing::MockSpec<__VA_ARGS__>& \
       gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
-                     GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2) constness { \
-    GMOCK_MOCKER_(2, constness, Method).RegisterOwner(this); \
-    return GMOCK_MOCKER_(2, constness, Method).With(gmock_a1, gmock_a2); \
+                     GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2) qualifiers { \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(2, Method) \
+        .RegisterOwner(& ::testing::internal::RemoveVolatileCast(*this)); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(2, Method) \
+        .With(gmock_a1, gmock_a2); \
   } \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(2, constness, \
-      Method)
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(2, Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD3_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD3_(tn, qualifiers, ct, Method, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
       GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
-      GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3) constness { \
+      GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3) qualifiers { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 3), \
         this_method_does_not_take_3_arguments); \
-    GMOCK_MOCKER_(3, constness, Method).SetOwnerAndName(this, #Method); \
-    return GMOCK_MOCKER_(3, constness, Method).Invoke(gmock_a1, gmock_a2, \
-        gmock_a3); \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(3, Method) \
+        .SetOwnerAndName(& ::testing::internal::RemoveVolatileCast(*this), #Method); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(3, Method) \
+        .Invoke(gmock_a1, gmock_a2, gmock_a3); \
   } \
   ::testing::MockSpec<__VA_ARGS__>& \
       gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
                      GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2, \
-                     GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3) constness { \
-    GMOCK_MOCKER_(3, constness, Method).RegisterOwner(this); \
-    return GMOCK_MOCKER_(3, constness, Method).With(gmock_a1, gmock_a2, \
-        gmock_a3); \
+                     GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3) qualifiers { \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(3, Method) \
+        .RegisterOwner(& ::testing::internal::RemoveVolatileCast(*this)); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(3, Method) \
+        .With(gmock_a1, gmock_a2, gmock_a3); \
   } \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(3, constness, \
-      Method)
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(3, Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD4_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD4_(tn, qualifiers, ct, Method, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
       GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
       GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
-      GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4) constness { \
+      GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4) qualifiers { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 4), \
         this_method_does_not_take_4_arguments); \
-    GMOCK_MOCKER_(4, constness, Method).SetOwnerAndName(this, #Method); \
-    return GMOCK_MOCKER_(4, constness, Method).Invoke(gmock_a1, gmock_a2, \
-        gmock_a3, gmock_a4); \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(4, Method) \
+        .SetOwnerAndName(& ::testing::internal::RemoveVolatileCast(*this), #Method); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(4, Method) \
+        .Invoke(gmock_a1, gmock_a2, gmock_a3, gmock_a4); \
   } \
   ::testing::MockSpec<__VA_ARGS__>& \
       gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
                      GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2, \
                      GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3, \
-                     GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4) constness { \
-    GMOCK_MOCKER_(4, constness, Method).RegisterOwner(this); \
-    return GMOCK_MOCKER_(4, constness, Method).With(gmock_a1, gmock_a2, \
-        gmock_a3, gmock_a4); \
+                     GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4) qualifiers { \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(4, Method) \
+        .RegisterOwner(& ::testing::internal::RemoveVolatileCast(*this)); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(4, Method) \
+        .With(gmock_a1, gmock_a2, gmock_a3, gmock_a4); \
   } \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(4, constness, \
-      Method)
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(4, Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD5_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD5_(tn, qualifiers, ct, Method, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
       GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
       GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
       GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, \
-      GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5) constness { \
+      GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5) qualifiers { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 5), \
         this_method_does_not_take_5_arguments); \
-    GMOCK_MOCKER_(5, constness, Method).SetOwnerAndName(this, #Method); \
-    return GMOCK_MOCKER_(5, constness, Method).Invoke(gmock_a1, gmock_a2, \
-        gmock_a3, gmock_a4, gmock_a5); \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(5, Method) \
+        .SetOwnerAndName(& ::testing::internal::RemoveVolatileCast(*this), #Method); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(5, Method) \
+        .Invoke(gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5); \
   } \
   ::testing::MockSpec<__VA_ARGS__>& \
       gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
                      GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2, \
                      GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3, \
                      GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4, \
-                     GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5) constness { \
-    GMOCK_MOCKER_(5, constness, Method).RegisterOwner(this); \
-    return GMOCK_MOCKER_(5, constness, Method).With(gmock_a1, gmock_a2, \
-        gmock_a3, gmock_a4, gmock_a5); \
+                     GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5) qualifiers { \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(5, Method) \
+        .RegisterOwner(& ::testing::internal::RemoveVolatileCast(*this)); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(5, Method) \
+        .With(gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5); \
   } \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(5, constness, \
-      Method)
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(5, Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD6_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD6_(tn, qualifiers, ct, Method, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
       GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
       GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
       GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, \
       GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5, \
-      GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6) constness { \
+      GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6) qualifiers { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 6), \
         this_method_does_not_take_6_arguments); \
-    GMOCK_MOCKER_(6, constness, Method).SetOwnerAndName(this, #Method); \
-    return GMOCK_MOCKER_(6, constness, Method).Invoke(gmock_a1, gmock_a2, \
-        gmock_a3, gmock_a4, gmock_a5, gmock_a6); \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(6, Method) \
+        .SetOwnerAndName(& ::testing::internal::RemoveVolatileCast(*this), #Method); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(6, Method) \
+        .Invoke(gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6); \
   } \
   ::testing::MockSpec<__VA_ARGS__>& \
       gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
@@ -515,16 +563,18 @@ using internal::FunctionMocker;
                      GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3, \
                      GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4, \
                      GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5, \
-                     GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6) constness { \
-    GMOCK_MOCKER_(6, constness, Method).RegisterOwner(this); \
-    return GMOCK_MOCKER_(6, constness, Method).With(gmock_a1, gmock_a2, \
-        gmock_a3, gmock_a4, gmock_a5, gmock_a6); \
+                     GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6) qualifiers { \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(6, Method) \
+        .RegisterOwner(& ::testing::internal::RemoveVolatileCast(*this)); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(6, Method) \
+        .With(gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6); \
   } \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(6, constness, \
-      Method)
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(6, Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD7_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD7_(tn, qualifiers, ct, Method, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
       GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
@@ -532,14 +582,17 @@ using internal::FunctionMocker;
       GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, \
       GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5, \
       GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
-      GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7) constness { \
+      GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7) qualifiers { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 7), \
         this_method_does_not_take_7_arguments); \
-    GMOCK_MOCKER_(7, constness, Method).SetOwnerAndName(this, #Method); \
-    return GMOCK_MOCKER_(7, constness, Method).Invoke(gmock_a1, gmock_a2, \
-        gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7); \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(7, Method) \
+        .SetOwnerAndName(& ::testing::internal::RemoveVolatileCast(*this), #Method); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(7, Method) \
+        .Invoke(gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7); \
   } \
   ::testing::MockSpec<__VA_ARGS__>& \
       gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
@@ -548,16 +601,18 @@ using internal::FunctionMocker;
                      GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4, \
                      GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5, \
                      GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6, \
-                     GMOCK_MATCHER_(tn, 7, __VA_ARGS__) gmock_a7) constness { \
-    GMOCK_MOCKER_(7, constness, Method).RegisterOwner(this); \
-    return GMOCK_MOCKER_(7, constness, Method).With(gmock_a1, gmock_a2, \
-        gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7); \
+                     GMOCK_MATCHER_(tn, 7, __VA_ARGS__) gmock_a7) qualifiers { \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(7, Method) \
+        .RegisterOwner(& ::testing::internal::RemoveVolatileCast(*this)); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(7, Method) \
+        .With(gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7); \
   } \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(7, constness, \
-      Method)
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(7, Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD8_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD8_(tn, qualifiers, ct, Method, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
       GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
@@ -566,14 +621,17 @@ using internal::FunctionMocker;
       GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5, \
       GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
       GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7, \
-      GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8) constness { \
+      GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8) qualifiers { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 8), \
         this_method_does_not_take_8_arguments); \
-    GMOCK_MOCKER_(8, constness, Method).SetOwnerAndName(this, #Method); \
-    return GMOCK_MOCKER_(8, constness, Method).Invoke(gmock_a1, gmock_a2, \
-        gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8); \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(8, Method) \
+        .SetOwnerAndName(& ::testing::internal::RemoveVolatileCast(*this), #Method); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(8, Method) \
+        .Invoke(gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8); \
   } \
   ::testing::MockSpec<__VA_ARGS__>& \
       gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
@@ -583,16 +641,18 @@ using internal::FunctionMocker;
                      GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5, \
                      GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6, \
                      GMOCK_MATCHER_(tn, 7, __VA_ARGS__) gmock_a7, \
-                     GMOCK_MATCHER_(tn, 8, __VA_ARGS__) gmock_a8) constness { \
-    GMOCK_MOCKER_(8, constness, Method).RegisterOwner(this); \
-    return GMOCK_MOCKER_(8, constness, Method).With(gmock_a1, gmock_a2, \
-        gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8); \
+                     GMOCK_MATCHER_(tn, 8, __VA_ARGS__) gmock_a8) qualifiers { \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(8, Method) \
+        .RegisterOwner(& ::testing::internal::RemoveVolatileCast(*this)); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(8, Method) \
+        .With(gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8); \
   } \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(8, constness, \
-      Method)
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(8, Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD9_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD9_(tn, qualifiers, ct, Method, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
       GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
@@ -602,15 +662,17 @@ using internal::FunctionMocker;
       GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
       GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7, \
       GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8, \
-      GMOCK_ARG_(tn, 9, __VA_ARGS__) gmock_a9) constness { \
+      GMOCK_ARG_(tn, 9, __VA_ARGS__) gmock_a9) qualifiers { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 9), \
         this_method_does_not_take_9_arguments); \
-    GMOCK_MOCKER_(9, constness, Method).SetOwnerAndName(this, #Method); \
-    return GMOCK_MOCKER_(9, constness, Method).Invoke(gmock_a1, gmock_a2, \
-        gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, \
-        gmock_a9); \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(9, Method) \
+        .SetOwnerAndName(& ::testing::internal::RemoveVolatileCast(*this), #Method); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(9, Method) \
+        .Invoke(gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9); \
   } \
   ::testing::MockSpec<__VA_ARGS__>& \
       gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
@@ -621,17 +683,18 @@ using internal::FunctionMocker;
                      GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6, \
                      GMOCK_MATCHER_(tn, 7, __VA_ARGS__) gmock_a7, \
                      GMOCK_MATCHER_(tn, 8, __VA_ARGS__) gmock_a8, \
-                     GMOCK_MATCHER_(tn, 9, __VA_ARGS__) gmock_a9) constness { \
-    GMOCK_MOCKER_(9, constness, Method).RegisterOwner(this); \
-    return GMOCK_MOCKER_(9, constness, Method).With(gmock_a1, gmock_a2, \
-        gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, \
-        gmock_a9); \
+                     GMOCK_MATCHER_(tn, 9, __VA_ARGS__) gmock_a9) qualifiers { \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(9, Method) \
+        .RegisterOwner(& ::testing::internal::RemoveVolatileCast(*this)); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(9, Method) \
+        .With(gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9); \
   } \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(9, constness, \
-      Method)
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(9, Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD10_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD10_(tn, qualifiers, ct, Method, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, \
       GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2, \
@@ -642,15 +705,17 @@ using internal::FunctionMocker;
       GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7, \
       GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8, \
       GMOCK_ARG_(tn, 9, __VA_ARGS__) gmock_a9, \
-      GMOCK_ARG_(tn, 10, __VA_ARGS__) gmock_a10) constness { \
+      GMOCK_ARG_(tn, 10, __VA_ARGS__) gmock_a10) qualifiers { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
             == 10), \
         this_method_does_not_take_10_arguments); \
-    GMOCK_MOCKER_(10, constness, Method).SetOwnerAndName(this, #Method); \
-    return GMOCK_MOCKER_(10, constness, Method).Invoke(gmock_a1, gmock_a2, \
-        gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, \
-        gmock_a10); \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(10, Method) \
+        .SetOwnerAndName(& ::testing::internal::RemoveVolatileCast(*this), #Method); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(10, Method) \
+        .Invoke(gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10); \
   } \
   ::testing::MockSpec<__VA_ARGS__>& \
       gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
@@ -663,14 +728,15 @@ using internal::FunctionMocker;
                      GMOCK_MATCHER_(tn, 8, __VA_ARGS__) gmock_a8, \
                      GMOCK_MATCHER_(tn, 9, __VA_ARGS__) gmock_a9, \
                      GMOCK_MATCHER_(tn, 10, \
-                         __VA_ARGS__) gmock_a10) constness { \
-    GMOCK_MOCKER_(10, constness, Method).RegisterOwner(this); \
-    return GMOCK_MOCKER_(10, constness, Method).With(gmock_a1, gmock_a2, \
-        gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, \
-        gmock_a10); \
+                         __VA_ARGS__) gmock_a10) qualifiers { \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(10, Method) \
+        .RegisterOwner(& ::testing::internal::RemoveVolatileCast(*this)); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_(10, Method) \
+        .With(gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, gmock_a10); \
   } \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(10, constness, \
-      Method)
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(10, Method)
 
 #define MOCK_METHOD0(m, ...) GMOCK_METHOD0_(, , , m, __VA_ARGS__)
 #define MOCK_METHOD1(m, ...) GMOCK_METHOD1_(, , , m, __VA_ARGS__)
@@ -822,6 +888,99 @@ using internal::FunctionMocker;
     GMOCK_METHOD9_(typename, const, ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD10_T_WITH_CALLTYPE(ct, m, ...) \
     GMOCK_METHOD10_(typename, const, ct, m, __VA_ARGS__)
+
+#define MOCK_QUALIFIED_METHOD0(m, qualifiers, ...) \
+    GMOCK_METHOD0_(, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD1(m, qualifiers, ...) \
+    GMOCK_METHOD1_(, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD2(m, qualifiers, ...) \
+    GMOCK_METHOD2_(, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD3(m, qualifiers, ...) \
+    GMOCK_METHOD3_(, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD4(m, qualifiers, ...) \
+    GMOCK_METHOD4_(, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD5(m, qualifiers, ...) \
+    GMOCK_METHOD5_(, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD6(m, qualifiers, ...) \
+    GMOCK_METHOD6_(, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD7(m, qualifiers, ...) \
+    GMOCK_METHOD7_(, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD8(m, qualifiers, ...) \
+    GMOCK_METHOD8_(, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD9(m, qualifiers, ...) \
+    GMOCK_METHOD9_(, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD10(m, qualifiers, ...) \
+    GMOCK_METHOD10_(, qualifiers, , m, __VA_ARGS__)
+
+#define MOCK_QUALIFIED_METHOD0_T(m, qualifiers, ...) \
+    GMOCK_METHOD0_(typename, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD1_T(m, qualifiers, ...) \
+    GMOCK_METHOD1_(typename, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD2_T(m, qualifiers, ...) \
+    GMOCK_METHOD2_(typename, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD3_T(m, qualifiers, ...) \
+    GMOCK_METHOD3_(typename, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD4_T(m, qualifiers, ...) \
+    GMOCK_METHOD4_(typename, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD5_T(m, qualifiers, ...) \
+    GMOCK_METHOD5_(typename, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD6_T(m, qualifiers, ...) \
+    GMOCK_METHOD6_(typename, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD7_T(m, qualifiers, ...) \
+    GMOCK_METHOD7_(typename, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD8_T(m, qualifiers, ...) \
+    GMOCK_METHOD8_(typename, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD9_T(m, qualifiers, ...) \
+    GMOCK_METHOD9_(typename, qualifiers, , m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD10_T(m, qualifiers, ...) \
+    GMOCK_METHOD10_(typename, qualifiers, , m, __VA_ARGS__)
+
+#define MOCK_QUALIFIED_METHOD0_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD0_(, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD1_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD1_(, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD2_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD2_(, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD3_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD3_(, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD4_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD4_(, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD5_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD5_(, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD6_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD6_(, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD7_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD7_(, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD8_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD8_(, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD9_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD9_(, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD10_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD10_(, qualifiers, ct, m, __VA_ARGS__)
+
+#define MOCK_QUALIFIED_METHOD0_T_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD0_(typename, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD1_T_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD1_(typename, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD2_T_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD2_(typename, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD3_T_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD3_(typename, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD4_T_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD4_(typename, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD5_T_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD5_(typename, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD6_T_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD6_(typename, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD7_T_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD7_(typename, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD8_T_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD8_(typename, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD9_T_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD9_(typename, qualifiers, ct, m, __VA_ARGS__)
+#define MOCK_QUALIFIED_METHOD10_T_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD10_(typename, qualifiers, ct, m, __VA_ARGS__)
+
 
 // A MockFunction<F> class has one mock method whose type is F.  It is
 // useful when you just want your test code to emit some messages and

--- a/googlemock/include/gmock/gmock-generated-function-mockers.h.pump
+++ b/googlemock/include/gmock/gmock-generated-function-mockers.h.pump
@@ -99,6 +99,16 @@ $if i >= 1 [[
 
 
 ]]
+
+template <typename T>
+T& RemoveVolatileCast(T& v) {
+  return v;
+}
+template <typename T>
+T& RemoveVolatileCast(T volatile& v) {
+  return const_cast<T&>(v);
+}
+
 }  // namespace internal
 
 // The style guide prohibits "using" statements in a namespace scope
@@ -128,9 +138,8 @@ using internal::FunctionMocker;
 
 // The variable for mocking the given method.
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_MOCKER_(arity, constness, Method) \
-    GTEST_CONCAT_TOKEN_(gmock##constness##arity##_##Method##_, __LINE__)
-
+#define GMOCK_MOCKER_(arity, Method) \
+    GTEST_CONCAT_TOKEN_(gmock##arity##_##Method##_, __LINE__)
 
 $for i [[
 $range j 1..i
@@ -140,24 +149,34 @@ $var as = [[$for j, [[gmock_a$j]]]]
 $var matcher_as = [[$for j, \
                      [[GMOCK_MATCHER_(tn, $j, __VA_ARGS__) gmock_a$j]]]]
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD$i[[]]_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD$i[[]]_(tn, qualifiers, ct, Method, ...) \
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
-      $arg_as) constness { \
+      $arg_as) qualifiers { \
     GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
         tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value == $i), \
         this_method_does_not_take_$i[[]]_argument[[$if i != 1 [[s]]]]); \
-    GMOCK_MOCKER_($i, constness, Method).SetOwnerAndName(this, #Method); \
-    return GMOCK_MOCKER_($i, constness, Method).Invoke($as); \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_($i, Method) \
+        .SetOwnerAndName(& ::testing::internal::RemoveVolatileCast(*this), #Method); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_($i, Method) \
+        .Invoke($as); \
   } \
   ::testing::MockSpec<__VA_ARGS__>& \
-      gmock_##Method($matcher_as) constness { \
-    GMOCK_MOCKER_($i, constness, Method).RegisterOwner(this); \
-    return GMOCK_MOCKER_($i, constness, Method).With($as); \
+      gmock_##Method($matcher_as) qualifiers { \
+    ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_($i, Method) \
+        .RegisterOwner(& ::testing::internal::RemoveVolatileCast(*this); \
+    return ::testing::internal::RemoveVolatileCast(*this) \
+        .GMOCK_MOCKER_($i, Method) \
+        .With($as); \
   } \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_($i, constness, Method)
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_($i, Method)
 
 
 ]]
+
+
 $for i [[
 #define MOCK_METHOD$i(m, ...) GMOCK_METHOD$i[[]]_(, , , m, __VA_ARGS__)
 
@@ -209,6 +228,35 @@ $for i [[
     GMOCK_METHOD$i[[]]_(typename, const, ct, m, __VA_ARGS__)
 
 ]]
+
+
+$for i [[
+#define MOCK_QUALIFIED_METHOD$i[[]](m, qualifiers, ...) \
+    GMOCK_METHOD$i[[]]_(, qualifiers, , m, __VA_ARGS__)
+
+]]
+
+
+$for i [[
+#define MOCK_QUALIFIED_METHOD$i[[]]_T(m, qualifiers, ...) \
+    GMOCK_METHOD$i[[]]_(typename, qualifiers, , m, __VA_ARGS__)
+
+]]
+
+
+$for i [[
+#define MOCK_QUALIFIED_METHOD$i[[]]_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD$i[[]]_(, qualifiers, ct, m, __VA_ARGS__)
+
+]]
+
+
+$for i [[
+#define MOCK_QUALIFIED_METHOD$i[[]]_T_WITH_CALLTYPE(ct, m, qualifiers, ...) \
+    GMOCK_METHOD$i[[]]_(typename, qualifiers, ct, m, __VA_ARGS__)
+
+]]
+
 
 // A MockFunction<F> class has one mock method whose type is F.  It is
 // useful when you just want your test code to emit some messages and

--- a/googlemock/test/gmock-generated-function-mockers_test.cc
+++ b/googlemock/test/gmock-generated-function-mockers_test.cc
@@ -109,6 +109,7 @@ class FooInterface {
   (bool b, char c, short d, int e, long f,  // NOLINT
    float g, double h, unsigned i, char* j, const std::string& k) = 0;
   STDMETHOD_(char, CTConst)(int x) const = 0;
+  STDMETHOD_(char, CTVolatile)(int x) volatile = 0;
 #endif  // GTEST_OS_WINDOWS
 };
 
@@ -168,6 +169,8 @@ class MockFoo : public FooInterface {
                                   float g, double h, unsigned i, char* j,
                                   const std::string& k));
   MOCK_CONST_METHOD1_WITH_CALLTYPE(STDMETHODCALLTYPE, CTConst, char(int));
+  MOCK_QUALIFIED_METHOD1_WITH_CALLTYPE(STDMETHODCALLTYPE, CTVolatile,
+                                       volatile, char(int x));
 
   // Tests that the function return type can contain unprotected comma.
   MOCK_METHOD0_WITH_CALLTYPE(STDMETHODCALLTYPE, CTReturnTypeWithComma,
@@ -342,6 +345,12 @@ TEST_F(FunctionMockerTest, MocksFunctionsConstFunctionWithCallType) {
   EXPECT_EQ('a', Const(*foo_).CTConst(0));
 }
 
+TEST_F(FunctionMockerTest, MocksFunctionsVolatileFunctionWithCallType) {
+  EXPECT_CALL(mock_foo_, CTVolatile(_))
+      .WillOnce(Return('v'));
+
+  EXPECT_EQ('v', foo_->CTVolatile(0));
+}
 TEST_F(FunctionMockerTest, MocksReturnTypeWithCommaAndCallType) {
   const std::map<int, std::string> a_map;
   EXPECT_CALL(mock_foo_, CTReturnTypeWithComma())
@@ -394,6 +403,7 @@ class StackInterface {
   virtual int GetSize() const = 0;
   // Template parameter appears in function return type.
   virtual const T& GetTop() const = 0;
+  virtual void Clear() volatile = 0;
 };
 
 template <typename T>
@@ -405,6 +415,7 @@ class MockStack : public StackInterface<T> {
   MOCK_METHOD0_T(Pop, void());
   MOCK_CONST_METHOD0_T(GetSize, int());  // NOLINT
   MOCK_CONST_METHOD0_T(GetTop, const T&());
+  MOCK_QUALIFIED_METHOD0_T(Clear, volatile, void());
 
   // Tests that the function return type can contain unprotected comma.
   MOCK_METHOD0_T(ReturnTypeWithComma, std::map<int, int>());
@@ -428,6 +439,8 @@ TEST(TemplateMockTest, Works) {
       .WillOnce(ReturnRef(n));
   EXPECT_CALL(mock, Pop())
       .Times(AnyNumber());
+  EXPECT_CALL(mock, Clear())
+      .Times(1);
 
   EXPECT_EQ(0, mock.GetSize());
   mock.Push(5);
@@ -435,6 +448,7 @@ TEST(TemplateMockTest, Works) {
   EXPECT_EQ(5, mock.GetTop());
   mock.Pop();
   EXPECT_EQ(0, mock.GetSize());
+  mock.Clear();
 }
 
 TEST(TemplateMockTest, MethodWithCommaInReturnTypeWorks) {
@@ -464,6 +478,7 @@ class StackInterfaceWithCallType {
   STDMETHOD_(int, GetSize)() const = 0;
   // Template parameter appears in function return type.
   STDMETHOD_(const T&, GetTop)() const = 0;
+  STDMETHOD_(void, Clear)() volatile = 0;
 };
 
 template <typename T>
@@ -475,6 +490,7 @@ class MockStackWithCallType : public StackInterfaceWithCallType<T> {
   MOCK_METHOD0_T_WITH_CALLTYPE(STDMETHODCALLTYPE, Pop, void());
   MOCK_CONST_METHOD0_T_WITH_CALLTYPE(STDMETHODCALLTYPE, GetSize, int());
   MOCK_CONST_METHOD0_T_WITH_CALLTYPE(STDMETHODCALLTYPE, GetTop, const T&());
+  MOCK_QUALIFIED_METHOD0_T_WITH_CALLTYPE(STDMETHODCALLTYPE, Clear, volatile, void());
 
  private:
   GTEST_DISALLOW_COPY_AND_ASSIGN_(MockStackWithCallType);
@@ -494,6 +510,8 @@ TEST(TemplateMockTestWithCallType, Works) {
       .WillOnce(ReturnRef(n));
   EXPECT_CALL(mock, Pop())
       .Times(AnyNumber());
+  EXPECT_CALL(mock, Clear())
+      .Times(1);
 
   EXPECT_EQ(0, mock.GetSize());
   mock.Push(5);
@@ -501,6 +519,7 @@ TEST(TemplateMockTestWithCallType, Works) {
   EXPECT_EQ(5, mock.GetTop());
   mock.Pop();
   EXPECT_EQ(0, mock.GetSize());
+  mock.Clear();
 }
 #endif  // GTEST_OS_WINDOWS
 
@@ -530,29 +549,90 @@ TEST(OverloadedMockMethodTest, CanOverloadOnArgNumberInMacroBody) {
   EXPECT_TRUE(mock.Overloaded(true, 1));
 }
 
-#define MY_MOCK_METHODS2_ \
-    MOCK_CONST_METHOD1(Overloaded, int(int n)); \
-    MOCK_METHOD1(Overloaded, int(int n));
-
-class MockOverloadedOnConstness {
+class MockOverloadedOnQualifiers {
  public:
-  MockOverloadedOnConstness() {}
+  MockOverloadedOnQualifiers() {}
 
-  MY_MOCK_METHODS2_;
+  MOCK_CONST_METHOD1(Overloaded, int(int n));
+  MOCK_METHOD1(Overloaded, int(int n));
+  MOCK_QUALIFIED_METHOD1(Overloaded, volatile, int(int n));
+  MOCK_QUALIFIED_METHOD1(Overloaded, const volatile, int(int n));
+
+#if GTEST_LANG_CXX11
+  MOCK_QUALIFIED_METHOD0(OverloadedRefQualifier, &, int());
+  MOCK_QUALIFIED_METHOD0(OverloadedRefQualifier, &&, int());
+#endif // GTEST_LANG_CXX11
 
  private:
-  GTEST_DISALLOW_COPY_AND_ASSIGN_(MockOverloadedOnConstness);
+  GTEST_DISALLOW_COPY_AND_ASSIGN_(MockOverloadedOnQualifiers);
 };
 
 TEST(OverloadedMockMethodTest, CanOverloadOnConstnessInMacroBody) {
-  MockOverloadedOnConstness mock;
-  const MockOverloadedOnConstness* const_mock = &mock;
+  MockOverloadedOnQualifiers mock;
+  const MockOverloadedOnQualifiers* const_mock = &mock;
+  volatile MockOverloadedOnQualifiers* volatile_mock = &mock;
+  const volatile MockOverloadedOnQualifiers* const_volatile_mock = &mock;
   EXPECT_CALL(mock, Overloaded(1)).WillOnce(Return(2));
   EXPECT_CALL(*const_mock, Overloaded(1)).WillOnce(Return(3));
+  EXPECT_CALL(*volatile_mock, Overloaded(1)).WillOnce(Return(4));
+  EXPECT_CALL(*const_volatile_mock, Overloaded(1)).WillOnce(Return(5));
 
   EXPECT_EQ(2, mock.Overloaded(1));
   EXPECT_EQ(3, const_mock->Overloaded(1));
+  EXPECT_EQ(4, volatile_mock->Overloaded(1));
+  EXPECT_EQ(5, const_volatile_mock->Overloaded(1));
 }
+
+#if GTEST_LANG_CXX11
+TEST(OverloadedMockMethodTest, CanOverloadRefQualified) {
+  MockOverloadedOnQualifiers mock;
+
+  EXPECT_CALL(mock, OverloadedRefQualifier()).WillOnce(Return(1));
+  EXPECT_CALL(std::move(mock), OverloadedRefQualifier()).WillOnce(Return(2));
+
+  EXPECT_EQ(1, mock.OverloadedRefQualifier());
+  EXPECT_EQ(2, std::move(mock).OverloadedRefQualifier());
+}
+#endif // GTEST_LANG_CXX11
+
+class MockExceptionSpec {
+ public:
+  MockExceptionSpec() {}
+
+  MOCK_QUALIFIED_METHOD0(EmptyCXX98Throw, throw(), int());
+
+#if GTEST_LANG_CXX11
+  MOCK_QUALIFIED_METHOD0(Noexcept, noexcept, int());
+  MOCK_QUALIFIED_METHOD0(NoexceptEvaluatesFalse, noexcept(false), int());
+#endif // GTEST_LANG_CXX11
+
+ private:
+  GTEST_DISALLOW_COPY_AND_ASSIGN_(MockExceptionSpec);
+};
+
+TEST(QualifiersMockMethodTest, CanMockExceptionSpec) {
+  MockExceptionSpec mock;
+
+  EXPECT_CALL(mock, EmptyCXX98Throw()).WillOnce(Return(1));
+  EXPECT_EQ(1, mock.EmptyCXX98Throw());
+}
+
+#if GTEST_LANG_CXX11
+TEST(QualifiersMockMethodTest, CanMockNoexcept) {
+  MockExceptionSpec mock;
+
+  EXPECT_CALL(mock, Noexcept()).WillOnce(Return(1));
+  EXPECT_CALL(mock, NoexceptEvaluatesFalse()).WillOnce(Return(2));
+
+  EXPECT_EQ(1, mock.Noexcept());
+  EXPECT_EQ(2, mock.NoexceptEvaluatesFalse());
+
+  GTEST_COMPILE_ASSERT_(noexcept(mock.Noexcept()), expected_noexcept);
+  GTEST_COMPILE_ASSERT_(!noexcept(mock.NoexceptEvaluatesFalse()),
+                        expected_noexcept_false);
+}
+#endif // GTEST_LANG_CXX11
+
 
 TEST(MockFunctionTest, WorksForVoidNullary) {
   MockFunction<void()> foo;


### PR DESCRIPTION
This is the same pull-request as in #794 but based on current master branch.

Former discussion can be found in the original pull-request.

### Text from original pull-request:

This fixes issue #546.

These new macros `MOCK_QUALIFIED_METHODx` are a generalized version of the
former macros `MOCK_METHODx` and `MOCK_CONST_METHODx`. They allow any
combination of function qualifiers (const, volatile, noexcept).

Versions for different call-types do also exist
(`MOCK_QUALIFIED_METHODx_WITH_CALLTYPE`) as well as templated versions
(`MOCK_QUALIFIED_METHODx_T` and `MOCK_QUALIFIED_METHODx_T_WITH_CALLTYPE`).

Example:

```
struct Example {
  virtual void func() = 0;
  virtual int constFunc(double) const = 0;
  virtual int constNoexceptFunc() const noexcept = 0;
};

struct ExampleMock : public Example {
  MOCK_QUALIFIED_METHOD0(func, , void());
  MOCK_QUALIFIED_METHOD1(constFunc, const, int(double));
  MOCK_QUALIFIED_METHOD0(constNoexceptFunc, const noexcept, int());
};
```

**Note**
This mainly applies the patches (from Edgar Ellis) referenced from issue #546 and fixes the errors which occurred while doing so (because the code evolved since the time the original patches were created).
