### PR TITLE
Revert "Allow macros inside of parametrized test names."

### DIFF
--- a/googletest/include/gtest/gtest-param-test.h
+++ b/googletest/include/gtest/gtest-param-test.h
@@ -1375,10 +1375,7 @@ internal::CartesianProductHolder10<Generator1, Generator2, Generator3,
 }
 # endif  // GTEST_HAS_COMBINE
 
-// Use a macro to stringify the test (case) name, because direct stringification
-// does not work if one of the arguments is itself a macro
-// (https://gcc.gnu.org/onlinedocs/cpp/Stringification.html).
-# define GTEST_STRINGIFY_(name) #name
+
 
 # define TEST_P(test_case_name, test_name) \
   class GTEST_TEST_CLASS_NAME_(test_case_name, test_name) \
@@ -1393,8 +1390,8 @@ internal::CartesianProductHolder10<Generator1, Generator2, Generator3,
               #test_case_name, \
               ::testing::internal::CodeLocation(\
                   __FILE__, __LINE__))->AddTestPattern(\
-                      GTEST_STRINGIFY_(test_case_name), \
-                      GTEST_STRINGIFY_(test_name), \
+                      #test_case_name, \
+                      #test_name, \
                       new ::testing::internal::TestMetaFactory< \
                           GTEST_TEST_CLASS_NAME_(\
                               test_case_name, test_name)>()); \
@@ -1415,11 +1412,11 @@ internal::CartesianProductHolder10<Generator1, Generator2, Generator3,
 // type testing::TestParamInfo<class ParamType>, and return std::string.
 //
 // testing::PrintToStringParamName is a builtin test suffix generator that
-// returns the value of testing::PrintToString(GetParam()).
+// returns the value of testing::PrintToString(GetParam()). It does not work
+// for std::string or C strings.
 //
 // Note: test names must be non-empty, unique, and may only contain ASCII
-// alphanumeric characters or underscore. Because PrintToString adds quotes
-// to std::string and C strings, it won't work for these types.
+// alphanumeric characters or underscore.
 
 # define INSTANTIATE_TEST_CASE_P(prefix, test_case_name, generator, ...) \
   ::testing::internal::ParamGenerator<test_case_name::ParamType> \

--- a/googletest/include/gtest/gtest-param-test.h.pump
+++ b/googletest/include/gtest/gtest-param-test.h.pump
@@ -441,10 +441,7 @@ internal::CartesianProductHolder$i<$for j, [[Generator$j]]> Combine(
 ]]
 # endif  // GTEST_HAS_COMBINE
 
-// Use a macro to stringify the test (case) name, because direct stringification
-// does not work if one of the arguments is itself a macro
-// (https://gcc.gnu.org/onlinedocs/cpp/Stringification.html).
-# define GTEST_STRINGIFY_(name) #name
+
 
 # define TEST_P(test_case_name, test_name) \
   class GTEST_TEST_CLASS_NAME_(test_case_name, test_name) \
@@ -459,8 +456,8 @@ internal::CartesianProductHolder$i<$for j, [[Generator$j]]> Combine(
               #test_case_name, \
               ::testing::internal::CodeLocation(\
                   __FILE__, __LINE__))->AddTestPattern(\
-                      GTEST_STRINGIFY_(test_case_name), \
-                      GTEST_STRINGIFY_(test_name), \
+                      #test_case_name, \
+                      #test_name, \
                       new ::testing::internal::TestMetaFactory< \
                           GTEST_TEST_CLASS_NAME_(\
                               test_case_name, test_name)>()); \

--- a/googletest/test/gtest-param-test_test.cc
+++ b/googletest/test/gtest-param-test_test.cc
@@ -809,34 +809,6 @@ TEST_P(NamingTest, TestsReportCorrectNamesAndParameters) {
 
 INSTANTIATE_TEST_CASE_P(ZeroToFiveSequence, NamingTest, Range(0, 5));
 
-// Tests that macros in test names are expanded correctly.
-class MacroNamingTest : public TestWithParam<int> {};
-
-#define PREFIX_WITH_FOO(test_name) FOO_##test_name
-#define PREFIX_WITH_MACRO(test_name) Macro##test_name
-
-TEST_P(PREFIX_WITH_MACRO(NamingTest), PREFIX_WITH_FOO(SomeTestName)) {
-  const ::testing::TestInfo* const test_info =
-     ::testing::UnitTest::GetInstance()->current_test_info();
-
-  EXPECT_STREQ("FortyTwo/MacroNamingTest", test_info->test_case_name());
-  EXPECT_STREQ("FOO_SomeTestName", test_info->name());
-}
-
-INSTANTIATE_TEST_CASE_P(FortyTwo, MacroNamingTest, Values(42));
-
-// Tests the same thing for non-parametrized tests.
-class MacroNamingTestNonParametrized : public ::testing::Test {};
-
-TEST_F(PREFIX_WITH_MACRO(NamingTestNonParametrized),
-       PREFIX_WITH_FOO(SomeTestName)) {
-  const ::testing::TestInfo* const test_info =
-     ::testing::UnitTest::GetInstance()->current_test_info();
-
-  EXPECT_STREQ("MacroNamingTestNonParametrized", test_info->test_case_name());
-  EXPECT_STREQ("FOO_SomeTestName", test_info->name());
-}
-
 // Tests that user supplied custom parameter names are working correctly.
 // Runs the test with a builtin helper method which uses PrintToString,
 // as well as a custom function and custom functor to ensure all possible


### PR DESCRIPTION
Reverts google/googletest#1245, merged too early