### PR TITLE
Changed CMAKE_BINARY_DIR to CMAKE_CURRENT_BINARY_DIR in documentation.

### DIFF
--- a/googletest/README.md
+++ b/googletest/README.md
@@ -129,8 +129,8 @@ New file `CMakeLists.txt.in`:
     ExternalProject_Add(googletest
       GIT_REPOSITORY    https://github.com/google/googletest.git
       GIT_TAG           master
-      SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
-      BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
+      SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+      BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
       CONFIGURE_COMMAND ""
       BUILD_COMMAND     ""
       INSTALL_COMMAND   ""
@@ -143,13 +143,13 @@ Existing build's `CMakeLists.txt`:
     configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
     execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
       RESULT_VARIABLE result
-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
     if(result)
       message(FATAL_ERROR "CMake step for googletest failed: ${result}")
     endif()
     execute_process(COMMAND ${CMAKE_COMMAND} --build .
       RESULT_VARIABLE result
-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
     if(result)
       message(FATAL_ERROR "Build step for googletest failed: ${result}")
     endif()
@@ -160,8 +160,8 @@ Existing build's `CMakeLists.txt`:
     
     # Add googletest directly to our build. This defines
     # the gtest and gtest_main targets.
-    add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
-                     ${CMAKE_BINARY_DIR}/googletest-build)
+    add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+                     ${CMAKE_CURRENT_BINARY_DIR}/googletest-build)
 
     # The gtest/gtest_main targets carry header search path
     # dependencies automatically when using CMake 2.8.11 or


### PR DESCRIPTION
Original code only worked if it was inserted in the main CMakeLists.txt, while using CMAKE_CURRENT_BINARY_DIR also works for a project added via add_subdirectory.