### PR TITLE
Add licenses() directive for googlemock/tests.

### DIFF
--- a/googlemock/test/BUILD.bazel
+++ b/googlemock/test/BUILD.bazel
@@ -32,6 +32,8 @@
 #   
 #   Bazel Build for Google C++ Testing Framework(Google Test)-googlemock
 
+licenses(["notice"])
+
 """ gmock own tests """
 
 cc_test(


### PR DESCRIPTION
Without the directive embedding googletest into third_party breaks any //... target.  For example, trying to add `googletest` as a submodule of [protobuf](https://github.com/google/protobuf) results in:

```console
$ bazel test //...:all
..............
ERROR: /Users/coryan/protobuf-develop/third_party/googletest/googlemock/test/BUILD.bazel:37:1: third-party rule '//third_party/googletest/googlemock/test:gmock_all_test' lacks a license declaration with one of the following types: notice, reciprocal, permissive, restricted, unencumbered, by_exception_only.
ERROR: package contains errors: third_party/googletest/googlemock/test.
ERROR: error loading package 'third_party/googletest/googlemock/test': Package 'third_party/googletest/googlemock/test' contains errors.
INFO: Elapsed time: 1.732s
ERROR: Couldn't start the build. Unable to run tests.
```

After this fix I still get errors, but those are in protobuf itself.
