### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@
 
 install:
 # /usr/bin/gcc is 4.6 always, but gcc-X.Y is available.
-- if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
+- if [ "$CXX" = "g++" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
 # /usr/bin/clang is 3.4, lets override with modern one.
 - if [ "$CXX" = "clang++" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then export CXX="clang++-3.7" CC="clang-3.7"; ln -sf /usr/bin/ccache /$HOME/bin/$CXX; ln -sf /usr/bin/ccache /$HOME/bin/$CC; fi
 # ccache on OS X needs installation first


### PR DESCRIPTION
Only enable g++-4.9 on Linux build, since that is the only OS where that version explicitly installed.