### PR TITLE
remove obsolete link_directories command

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -75,9 +75,6 @@ include_directories(
   ${gtest_SOURCE_DIR}/include
   ${gtest_SOURCE_DIR})
 
-# Where Google Test's libraries can be found.
-link_directories(${gtest_BINARY_DIR}/src)
-
 # Summary of tuple support for Microsoft Visual Studio:
 # Compiler    version(MS)  version(cmake)  Support
 # ----------  -----------  --------------  -----------------------------


### PR DESCRIPTION
The link_directories() command not necessary, as the target_link_libraries command contains an absolute path already, and the path given doesn't exist anymore, leading only to linker warnings like:
```
ld: warning: directory not found for option '-L/Users/travis/build/google/googletest/build/googlemock/gtest/src'
```
