### PR TITLE
Make TypeWithoutFormatter compatible with Objective-C++ with ARC.

### DIFF
--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -137,7 +137,8 @@ class TypeWithoutFormatter {
  public:
   // This default version is called when kTypeKind is kOtherType.
   static void PrintValue(const T& value, ::std::ostream* os) {
-    PrintBytesInObjectTo(reinterpret_cast<const unsigned char*>(&value),
+    PrintBytesInObjectTo(reinterpret_cast<const unsigned char*>(
+                         reinterpret_cast<const void *>(&value)),
                          sizeof(value), os);
   }
 };

--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -137,8 +137,8 @@ class TypeWithoutFormatter {
  public:
   // This default version is called when kTypeKind is kOtherType.
   static void PrintValue(const T& value, ::std::ostream* os) {
-    PrintBytesInObjectTo(reinterpret_cast<const unsigned char*>(
-                         reinterpret_cast<const void *>(&value)),
+    PrintBytesInObjectTo(static_cast<const unsigned char*>(
+                             reinterpret_cast<const void *>(&value)),
                          sizeof(value), os);
   }
 };


### PR DESCRIPTION
When compiling with [Objective-C ARC](https://clang.llvm.org/docs/AutomaticReferenceCounting.html), casting `id` (Objective-C object type) to `char*` is not allowed. However, casting to `void*` is possible. 
Casting the print value to `void*` first enables using GMock in Objective-C++ projects using ARC. For example, using `MOCK_METHOD` for a method that takes an Objective-C block as one of the parameters is now possible.