### PR TITLE
Adding CMake visibility policy setting

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -52,6 +52,10 @@ else()
 endif()
 cmake_minimum_required(VERSION 2.6.4)
 
+if (POLICY CMP0063) # Visibility
+  cmake_policy(SET CMP0063 NEW)
+endif (POLICY CMP0063)
+
 if (COMMAND set_up_hermetic_build)
   set_up_hermetic_build()
 endif()


### PR DESCRIPTION
This policy setting will silence a warning when using with a visibility settings on targets. Due to the forced `cmake_minimum_version`, policy settings in CMakeLists calling this one (including the main CMakeLists) are lost, forcing the change to be made here.