### PR TITLE
enable Travis ccache to speed up CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 # /usr/bin/gcc is 4.6 always, but gcc-X.Y is available.
 - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
 # /usr/bin/clang is 3.4, lets override with modern one.
-- if [ "$CXX" = "clang++" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then export CXX="clang++-3.7" CC="clang-3.7"; fi
+- if [ "$CXX" = "clang++" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then export CXX="clang++-3.7" CC="clang-3.7"; ln -sf /usr/bin/ccache /$HOME/bin/$CXX; ln -sf /usr/bin/ccache /$HOME/bin/$CC; fi
 # ccache on OS X needs installation first
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install ccache; export PATH="/usr/local/opt/ccache/libexec:$PATH"; fi
 - echo ${PATH}

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ os:
   - linux
   - osx
 language: cpp
+cache: ccache
 compiler:
   - gcc
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ os:
   - osx
 language: cpp
 cache: ccache
+before_cache:
+  # print statistics before uploading new cache
+  - ccache --show-stats
 compiler:
   - gcc
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ install:
 - if [ "$CXX" = "clang++" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then export CXX="clang++-3.7" CC="clang-3.7"; ln -sf /usr/bin/ccache /$HOME/bin/$CXX; ln -sf /usr/bin/ccache /$HOME/bin/$CC; fi
 # ccache on OS X needs installation first
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install ccache; export PATH="/usr/local/opt/ccache/libexec:$PATH"; fi
+# reset ccache statistics
+- ccache --zero-stats
 - echo ${PATH}
 - echo ${CXX}
 - ${CXX} --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ install:
 - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
 # /usr/bin/clang is 3.4, lets override with modern one.
 - if [ "$CXX" = "clang++" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then export CXX="clang++-3.7" CC="clang-3.7"; fi
+# ccache on OS X needs installation first
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install ccache; export PATH="/usr/local/opt/ccache/libexec:$PATH"; fi
 - echo ${PATH}
 - echo ${CXX}
 - ${CXX} --version


### PR DESCRIPTION
Travis-CI supports [caching](https://docs.travis-ci.com/user/caching) of different build artefacts.

Using `ccache` speeds up builds especially in case of minor changes (doc etc.).

The first build for this pull request does not show any acceleration, as the cache needs to be filled first. But further builds can be faster in case the cache contains fitting objects.