### PR TITLE
drop unused valgrind package from Travis build slave installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,8 @@ addons:
     - ubuntu-toolchain-r-test
     - llvm-toolchain-precise-3.7
     packages:
-    - gcc-4.9
     - g++-4.9
     - clang-3.7
-    - valgrind
 os:
   - linux
   - osx


### PR DESCRIPTION
The valgrind package is not used in the current `travis.sh` build, so there is no need to install it on the build slaves.

... and remove explicit gcc installation (will be installed automatically as dependency of g++).
