### PR TITLE
Fix ODR violation of gtest global variables for non-Windows platforms

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -86,16 +86,23 @@ endif()
 # Google Mock libraries.  We build them using more strict warnings than what
 # are used for other targets, to ensure that Google Mock can be compiled by
 # a user aggressive about warnings.
-cxx_library(gmock
-            "${cxx_strict}"
-            "${gtest_dir}/src/gtest-all.cc"
-            src/gmock-all.cc)
+if (MSVC)
+  cxx_library(gmock
+              "${cxx_strict}"
+              "${gtest_dir}/src/gtest-all.cc"
+              src/gmock-all.cc)
 
-cxx_library(gmock_main
-            "${cxx_strict}"
-            "${gtest_dir}/src/gtest-all.cc"
-            src/gmock-all.cc
-            src/gmock_main.cc)
+  cxx_library(gmock_main
+              "${cxx_strict}"
+              "${gtest_dir}/src/gtest-all.cc"
+              src/gmock-all.cc
+              src/gmock_main.cc)
+else()
+  cxx_library(gmock "${cxx_strict}" src/gmock-all.cc)
+  target_link_libraries(gmock gtest)
+  cxx_library(gmock_main "${cxx_strict}" src/gmock_main.cc)
+  target_link_libraries(gmock_main gmock)
+endif()
 
 # If the CMake version supports it, attach header directory information
 # to the targets for when we are part of a parent build (ie being pulled
@@ -175,32 +182,46 @@ if (gmock_build_tests)
   ############################################################
   # C++ tests built with non-standard compiler flags.
 
-  cxx_library(gmock_main_no_exception "${cxx_no_exception}"
-    "${gtest_dir}/src/gtest-all.cc" src/gmock-all.cc src/gmock_main.cc)
-
-  cxx_library(gmock_main_no_rtti "${cxx_no_rtti}"
-    "${gtest_dir}/src/gtest-all.cc" src/gmock-all.cc src/gmock_main.cc)
-
-  if (NOT MSVC OR MSVC_VERSION LESS 1600)  # 1600 is Visual Studio 2010.
-    # Visual Studio 2010, 2012, and 2013 define symbols in std::tr1 that
-    # conflict with our own definitions. Therefore using our own tuple does not
-    # work on those compilers.
-    cxx_library(gmock_main_use_own_tuple "${cxx_use_own_tuple}"
+  if (MSVC)
+    cxx_library(gmock_main_no_exception "${cxx_no_exception}"
       "${gtest_dir}/src/gtest-all.cc" src/gmock-all.cc src/gmock_main.cc)
 
-    cxx_test_with_flags(gmock_use_own_tuple_test "${cxx_use_own_tuple}"
-      gmock_main_use_own_tuple test/gmock-spec-builders_test.cc)
-  endif()
+    cxx_library(gmock_main_no_rtti "${cxx_no_rtti}"
+      "${gtest_dir}/src/gtest-all.cc" src/gmock-all.cc src/gmock_main.cc)
 
+    if (MSVC_VERSION LESS 1600)  # 1600 is Visual Studio 2010.
+      # Visual Studio 2010, 2012, and 2013 define symbols in std::tr1 that
+      # conflict with our own definitions. Therefore using our own tuple does not
+      # work on those compilers.
+      cxx_library(gmock_main_use_own_tuple "${cxx_use_own_tuple}"
+        "${gtest_dir}/src/gtest-all.cc" src/gmock-all.cc src/gmock_main.cc)
+
+      cxx_test_with_flags(gmock_use_own_tuple_test "${cxx_use_own_tuple}"
+        gmock_main_use_own_tuple test/gmock-spec-builders_test.cc)
+    endif()
+  else()
+    cxx_library(gmock_main_no_exception "${cxx_no_exception}" src/gmock_main.cc)
+    target_link_libraries(gmock_main_no_exception gmock)
+
+    cxx_library(gmock_main_no_rtti "${cxx_no_rtti}" src/gmock_main.cc)
+    target_link_libraries(gmock_main_no_rtti gmock)
+
+    cxx_library(gmock_main_use_own_tuple "${cxx_use_own_tuple}" src/gmock_main.cc)
+    target_link_libraries(gmock_main_use_own_tuple gmock)
+  endif()
   cxx_test_with_flags(gmock-more-actions_no_exception_test "${cxx_no_exception}"
     gmock_main_no_exception test/gmock-more-actions_test.cc)
 
   cxx_test_with_flags(gmock_no_rtti_test "${cxx_no_rtti}"
     gmock_main_no_rtti test/gmock-spec-builders_test.cc)
 
-  cxx_shared_library(shared_gmock_main "${cxx_default}"
-    "${gtest_dir}/src/gtest-all.cc" src/gmock-all.cc src/gmock_main.cc)
-
+  if (MSVC)
+    cxx_shared_library(shared_gmock_main "${cxx_default}"
+      "${gtest_dir}/src/gtest-all.cc" src/gmock-all.cc src/gmock_main.cc)
+  else()
+    cxx_shared_library(shared_gmock_main "${cxx_default}" src/gmock_main.cc)
+    target_link_libraries(shared_gmock_main gmock)
+  endif()
   # Tests that a binary can be built with Google Mock as a shared library.  On
   # some system configurations, it may not possible to run the binary without
   # knowing more details about the system configurations. We do not try to run


### PR DESCRIPTION
This PR is to partially resolve https://github.com/google/googletest/issues/930 and is based on https://github.com/google/googletest/pull/1059.

The Windows build apparently requires gtest to be linked into gmock, otherwise the build fails with  unresolved symbols.  This is not the case with posix builds.  Thus, wrapping the changes from https://github.com/google/googletest/pull/1059 in 
```
if (MSVC)
...
else()
...
endif()
```
should suffice to resolve the issue at least on non-Windows platforms. 