### PR TITLE
Remove redundant declaration

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -2591,10 +2591,6 @@ std::string StringFromGTestEnv(const char* flag, const char* default_val);
 
 }  // namespace internal
 
-// Returns a path to temporary directory.
-// Tries to determine an appropriate directory for the platform.
-GTEST_API_ std::string TempDir();
-
 }  // namespace testing
 
 #endif  // GTEST_INCLUDE_GTEST_INTERNAL_GTEST_PORT_H_


### PR DESCRIPTION
TempDir() function is declared twice, once in `internal/gtest-port.h`
and a second time in `gtest.h`.

Removes a warning with GCC when -Wredundant-decls is given.

Fixes issue ##1264.