### PR TITLE
Also define GTEST_ATTRIBUTE_PRINTF_ in clang-cl.

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -879,7 +879,7 @@ using ::std::tuple_size;
 #endif
 
 // Use this annotation before a function that takes a printf format string.
-#if defined(__GNUC__) && !defined(COMPILER_ICC)
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(COMPILER_ICC)
 # if defined(__MINGW_PRINTF_FORMAT)
 // MinGW has two different printf implementations. Ensure the format macro
 // matches the selected implementation. See


### PR DESCRIPTION
I think this the last patch we're carrying for googletest in BoringSSL! :-)

clang-cl is clang for Windows running in MSVC mode. Chromium uses it for Windows builds. clang-cl is weird in that it defines `__clang__` and `_MSC_VER`, but *NOT* `__GNUC__`. This is vaguely analogous to how normal clang defines `__clang__` (what it is) and `__GNUC__` (what it is compatible with).

However, clang-cl still implements most GCC extensions, being clang. Notably, the way to control `-Wformat-literal` is still with `__attribute__((__format__))`. For better error-checking and strict `-Wformat-literal` compatibility (see 53c478d639b8eebd2942e88266610ebc79c541f6), define `GTEST_ATTRIBUTE_PRINTF_` in clang-cl too.