### PR TITLE
run parallelized builds on Travis CI

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env sh
 set -evx
+
+# if possible, ask for the precise number of processors,
+# otherwise take 2 processors as reasonable default; see
+# https://docs.travis-ci.com/user/speeding-up-the-build/#Makefile-optimization
+if [ -x /usr/bin/getconf ]; then
+    MAKEFLAGS=j$(/usr/bin/getconf _NPROCESSORS_ONLN)
+else
+    MAKEFLAGS="j2"
+fi
+export MAKEFLAGS
+
 env | sort
 
 mkdir build || true

--- a/travis.sh
+++ b/travis.sh
@@ -5,10 +5,19 @@ set -evx
 # otherwise take 2 processors as reasonable default; see
 # https://docs.travis-ci.com/user/speeding-up-the-build/#Makefile-optimization
 if [ -x /usr/bin/getconf ]; then
-    MAKEFLAGS=j$(/usr/bin/getconf _NPROCESSORS_ONLN)
+    NPROCESSORS=$(/usr/bin/getconf _NPROCESSORS_ONLN)
 else
-    MAKEFLAGS="j2"
+    NPROCESSORS=2
 fi
+# as of 2017-09-04 Travis CI reports 32 processors, but GCC build
+# crashes if parallelized too much (maybe memory consumption problem),
+# so limit to 4 processors for the time being.
+if [ $NPROCESSORS -gt 4 ] ; then
+	echo "$0:Note: Limiting processors to use by make from $NPROCESSORS to 4."
+	NPROCESSORS=4
+fi
+# Tell make to use the processors. No preceding '-' required.
+MAKEFLAGS="j${NPROCESSORS}"
 export MAKEFLAGS
 
 env | sort


### PR DESCRIPTION
Build on Travis CI can be speed up by running parallelized builds as suggested in [Travis Doc](https://docs.travis-ci.com/user/speeding-up-the-build/#Makefile-optimization).

Instead of setting an environment variable in `.travis.yml` as suggested by Travis, I propose to use the more flexible change in the shell script `travis.sh` which we have anyway.