### PR TITLE
Fix problem installing gtest when gmock enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,11 @@ else()
 endif()
 
 option(BUILD_GTEST "Builds the googletest subproject" OFF)
-cmake_dependent_option(INSTALL_GTEST "Enable installation of googletest. (Projects embedding googletest may want to turn this OFF.)" ON "BUILD_GTEST OR BUILD_GMOCK" OFF)
 
 #Note that googlemock target already builds googletest
 option(BUILD_GMOCK "Builds the googlemock subproject" ON)
+
+cmake_dependent_option(INSTALL_GTEST "Enable installation of googletest. (Projects embedding googletest may want to turn this OFF.)" ON "BUILD_GTEST OR BUILD_GMOCK" OFF)
 cmake_dependent_option(INSTALL_GMOCK "Enable installation of googlemock. (Projects embedding googlemock may want to turn this OFF.)" ON "BUILD_GMOCK" OFF)
 
 if(BUILD_GMOCK)


### PR DESCRIPTION
Fix a bug deciding whether to enable the option to install Google Test caused by one of the dependent option dependencies not being defined yet.

Fixes #1198; impossible to install Google Test if Google Mock is built.