### PR TITLE
Fix compilation errors with Embarcadero C++Builder 10.2 update 1

### DIFF
--- a/googletest/codegear/.gitignore
+++ b/googletest/codegear/.gitignore
@@ -1,0 +1,7 @@
+Debug
+Release
+*.local
+*.res
+*.stat
+*.ico
+*.otares

--- a/googletest/codegear/gtest.cbproj
+++ b/googletest/codegear/gtest.cbproj
@@ -32,6 +32,7 @@
     <AllPackageLibs>rtl.lib;vcl.lib</AllPackageLibs>
     <TLIB_PageSize>32</TLIB_PageSize>
     <ILINK_LibraryPath>$(BDS)\lib;$(BDS)\lib\obj;$(BDS)\lib\psdk</ILINK_LibraryPath>
+    <BCC_UseClassicCompiler>false</BCC_UseClassicCompiler>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Cfg_1)'!=''">
     <BCC_OptimizeForSpeed>false</BCC_OptimizeForSpeed>

--- a/googletest/codegear/gtest.groupproj
+++ b/googletest/codegear/gtest.groupproj
@@ -6,7 +6,9 @@
   <ItemGroup>
     <Projects Include="gtest.cbproj" />
     <Projects Include="gtest_main.cbproj" />
-    <Projects Include="gtest_unittest.cbproj" />
+    <Projects Include="gtest_unittest.cbproj">
+        <Dependencies>gtest.cbproj;gtest_main.cbproj</Dependencies>
+    </Projects>
   </ItemGroup>
   <ProjectExtensions>
     <Borland.Personality>Default.Personality</Borland.Personality>
@@ -32,13 +34,13 @@
   <Target Name="gtest_main:Make">
     <MSBuild Projects="gtest_main.cbproj" Targets="Make" />
   </Target>
-  <Target Name="gtest_unittest">
+  <Target Name="gtest_unittest" DependsOnTargets="gtest;gtest_main">
     <MSBuild Projects="gtest_unittest.cbproj" Targets="" />
   </Target>
-  <Target Name="gtest_unittest:Clean">
+  <Target Name="gtest_unittest:Clean" DependsOnTargets="gtest:Clean;gtest_main:Clean">
     <MSBuild Projects="gtest_unittest.cbproj" Targets="Clean" />
   </Target>
-  <Target Name="gtest_unittest:Make">
+  <Target Name="gtest_unittest:Make" DependsOnTargets="gtest:Make;gtest_main:Make">
     <MSBuild Projects="gtest_unittest.cbproj" Targets="Make" />
   </Target>
   <Target Name="Build">

--- a/googletest/codegear/gtest_main.cbproj
+++ b/googletest/codegear/gtest_main.cbproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ProjectGuid>{bca37a72-5b07-46cf-b44e-89f8e06451a2}</ProjectGuid>
+    <ProjectGuid>{2D65159B-F95B-43F7-8DFA-F6DA19A745E5}</ProjectGuid>
     <Config Condition="'$(Config)'==''">Release</Config>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
@@ -32,6 +32,7 @@
     <AllPackageLibs>rtl.lib;vcl.lib</AllPackageLibs>
     <TLIB_PageSize>32</TLIB_PageSize>
     <ILINK_LibraryPath>$(BDS)\lib;$(BDS)\lib\obj;$(BDS)\lib\psdk</ILINK_LibraryPath>
+    <BCC_UseClassicCompiler>false</BCC_UseClassicCompiler>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Cfg_1)'!=''">
     <BCC_OptimizeForSpeed>false</BCC_OptimizeForSpeed>

--- a/googletest/codegear/gtest_unittest.cbproj
+++ b/googletest/codegear/gtest_unittest.cbproj
@@ -33,6 +33,7 @@
     <IncludePath>$(BDS)\include;$(BDS)\include\dinkumware;$(BDS)\include\vcl;..\include;..\test;..</IncludePath>
     <ILINK_LibraryPath>$(BDS)\lib;$(BDS)\lib\obj;$(BDS)\lib\psdk;..\test</ILINK_LibraryPath>
     <Multithreaded>true</Multithreaded>
+    <BCC_UseClassicCompiler>false</BCC_UseClassicCompiler>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Cfg_1)'!=''">
     <BCC_OptimizeForSpeed>false</BCC_OptimizeForSpeed>

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -813,9 +813,10 @@ using ::std::tuple_size;
 // Determines whether to support type-driven tests.
 
 // Typed tests need <typeinfo> and variadic macros, which GCC, VC++ 8.0,
-// Sun Pro CC, IBM Visual Age, and HP aCC support.
+// Sun Pro CC, IBM Visual Age, HP aCC, and Clang-based C++Builder support.
 #if defined(__GNUC__) || (_MSC_VER >= 1400) || defined(__SUNPRO_CC) || \
-    defined(__IBMCPP__) || defined(__HP_aCC)
+    defined(__IBMCPP__) || defined(__HP_aCC) || \
+    (defined(__BORLANDC__) && defined(__clang__))
 # define GTEST_HAS_TYPED_TEST 1
 # define GTEST_HAS_TYPED_TEST_P 1
 #endif

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -3591,6 +3591,10 @@ static bool PortableLocaltime(time_t seconds, struct tm* out) {
     return false;
   *out = *tm_ptr;
   return true;
+#elif __BORLANDC__
+  // C++Builder contains a POSIX-compliant localtime_s() but no localtime_r()
+  // http://docwiki.embarcadero.com/RADStudio/Tokyo/en/Localtime_s
+  return localtime_s(&seconds, out);
 #else
   return localtime_r(&seconds, out) != NULL;
 #endif

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -65,6 +65,10 @@ TEST(CommandLineFlagsTest, CanBeAccessedInCodeOnceGTestHIsIncluded) {
 #include <vector>
 #include <ostream>
 
+#if __BORLANDC__
+#include <memory>  // For auto_ptr
+#endif
+
 #include "gtest/gtest-spi.h"
 
 // Indicates that this translation unit is part of Google Test's
@@ -451,6 +455,18 @@ class FormatEpochTimeInMillisAsIso8601Test : public Test {
     GTEST_DISABLE_MSC_WARNINGS_PUSH_(4996 /* deprecated function */)
     tzset();
     GTEST_DISABLE_MSC_WARNINGS_POP_()
+#elif __BORLANDC__
+    // putenv() in C++Builder requires caller's C-string to persist
+    // http://docwiki.embarcadero.com/RADStudio/Tokyo/en/Putenv,_wputenv
+    static std::auto_ptr<std::string> env_var;
+    std::string * s =
+        new std::string(std::string("TZ=") + (time_zone ? time_zone : ""));
+    if (0 == putenv(s->c_str())) {
+        env_var.reset(s);
+    } else {
+        delete s;
+    }
+    _tzset();
 #else
     if (time_zone) {
       setenv(("TZ"), time_zone, 1);


### PR DESCRIPTION
Fix compilation errors using the latest [Clang-enhanced C++Builder](http://docwiki.embarcadero.com/RADStudio/Tokyo/en/Clang-enhanced_C%2B%2B_Compilers) compiler (`bcc32c.exe`).

Update the project files in `googletest/codegear` to:
- specify dependencies between the projects
- use a different project GUID for `gtest_main.lib` (to avoid conflict with `gtest.lib`)
- disable the classic Borland compiler (`bcc32.exe`)

Also add a local `.gitignore` file to ignore build products from C++Builder.

Fixes: #1037, #838. (Examples of the numerous compilation errors are given in those Issues.)