### PR TITLE
Use wider types to prevent unsigned overflow diagnostics

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -310,7 +310,8 @@ namespace internal {
 // than kMaxRange.
 UInt32 Random::Generate(UInt32 range) {
   // These constants are the same as are used in glibc's rand(3).
-  state_ = (1103515245U*state_ + 12345U) % kMaxRange;
+  // Use wider types than necessary to prevent unsigned overflow diagnostics.
+  state_ = static_cast<UInt32>(1103515245ULL*state_ + 12345U) % kMaxRange;
 
   GTEST_CHECK_(range > 0)
       << "Cannot generate a number in the range [0, 0).";


### PR DESCRIPTION
The rest of the (covered) codebase is already integer overflow clean.
This is a cherry-pick of an internal change.

TESTED=gtest_shuffle_test goes from fail to pass with -fsanitize=integer