### PR TITLE
Fix scoped class gmock-gen.py

### DIFF
--- a/googlemock/scripts/generator/cpp/ast.py
+++ b/googlemock/scripts/generator/cpp/ast.py
@@ -1264,6 +1264,9 @@ class AstBuilder(object):
         return self._GetNestedType(Union)
 
     def handle_enum(self):
+        token = self._GetNextToken()
+        if not (token.token_type == tokenize.NAME and token.name == 'class'):
+            self._AddBackToken(token)
         return self._GetNestedType(Enum)
 
     def handle_auto(self):

--- a/googlemock/scripts/generator/cpp/gmock_class_test.py
+++ b/googlemock/scripts/generator/cpp/gmock_class_test.py
@@ -444,5 +444,23 @@ void(const FooType& test_arg));
     self.assertEqualIgnoreLeadingWhitespace(
         expected, self.GenerateMocks(source))
 
+  def testEnumClass(self):
+    source = """
+class Test {
+ public:
+  enum class Baz { BAZINGA };
+  virtual void Bar(const FooType& test_arg);
+};
+"""
+    expected = """\
+class MockTest : public Test {
+public:
+MOCK_METHOD1(Bar,
+void(const FooType& test_arg));
+};
+"""
+    self.assertEqualIgnoreLeadingWhitespace(
+        expected, self.GenerateMocks(source))
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Addresses the issue of scoped enums causing the mock generator script to skip subsequent method declarations.

🙏 Thanks!