### PR TITLE
Fix test build issue with gcc 7.2

### DIFF
--- a/googletest/test/gtest-death-test_test.cc
+++ b/googletest/test/gtest-death-test_test.cc
@@ -281,6 +281,8 @@ TEST_F(TestForDeathTest, SingleStatement) {
   if (AlwaysFalse())
     // This would fail if executed; this is a compilation test only
     ASSERT_DEATH(return, "");
+  else
+    ;  // NOLINT
 
   if (AlwaysTrue())
     EXPECT_DEATH(_exit(1), "");
@@ -291,6 +293,8 @@ TEST_F(TestForDeathTest, SingleStatement) {
 
   if (AlwaysFalse())
     ASSERT_DEATH(return, "") << "did not die";
+  else
+    ;  // NOLINT
 
   if (AlwaysFalse())
     ;
@@ -1376,6 +1380,8 @@ TEST(ConditionalDeathMacrosSyntaxDeathTest, SingleStatement) {
   if (AlwaysFalse())
     // This would fail if executed; this is a compilation test only
     ASSERT_DEATH_IF_SUPPORTED(return, "");
+  else
+    ;  // NOLINT
 
   if (AlwaysTrue())
     EXPECT_DEATH_IF_SUPPORTED(_exit(1), "");
@@ -1386,6 +1392,8 @@ TEST(ConditionalDeathMacrosSyntaxDeathTest, SingleStatement) {
 
   if (AlwaysFalse())
     ASSERT_DEATH_IF_SUPPORTED(return, "") << "did not die";
+  else
+    ;  // NOLINT
 
   if (AlwaysFalse())
     ;  // NOLINT

--- a/googletest/test/gtest-port_test.cc
+++ b/googletest/test/gtest-port_test.cc
@@ -233,6 +233,8 @@ TEST(GtestCheckSyntaxTest, BehavesLikeASingleStatement) {
   if (AlwaysFalse())
     GTEST_CHECK_(false) << "This should never be executed; "
                            "It's a compilation test only.";
+  else
+    ;  // NOLINT
 
   if (AlwaysTrue())
     GTEST_CHECK_(true);

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -4066,6 +4066,8 @@ TEST(AssertionSyntaxTest, BasicAssertionsBehavesLikeSingleStatement) {
   if (AlwaysFalse())
     ASSERT_TRUE(false) << "This should never be executed; "
                           "It's a compilation test only.";
+  else
+    ;  // NOLINT
 
   if (AlwaysTrue())
     EXPECT_FALSE(false);
@@ -4074,6 +4076,8 @@ TEST(AssertionSyntaxTest, BasicAssertionsBehavesLikeSingleStatement) {
 
   if (AlwaysFalse())
     ASSERT_LT(1, 3);
+  else
+    ;  // NOLINT
 
   if (AlwaysFalse())
     ;  // NOLINT
@@ -4099,6 +4103,8 @@ TEST(ExpectThrowTest, DoesNotGenerateUnreachableCodeWarning) {
 TEST(AssertionSyntaxTest, ExceptionAssertionsBehavesLikeSingleStatement) {
   if (AlwaysFalse())
     EXPECT_THROW(ThrowNothing(), bool);
+  else
+    ;  // NOLINT
 
   if (AlwaysTrue())
     EXPECT_THROW(ThrowAnInteger(), int);
@@ -4107,6 +4113,8 @@ TEST(AssertionSyntaxTest, ExceptionAssertionsBehavesLikeSingleStatement) {
 
   if (AlwaysFalse())
     EXPECT_NO_THROW(ThrowAnInteger());
+  else
+    ;  // NOLINT
 
   if (AlwaysTrue())
     EXPECT_NO_THROW(ThrowNothing());
@@ -4115,6 +4123,8 @@ TEST(AssertionSyntaxTest, ExceptionAssertionsBehavesLikeSingleStatement) {
 
   if (AlwaysFalse())
     EXPECT_ANY_THROW(ThrowNothing());
+  else
+    ;  // NOLINT
 
   if (AlwaysTrue())
     EXPECT_ANY_THROW(ThrowAnInteger());


### PR DESCRIPTION
See Issue #1368

Despite of the compiler error message `suggest explicit braces to avoid ambiguous ‘else’`, the use of braces here could create _false positives_ in the tests. Therefore, consistently with what I see in the files, the solution is to add an `else ;` where needed.