### PR TITLE
Correct some typos in a comment

### DIFF
--- a/googlemock/test/gmock-generated-actions_test.cc
+++ b/googlemock/test/gmock-generated-actions_test.cc
@@ -1120,7 +1120,7 @@ TEST(ActionTemplateTest, WorksForIntegralTemplateParams) {
   EXPECT_FALSE(b);  // Verifies that resetter is deleted.
 }
 
-// Tests that ACTION_TEMPLATES works for template parameters.
+// Tests that ACTION_TEMPLATE works for a template with template parameters.
 ACTION_TEMPLATE(ReturnSmartPointer,
                 HAS_1_TEMPLATE_PARAMS(template <typename Pointee> class,
                                       Pointer),


### PR DESCRIPTION
This commit correct some typos in one of the lines - a wrong identifier and awkward phrasing. Please merge it as soon as possible. It is the resubmission of https://github.com/google/googletest/pull/978 .