### PR TITLE
Fix testing::Combine on MSVC 2017.

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -827,7 +827,7 @@ using ::std::tuple_size;
 // Determines whether to support Combine().
 // The implementation doesn't work on Sun Studio since it doesn't
 // understand templated conversion operators.
-#if GTEST_HAS_TR1_TUPLE && !defined(__SUNPRO_CC)
+#if (GTEST_HAS_TR1_TUPLE || GTEST_HAS_STD_TUPLE_) && !defined(__SUNPRO_CC)
 # define GTEST_HAS_COMBINE 1
 #endif
 


### PR DESCRIPTION
On platforms with std::tuple and not std::tr1::tuple, GTEST_HAS_COMBINE
gets turned off when it works fine (due to GTEST_TUPLE_NAMESPACE_).
Elsewhere in the project, several GTEST_HAS_TR1_TUPLE checks
additionally check GTEST_HAS_STD_TUPLE_, so use that formulation.

(The ones that don't are specific to std::tr1::tuple and are followed by
an identical GTEST_HAS_STD_TUPLE_ version underneath it.)

In particular, this fixes testing::Combine on MSVC 2017, which regressed
here:
https://github.com/google/googletest/pull/1348#issuecomment-353879010