### PR TITLE
wrap thread related test with GTEST_HAS_PTHREAD

### DIFF
--- a/googletest/test/gtest-port_test.cc
+++ b/googletest/test/gtest-port_test.cc
@@ -304,6 +304,7 @@ TEST(FormatCompilerIndependentFileLocationTest, FormatsUknownFileAndLine) {
   EXPECT_EQ("unknown file", FormatCompilerIndependentFileLocation(NULL, -1));
 }
 
+#if GTEST_HAS_PTHREAD
 #if GTEST_OS_LINUX || GTEST_OS_MAC || GTEST_OS_QNX
 void* ThreadFunc(void* data) {
   internal::Mutex* mutex = static_cast<internal::Mutex*>(data);
@@ -349,6 +350,7 @@ TEST(GetThreadCountTest, ReturnsZeroWhenUnableToCountThreads) {
   EXPECT_EQ(0U, GetThreadCount());
 }
 #endif  // GTEST_OS_LINUX || GTEST_OS_MAC || GTEST_OS_QNX
+#endif  // GTEST_HAS_PTHREAD
 
 TEST(GtestCheckDeathTest, DiesWithCorrectOutputOnFailure) {
   const bool a_false_condition = false;


### PR DESCRIPTION
Compilation of Google Test's Unit Tests fails if threads are disabled, i.e.:
```
cd build
cmake -Dgtest_disable_pthreads=ON -Dgtest_build_tests=ON  ..
```
This was reported in issue #1144 already.

This pull request adds a `GTEST_HAS_PTHREAD` wrapper around the affected thread related test. The test is then excluded, as it doesn't make sense to test thread related behaviour when thread support is disabled.