### PR TITLE
remove unused variables from travis environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ compiler:
 script: ./travis.sh
 env:
   matrix:
-    - SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=Debug VERBOSE=1
-    - SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=Debug VERBOSE=1 CXX_FLAGS=-std=c++11
+    - BUILD_TYPE=Debug VERBOSE=1
+    - BUILD_TYPE=Debug VERBOSE=1 CXX_FLAGS=-std=c++11
 notifications:
   email: false
 sudo: false


### PR DESCRIPTION
The environment variables `SHARED_LIB`, `STATIC_LIB` and `CMAKE_PKG` are currently not used neither in `travis.sh` nor by `cmake`.

Therefore they should be removed to avoid confusion and keep `.travis.yml` maintainable. 