### PR TITLE
Use system includes

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -101,8 +101,8 @@ cxx_library(gmock_main
 # to the targets for when we are part of a parent build (ie being pulled
 # in via add_subdirectory() rather than being a standalone build).
 if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
-  target_include_directories(gmock      INTERFACE "${gmock_SOURCE_DIR}/include")
-  target_include_directories(gmock_main INTERFACE "${gmock_SOURCE_DIR}/include")
+  target_include_directories(gmock      SYSTEM INTERFACE "${gmock_SOURCE_DIR}/include")
+  target_include_directories(gmock_main SYSTEM INTERFACE "${gmock_SOURCE_DIR}/include")
 endif()
 
 ########################################################################

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -103,8 +103,8 @@ target_link_libraries(gtest_main gtest)
 # to the targets for when we are part of a parent build (ie being pulled
 # in via add_subdirectory() rather than being a standalone build).
 if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
-  target_include_directories(gtest      INTERFACE "${gtest_SOURCE_DIR}/include")
-  target_include_directories(gtest_main INTERFACE "${gtest_SOURCE_DIR}/include")
+  target_include_directories(gtest      SYSTEM INTERFACE "${gtest_SOURCE_DIR}/include")
+  target_include_directories(gtest_main SYSTEM INTERFACE "${gtest_SOURCE_DIR}/include")
 endif()
 
 ########################################################################


### PR DESCRIPTION
Using system includes for the CMake `INTERFACE_INCLUDE_DIRECTORIES` property silences some warnings that cannot be silenced otherwise. For example, when compiling with `-Wpedantic`, `INSTANTIATE_TEST_CASE_P` generates a warning `ISO C++11 requires at least one argument for the "..." in a variadic macro`. I also had some other warnings about signed-unsigned comparison when using `{ASSERT,EXPECT}_EQ` with an integral constant as the second parameter.

This also conforms to the behavior when `find_package(GTest)` is used, which will facilitate changing from a system-wide install to building googletest as part of the project (as the FAQ recommends)