### PR TITLE
Clean up now unneccessary std::tr1::tuple undefined behavior.

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -671,14 +671,9 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 #  define GTEST_ENV_HAS_TR1_TUPLE_ 1
 # endif
 
-// C++11 specifies that <tuple> provides std::tuple. Use that if gtest is used
-// in C++11 mode and libstdc++ isn't very old (binaries targeting OS X 10.6
-// can build with clang but need to use gcc4.2's libstdc++).
-# if GTEST_LANG_CXX11 && (!defined(__GLIBCXX__) || __GLIBCXX__ > 20110325)
-#  define GTEST_ENV_HAS_STD_TUPLE_ 1
-# endif
-
-# if GTEST_ENV_HAS_TR1_TUPLE_ || GTEST_ENV_HAS_STD_TUPLE_
+// Use our own std::tr1::tuple if one is not available and we do not have a
+// std::tuple to use instead.
+# if GTEST_ENV_HAS_TR1_TUPLE_ || GTEST_HAS_STD_TUPLE_
 #  define GTEST_USE_OWN_TR1_TUPLE 0
 # else
 #  define GTEST_USE_OWN_TR1_TUPLE 1
@@ -703,21 +698,6 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 
 # if GTEST_USE_OWN_TR1_TUPLE
 #  include "gtest/internal/gtest-tuple.h"  // IWYU pragma: export  // NOLINT
-# elif GTEST_ENV_HAS_STD_TUPLE_
-#  include <tuple>
-// C++11 puts its tuple into the ::std namespace rather than
-// ::std::tr1.  gtest expects tuple to live in ::std::tr1, so put it there.
-// This causes undefined behavior, but supported compilers react in
-// the way we intend.
-namespace std {
-namespace tr1 {
-using ::std::get;
-using ::std::make_tuple;
-using ::std::tuple;
-using ::std::tuple_element;
-using ::std::tuple_size;
-}
-}
 
 # elif GTEST_OS_SYMBIAN
 


### PR DESCRIPTION
This is just some cleanup. It doesn't add or fix functionality. I also could have done my archaeology wrong, so this warrants some careful testing.

---

Originally, gtest relied on std::tr1::tuple for some features. Later on,
GTEST_USE_OWN_TR1_TUPLE was introduced which provided an alternate
std::tr1::tuple if one was not provided. (This was injected into
std::tr1 which I believe is undefined behavior, but this CL doesn't
attempt to resolve it.)

Later, 2147489625ea8071ca560462f19b1ceb8940a229 introduced some logic to
use std::tuple on platforms which had std::tuple and not
std::tr1::tuple. Since the rest of gtest expected the tuple to live at
std::tr1::tuple, it just injected std::tuple into std::tr1::tuple, which
is I believe also undefined behavior.

Later work (ccf8e33bc59a26745753d494b2535a5f0a97acc5 and
5df87d70b64dd8080ab9e3f1b0250e74715e2a60) removed the need for this
hack. Instead, gtest now no longer depends on tuples existing at
std::tr1::tuple. It includes pretty-printers for std::tuple or
std::tr1::tuple, whichever exists, and exports the one it needs
internally in testing::tuple.

Thus, the hack to inject std::tuple into std::tr1::tuple is no longer
necessary. Remove it. This does have a slight subtlety in that, if
std::tr1::tuple does not exists, but std::tuple does, we should not set
GTEST_USE_OWN_TR1_TUPLE as later code will otherwise include the header
when it shouldn't.