### PR TITLE
Updated README with C runtime dynamic/static linking issues in Windows info

### DIFF
--- a/googletest/README.md
+++ b/googletest/README.md
@@ -182,6 +182,17 @@ technique is discussed in more detail in
 which also contains a link to a fully generalized implementation
 of the technique.
 
+##### Visual Studio Dynamic vs Static Runtimes #####
+
+By default, new Visual Studio projects link the C runtimes dynamically
+but Google Test links them statically.
+This will generate an error that looks something like the following:
+    gtest.lib(gtest-all.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_StaticDebug' doesn't match value 'MDd_DynamicDebug' in main.obj
+
+Google Test already has a CMake option for this: `gtest_force_shared_crt`
+
+Enabling this option will make gtest link the runtimes dynamically too,
+and match the project in which it is included.
 
 ### Legacy Build Scripts ###
 


### PR DESCRIPTION
I had this issue and spent a while trying to figure out how to change the option, only to find that it's already handled in the CMake file.

Judging by some of the comments in issues (e.g. #266) other people have had the same problem.

Therefore, simply added it explicitly to the README at the bottom of the section about integrating with an existing CMake project.