### PR TITLE
switch one Trevis build to Release mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script: ./travis.sh
 env:
   matrix:
     - SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=Debug VERBOSE=1
-    - SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=Debug VERBOSE=1 CXX_FLAGS=-std=c++11
+    - SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11
 notifications:
   email: false
 sudo: false

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -94,7 +94,7 @@ macro(config_compiler_and_linker)
     set(cxx_no_exception_flags "-D_HAS_EXCEPTIONS=0")
     set(cxx_no_rtti_flags "-GR-")
   elseif (CMAKE_COMPILER_IS_GNUCXX)
-    set(cxx_base_flags "-Wall -Wshadow")
+    set(cxx_base_flags "-Wall -Wshadow -Werror")
     set(cxx_exception_flags "-fexceptions")
     set(cxx_no_exception_flags "-fno-exceptions")
     # Until version 4.3.2, GCC doesn't define a macro to indicate

--- a/googletest/test/gtest-param-test_test.cc
+++ b/googletest/test/gtest-param-test_test.cc
@@ -857,8 +857,8 @@ TEST_P(CustomLambdaNamingTest, CustomTestNames) {}
 INSTANTIATE_TEST_CASE_P(CustomParamNameLambda,
                         CustomLambdaNamingTest,
                         Values(std::string("LambdaName")),
-                        [](const ::testing::TestParamInfo<std::string>& info) {
-                          return info.param;
+                        [](const ::testing::TestParamInfo<std::string>& tpinfo) {
+                          return tpinfo.param;
                         });
 
 #endif  // GTEST_LANG_CXX11

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -2096,7 +2096,7 @@ class UnitTestRecordPropertyTestEnvironment : public Environment {
 };
 
 // This will test property recording outside of any test or test case.
-Environment* record_property_env =
+Environment* record_property_env GTEST_ATTRIBUTE_UNUSED_ =
     AddGlobalTestEnvironment(new UnitTestRecordPropertyTestEnvironment);
 
 // This group of tests is for predicate assertions (ASSERT_PRED*, etc)
@@ -4187,12 +4187,6 @@ TEST(AssertionSyntaxTest, WorksWithConst) {
 #endif  // GTEST_HAS_EXCEPTIONS
 
 }  // namespace
-
-// we don't use the variable further, just avoid compiler warning
-// by defining a function which uses it
-void dummy_use_of_record_property_env() {
-	(void) record_property_env;
-}
 
 namespace testing {
 

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -2096,7 +2096,7 @@ class UnitTestRecordPropertyTestEnvironment : public Environment {
 };
 
 // This will test property recording outside of any test or test case.
-static Environment* record_property_env =
+Environment* record_property_env =
     AddGlobalTestEnvironment(new UnitTestRecordPropertyTestEnvironment);
 
 // This group of tests is for predicate assertions (ASSERT_PRED*, etc)
@@ -4187,6 +4187,12 @@ TEST(AssertionSyntaxTest, WorksWithConst) {
 #endif  // GTEST_HAS_EXCEPTIONS
 
 }  // namespace
+
+// we don't use the variable further, just avoid compiler warning
+// by defining a function which uses it
+void dummy_use_of_record_property_env() {
+	(void) record_property_env;
+}
 
 namespace testing {
 


### PR DESCRIPTION
Using Release mode turns on the compiler's optimization which allows the compiler to discover more problems and omit some more warnings.

This enhances the coverage of hidden problems in comparison to running debug mode builds only.