### PR TITLE
Add support for pkgconfig

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -37,7 +37,12 @@ endif()
 # as ${gmock_SOURCE_DIR} and to the root binary directory as
 # ${gmock_BINARY_DIR}.
 # Language "C" is required for find_package(Threads).
-project(gmock CXX C)
+if (CMAKE_VERSION VERSION_LESS 3.0)
+  project(gmock CXX C)
+else()
+  cmake_policy(SET CMP0048 NEW)
+  project(gmock VERSION 1.9.0 LANGUAGES CXX C)
+endif()
 cmake_minimum_required(VERSION 2.6.4)
 
 if (COMMAND set_up_hermetic_build)
@@ -110,6 +115,18 @@ if(INSTALL_GMOCK)
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
   install(DIRECTORY ${gmock_SOURCE_DIR}/include/gmock
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+  # configure and install pkgconfig files
+  configure_file(
+    cmake/gmock.pc.in
+    "${CMAKE_BINARY_DIR}/gmock.pc"
+    @ONLY)
+  configure_file(
+    cmake/gmock_main.pc.in
+    "${CMAKE_BINARY_DIR}/gmock_main.pc"
+    @ONLY)
+  install(FILES "${CMAKE_BINARY_DIR}/gmock.pc" "${CMAKE_BINARY_DIR}/gmock_main.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endif()
 
 ########################################################################

--- a/googlemock/cmake/gmock.pc.in
+++ b/googlemock/cmake/gmock.pc.in
@@ -1,0 +1,9 @@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: gmock
+Description: GoogleMock (without main() function)
+Version: @PROJECT_VERSION@
+URL: https://github.com/google/googletest
+Libs: -L${libdir} -lgmock @CMAKE_THREAD_LIBS_INIT@
+Cflags: -I${includedir} @GTEST_HAS_PTHREAD_MACRO@ @CMAKE_THREAD_LIBS_INIT@

--- a/googlemock/cmake/gmock_main.pc.in
+++ b/googlemock/cmake/gmock_main.pc.in
@@ -1,0 +1,9 @@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: gmock_main
+Description: GoogleMock (with main() function)
+Version: @PROJECT_VERSION@
+URL: https://github.com/google/googletest
+Libs: -L${libdir} -lgmock_main @CMAKE_THREAD_LIBS_INIT@
+Cflags: -I${includedir} @GTEST_HAS_PTHREAD_MACRO@ @CMAKE_THREAD_LIBS_INIT@

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -44,7 +44,12 @@ endif()
 # as ${gtest_SOURCE_DIR} and to the root binary directory as
 # ${gtest_BINARY_DIR}.
 # Language "C" is required for find_package(Threads).
-project(gtest CXX C)
+if (CMAKE_VERSION VERSION_LESS 3.0)
+  project(gtest CXX C)
+else()
+  cmake_policy(SET CMP0048 NEW)
+  project(gtest VERSION 1.9.0 LANGUAGES CXX C)
+endif()
 cmake_minimum_required(VERSION 2.6.4)
 
 if (COMMAND set_up_hermetic_build)
@@ -109,6 +114,18 @@ if(INSTALL_GTEST)
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
   install(DIRECTORY ${gtest_SOURCE_DIR}/include/gtest
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+  # configure and install pkgconfig files
+  configure_file(
+    cmake/gtest.pc.in
+    "${CMAKE_BINARY_DIR}/gtest.pc"
+    @ONLY)
+  configure_file(
+    cmake/gtest_main.pc.in
+    "${CMAKE_BINARY_DIR}/gtest_main.pc"
+    @ONLY)
+  install(FILES "${CMAKE_BINARY_DIR}/gtest.pc" "${CMAKE_BINARY_DIR}/gtest_main.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endif()
 
 ########################################################################

--- a/googletest/cmake/gtest.pc.in
+++ b/googletest/cmake/gtest.pc.in
@@ -1,0 +1,9 @@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: gtest
+Description: GoogleTest (without main() function)
+Version: @PROJECT_VERSION@
+URL: https://github.com/google/googletest
+Libs: -L${libdir} -lgtest @CMAKE_THREAD_LIBS_INIT@
+Cflags: -I${includedir} @GTEST_HAS_PTHREAD_MACRO@ @CMAKE_THREAD_LIBS_INIT@

--- a/googletest/cmake/gtest_main.pc.in
+++ b/googletest/cmake/gtest_main.pc.in
@@ -1,0 +1,10 @@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: gtest_main
+Description: GoogleTest (with main() function)
+Version: @PROJECT_VERSION@
+URL: https://github.com/google/googletest
+Requires: gtest
+Libs: -L${libdir} -lgtest_main @CMAKE_THREAD_LIBS_INIT@
+Cflags: -I${includedir} @GTEST_HAS_PTHREAD_MACRO@ @CMAKE_THREAD_LIBS_INIT@

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -50,6 +50,7 @@ macro(config_compiler_and_linker)
   # instead, we use windows threading primitives
   if (NOT gtest_disable_pthreads AND NOT MINGW)
     # Defines CMAKE_USE_PTHREADS_INIT and CMAKE_THREAD_LIBS_INIT.
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads)
   endif()
 
@@ -126,10 +127,11 @@ macro(config_compiler_and_linker)
   endif()
 
   if (CMAKE_USE_PTHREADS_INIT)  # The pthreads library is available and allowed.
-    set(cxx_base_flags "${cxx_base_flags} -DGTEST_HAS_PTHREAD=1")
+    set(GTEST_HAS_PTHREAD_MACRO "-DGTEST_HAS_PTHREAD=1")
   else()
-    set(cxx_base_flags "${cxx_base_flags} -DGTEST_HAS_PTHREAD=0")
+    set(GTEST_HAS_PTHREAD_MACRO "-DGTEST_HAS_PTHREAD=0")
   endif()
+  set(cxx_base_flags "${cxx_base_flags} ${GTEST_HAS_PTHREAD_MACRO}")
 
   # For building gtest's own tests and samples.
   set(cxx_exception "${CMAKE_CXX_FLAGS} ${cxx_base_flags} ${cxx_exception_flags}")

--- a/googletest/docs/FAQ.md
+++ b/googletest/docs/FAQ.md
@@ -1060,6 +1060,12 @@ TEST_F(CoolTest, DoSomething) {
 If you try to build Google Test's Xcode project with Xcode 4.0 or later, you may encounter an error message that looks like
 "Missing SDK in target gtest\_framework: /Developer/SDKs/MacOSX10.4u.sdk". That means that Xcode does not support the SDK the project is targeting. See the Xcode section in the [README](../README.md) file on how to resolve this.
 
+## How do I easily discover the flags needed for GoogleTest? ##
+
+GoogleTest (and GoogleMock) now support discovering all necessary flags using pkg-config.
+See the [pkg-config guide](Pkgconfig.md) on how you can easily discover all compiler and
+linker flags using pkg-config.
+
 ## My question is not covered in your FAQ! ##
 
 If you cannot find the answer to your question in this FAQ, there are

--- a/googletest/docs/Pkgconfig.md
+++ b/googletest/docs/Pkgconfig.md
@@ -1,0 +1,146 @@
+## Using GoogleTest from various build systems ##
+
+GoogleTest comes with pkg-config files that can be used to determine all
+necessary flags for compiling and linking to GoogleTest (and GoogleMock).
+Pkg-config is a standardised plain-text format containing
+
+  * the includedir (-I) path
+  * necessary macro (-D) definitions
+  * further required flags (-pthread)
+  * the library (-L) path
+  * the library (-l) to link to
+
+All current build systems support pkg-config in one way or another. For
+all examples here we assume you want to compile the sample
+`samples/sample3_unittest.cc`.
+
+
+### CMake ###
+
+Using `pkg-config` in CMake is fairly easy:
+
+```
+cmake_minimum_required(VERSION 3.0)
+
+cmake_policy(SET CMP0048 NEW)
+project(my_gtest_pkgconfig VERSION 0.0.1 LANGUAGES CXX)
+
+find_package(PkgConfig)
+pkg_search_module(GTEST REQUIRED gtest_main)
+
+add_executable(testapp samples/sample3_unittest.cc)
+target_link_libraries(testapp ${GTEST_LDFLAGS})
+target_compile_options(testapp PUBLIC ${GTEST_CFLAGS})
+
+include(CTest)
+add_test(first_and_only_test testapp)
+```
+
+It is generally recommended that you use `target_compile_options` + `_CFLAGS`
+over `target_include_directories` + `_INCLUDE_DIRS` as the former includes not
+just -I flags (GoogleTest might require a macro indicating to internal headers
+that all libraries have been compiled with threading enabled. In addition,
+GoogleTest might also require `-pthread` in the compiling step, and as such
+splitting the pkg-config `Cflags` variable into include dirs and macros for
+`target_compile_definitions()` might still miss this). The same recommendation
+goes for using `_LDFLAGS` over the more commonplace `_LIBRARIES`, which
+happens to discard `-L` flags and `-pthread`.
+
+
+### Autotools ###
+
+Finding GoogleTest in Autoconf and using it from Automake is also fairly easy:
+
+In your `configure.ac`:
+
+```
+AC_PREREQ([2.69])
+AC_INIT([my_gtest_pkgconfig], [0.0.1])
+AC_CONFIG_SRCDIR([samples/sample3_unittest.cc])
+AC_PROG_CXX
+
+PKG_CHECK_MODULES([GTEST], [gtest_main])
+
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT
+```
+
+and in your `Makefile.am`:
+
+```
+check_PROGRAMS = testapp
+TESTS = $(check_PROGRAMS)
+
+testapp_SOURCES = samples/sample3_unittest.cc
+testapp_CXXFLAGS = $(GTEST_CFLAGS)
+testapp_LDADD = $(GTEST_LIBS)
+```
+
+
+### Meson ###
+
+Meson natively uses pkgconfig to query dependencies:
+
+```
+project('my_gtest_pkgconfig', 'cpp', version : '0.0.1')
+
+gtest_dep = dependency('gtest_main')
+
+testapp = executable(
+  'testapp',
+  files(['samples/sample3_unittest.cc']),
+  dependencies : gtest_dep,
+  install : false)
+
+test('first_and_only_test', testapp)
+```
+
+
+### Plain Makefiles ###
+
+Since `pkg-config` is a small Unix command-line utility, it can be used
+in handwritten `Makefile`s too:
+
+```
+GTEST_CFLAGS = `pkg-config --cflags gtest_main`
+GTEST_LIBS = `pkg-config --libs gtest_main`
+
+.PHONY: tests all
+
+tests: all
+	./testapp
+
+all: testapp
+
+testapp: testapp.o
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $< -o $@ $(GTEST_LIBS)
+
+testapp.o: samples/sample3_unittest.cc
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< -c -o $@ $(GTEST_CFLAGS)
+```
+
+
+### Help! pkg-config can't find GoogleTest! ###
+
+Let's say you have a `CMakeLists.txt` along the lines of the one in this
+tutorial and you try to run `cmake`. It is very possible that you get a
+failure along the lines of:
+
+```
+-- Checking for one of the modules 'gtest_main'
+CMake Error at /usr/share/cmake/Modules/FindPkgConfig.cmake:640 (message):
+  None of the required 'gtest_main' found
+```
+
+These failures are common if you installed GoogleTest yourself and have not
+sourced it from a distro or other package manager. If so, you need to tell
+pkg-config where it can find the `.pc` files containing the information.
+Say you installed GoogleTest to `/usr/local`, then it might be that the
+`.pc` files are installed under `/usr/local/lib64/pkgconfig`. If you set
+
+```
+export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig
+```
+
+pkg-config will also try to look in `PKG_CONFIG_PATH` to find `gtest_main.pc`.


### PR DESCRIPTION
This PR adds support for pkgconfig. Pkgconfig is the quasi-standard for determining the required flags and libraries to link to. The `gtest-config` utility is not tractable, does not generalise, is not supported natively by any build system and is ultimately rather cumbersome. Autoconf/CMake/Waf/Scons/Meson all have methods to use pkg-config files, which is the proper build system agnostic way to determine the required flags.