### PR TITLE
Silence -Wmissing-variable-declarations in INSTANTIATE_TEST_CASE_P

### DIFF
--- a/googletest/include/gtest/gtest-param-test.h
+++ b/googletest/include/gtest/gtest-param-test.h
@@ -1426,7 +1426,7 @@ internal::CartesianProductHolder10<Generator1, Generator2, Generator3,
     return ::testing::internal::GetParamNameGen<test_case_name::ParamType> \
         (__VA_ARGS__)(info); \
   } \
-  int gtest_##prefix##test_case_name##_dummy_ GTEST_ATTRIBUTE_UNUSED_ = \
+  const int gtest_##prefix##test_case_name##_dummy_ GTEST_ATTRIBUTE_UNUSED_ = \
       ::testing::UnitTest::GetInstance()->parameterized_test_registry(). \
           GetTestCasePatternHolder<test_case_name>(\
               #test_case_name, \


### PR DESCRIPTION
Silences "no previous extern declaration for non-static.." Clang warning
on the dummy variable in the expansion of `INSTANTIATE_TEST_CASE_P`.

(cf. Similar discussion regarding the same type of warning here:
https://groups.google.com/forum/#!topic/googletestframework/7w2qD6zWatc)

**Test Case**

```cpp
#include <gtest/gtest.h>

using ::testing::TestWithParam;
using ::testing::Values;

using SomeTest = TestWithParam<int>;

INSTANTIATE_TEST_CASE_P(SomeData, SomeTest, Values(1, 2, 3));
```
```cmake
cmake_minimum_required(VERSION 2.6.4)

project(testcase)

add_executable(testcase testcase.cpp)

target_link_libraries(testcase gtest gtest_main)

target_compile_options(testcase PRIVATE -Wmissing-variable-declarations)

set_property(TARGET testcase PROPERTY CXX_STANDARD 11)

add_subdirectory(googletest)
```

**Before**:
```
/home/estan/testcase/testcase.cpp:8:1: warning: no previous extern declaration for non-static variable 'gtest_SomeDataSomeTest_dummy_' [-Wmissing-variable-declarations]
INSTANTIATE_TEST_CASE_P(SomeData, SomeTest, Values(1, 2, 3));
^
/home/estan/testcase/googletest/googletest/include/gtest/gtest-param-test.h:1429:7: note: expanded from macro 'INSTANTIATE_TEST_CASE_P'
  int gtest_##prefix##test_case_name##_dummy_ GTEST_ATTRIBUTE_UNUSED_ = \
      ^
<scratch space>:69:1: note: expanded from here
gtest_SomeDataSomeTest_dummy_
^
1 warning generated.
```

**After**: No warning