### PR TITLE
upstreaming cl 124976692

### DIFF
--- a/googlemock/test/gmock-internal-utils_test.cc
+++ b/googlemock/test/gmock-internal-utils_test.cc
@@ -44,15 +44,7 @@
 #include "gmock/internal/gmock-port.h"
 #include "gtest/gtest.h"
 #include "gtest/gtest-spi.h"
-
-// Indicates that this translation unit is part of Google Test's
-// implementation.  It must come before gtest-internal-inl.h is
-// included, or there will be a compiler error.  This trick is to
-// prevent a user from accidentally including gtest-internal-inl.h in
-// their code.
-#define GTEST_IMPLEMENTATION_ 1
 #include "src/gtest-internal-inl.h"
-#undef GTEST_IMPLEMENTATION_
 
 #if GTEST_OS_CYGWIN
 # include <sys/types.h>  // For ssize_t. NOLINT

--- a/googletest/src/gtest-death-test.cc
+++ b/googletest/src/gtest-death-test.cc
@@ -66,15 +66,7 @@
 
 #include "gtest/gtest-message.h"
 #include "gtest/internal/gtest-string.h"
-
-// Indicates that this translation unit is part of Google Test's
-// implementation.  It must come before gtest-internal-inl.h is
-// included, or there will be a compiler error.  This trick exists to
-// prevent the accidental inclusion of gtest-internal-inl.h in the
-// user's code.
-#define GTEST_IMPLEMENTATION_ 1
 #include "src/gtest-internal-inl.h"
-#undef GTEST_IMPLEMENTATION_
 
 namespace testing {
 

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -37,14 +37,6 @@
 #ifndef GTEST_SRC_GTEST_INTERNAL_INL_H_
 #define GTEST_SRC_GTEST_INTERNAL_INL_H_
 
-// GTEST_IMPLEMENTATION_ is defined to 1 iff the current translation unit is
-// part of Google Test's implementation; otherwise it's undefined.
-#if !GTEST_IMPLEMENTATION_
-// If this file is included from the user's code, just say no.
-# error "gtest-internal-inl.h is part of Google Test's internal implementation."
-# error "It must not be included except by Google Test itself."
-#endif  // GTEST_IMPLEMENTATION_
-
 #ifndef _WIN32_WCE
 # include <errno.h>
 #endif  // !_WIN32_WCE

--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -67,15 +67,7 @@
 #include "gtest/gtest-message.h"
 #include "gtest/internal/gtest-internal.h"
 #include "gtest/internal/gtest-string.h"
-
-// Indicates that this translation unit is part of Google Test's
-// implementation.  It must come before gtest-internal-inl.h is
-// included, or there will be a compiler error.  This trick exists to
-// prevent the accidental inclusion of gtest-internal-inl.h in the
-// user's code.
-#define GTEST_IMPLEMENTATION_ 1
 #include "src/gtest-internal-inl.h"
-#undef GTEST_IMPLEMENTATION_
 
 namespace testing {
 namespace internal {

--- a/googletest/src/gtest-test-part.cc
+++ b/googletest/src/gtest-test-part.cc
@@ -32,15 +32,7 @@
 // The Google C++ Testing Framework (Google Test)
 
 #include "gtest/gtest-test-part.h"
-
-// Indicates that this translation unit is part of Google Test's
-// implementation.  It must come before gtest-internal-inl.h is
-// included, or there will be a compiler error.  This trick exists to
-// prevent the accidental inclusion of gtest-internal-inl.h in the
-// user's code.
-#define GTEST_IMPLEMENTATION_ 1
 #include "src/gtest-internal-inl.h"
-#undef GTEST_IMPLEMENTATION_
 
 namespace testing {
 

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -133,14 +133,7 @@
 # include <sys/types.h>  // NOLINT
 #endif
 
-// Indicates that this translation unit is part of Google Test's
-// implementation.  It must come before gtest-internal-inl.h is
-// included, or there will be a compiler error.  This trick is to
-// prevent a user from accidentally including gtest-internal-inl.h in
-// their code.
-#define GTEST_IMPLEMENTATION_ 1
 #include "src/gtest-internal-inl.h"
-#undef GTEST_IMPLEMENTATION_
 
 #if GTEST_OS_WINDOWS
 # define vsnprintf _vsnprintf
@@ -2569,7 +2562,7 @@ void ReportInvalidTestCaseType(const char* test_case_name,
       << "probably rename one of the classes to put the tests into different\n"
       << "test cases.";
 
-  GTEST_LOG_(ERROR) 
+  GTEST_LOG_(ERROR)
        << FormatFileLocation(code_location.file.c_str(),
                              code_location.line)
        << " " << errors.GetString();
@@ -2918,7 +2911,7 @@ WORD GetNewColor(GTestColor color, WORD old_color_attrs) {
   }
   return new_color;
 }
-	
+
 #else
 
 // Returns the ANSI color code for the given color.  COLOR_DEFAULT is
@@ -3005,7 +2998,7 @@ void ColoredPrintf(GTestColor color, const char* fmt, ...) {
   GetConsoleScreenBufferInfo(stdout_handle, &buffer_info);
   const WORD old_color_attrs = buffer_info.wAttributes;
   const WORD new_color = GetNewColor(color, old_color_attrs);
-  
+
   // We need to flush the stream buffers into the console before each
   // SetConsoleTextAttribute call lest it affect the text that is already
   // printed but has not yet reached the console.
@@ -3471,7 +3464,7 @@ void XmlUnitTestResultPrinter::OnTestIterationEnd(const UnitTest& unit_test,
     //   3. To interpret the meaning of errno in a thread-safe way,
     //      we need the strerror_r() function, which is not available on
     //      Windows.
-    GTEST_LOG_(FATAL) << "Unable to open file \"" 
+    GTEST_LOG_(FATAL) << "Unable to open file \""
                       << output_file_ << "\"";
   }
   std::stringstream stream;
@@ -4419,8 +4412,8 @@ void UnitTestImpl::ConfigureXmlOutput() {
     listeners()->SetDefaultXmlGenerator(new XmlUnitTestResultPrinter(
         UnitTestOptions::GetAbsolutePathToOutputFile().c_str()));
   } else if (output_format != "") {
-    GTEST_LOG_(WARNING) << "WARNING: unrecognized output format \"" 
-                        << output_format 
+    GTEST_LOG_(WARNING) << "WARNING: unrecognized output format \""
+                        << output_format
                         << "\" ignored.";
   }
 }
@@ -4436,8 +4429,8 @@ void UnitTestImpl::ConfigureStreamingOutput() {
       listeners()->Append(new StreamingListener(target.substr(0, pos),
                                                 target.substr(pos+1)));
     } else {
-      GTEST_LOG_(WARNING) << "unrecognized streaming target \"" 
-                          << target 
+      GTEST_LOG_(WARNING) << "unrecognized streaming target \""
+                          << target
                           << "\" ignored.";
     }
   }
@@ -4567,7 +4560,7 @@ static void TearDownEnvironment(Environment* env) { env->TearDown(); }
 bool UnitTestImpl::RunAllTests() {
   // Makes sure InitGoogleTest() was called.
   if (!GTestIsInitialized()) {
-    GTEST_LOG_(ERROR) << 
+    GTEST_LOG_(ERROR) <<
       "\nThis test program did NOT call ::testing::InitGoogleTest "
       "before calling RUN_ALL_TESTS().  Please fix it.";
     return false;
@@ -5269,8 +5262,8 @@ bool ParseGoogleTestFlag(const char* const arg) {
 void LoadFlagsFromFile(const std::string& path) {
   FILE* flagfile = posix::FOpen(path.c_str(), "r");
   if (!flagfile) {
-    GTEST_LOG_(FATAL) << "Unable to open file \"" 
-                      << GTEST_FLAG(flagfile) 
+    GTEST_LOG_(FATAL) << "Unable to open file \""
+                      << GTEST_FLAG(flagfile)
                       << "\"";
   }
   std::string contents(ReadEntireFile(flagfile));

--- a/googletest/test/gtest-death-test_test.cc
+++ b/googletest/test/gtest-death-test_test.cc
@@ -56,15 +56,7 @@ using testing::internal::AlwaysTrue;
 # endif  // GTEST_OS_LINUX
 
 # include "gtest/gtest-spi.h"
-
-// Indicates that this translation unit is part of Google Test's
-// implementation.  It must come before gtest-internal-inl.h is
-// included, or there will be a compiler error.  This trick is to
-// prevent a user from accidentally including gtest-internal-inl.h in
-// their code.
-# define GTEST_IMPLEMENTATION_ 1
 # include "src/gtest-internal-inl.h"
-# undef GTEST_IMPLEMENTATION_
 
 namespace posix = ::testing::internal::posix;
 

--- a/googletest/test/gtest-filepath_test.cc
+++ b/googletest/test/gtest-filepath_test.cc
@@ -40,15 +40,7 @@
 
 #include "gtest/internal/gtest-filepath.h"
 #include "gtest/gtest.h"
-
-// Indicates that this translation unit is part of Google Test's
-// implementation.  It must come before gtest-internal-inl.h is
-// included, or there will be a compiler error.  This trick is to
-// prevent a user from accidentally including gtest-internal-inl.h in
-// their code.
-#define GTEST_IMPLEMENTATION_ 1
 #include "src/gtest-internal-inl.h"
-#undef GTEST_IMPLEMENTATION_
 
 #if GTEST_OS_WINDOWS_MOBILE
 # include <windows.h>  // NOLINT

--- a/googletest/test/gtest-options_test.cc
+++ b/googletest/test/gtest-options_test.cc
@@ -46,14 +46,7 @@
 # include <direct.h>
 #endif  // GTEST_OS_WINDOWS_MOBILE
 
-// Indicates that this translation unit is part of Google Test's
-// implementation.  It must come before gtest-internal-inl.h is
-// included, or there will be a compiler error.  This trick is to
-// prevent a user from accidentally including gtest-internal-inl.h in
-// their code.
-#define GTEST_IMPLEMENTATION_ 1
 #include "src/gtest-internal-inl.h"
-#undef GTEST_IMPLEMENTATION_
 
 namespace testing {
 namespace internal {

--- a/googletest/test/gtest-param-test_test.cc
+++ b/googletest/test/gtest-param-test_test.cc
@@ -41,11 +41,7 @@
 # include <sstream>
 # include <string>
 # include <vector>
-
-// To include gtest-internal-inl.h.
-# define GTEST_IMPLEMENTATION_ 1
 # include "src/gtest-internal-inl.h"  // for UnitTestOptions
-# undef GTEST_IMPLEMENTATION_
 
 # include "test/gtest-param-test_test.h"
 

--- a/googletest/test/gtest-port_test.cc
+++ b/googletest/test/gtest-port_test.cc
@@ -45,15 +45,7 @@
 
 #include "gtest/gtest.h"
 #include "gtest/gtest-spi.h"
-
-// Indicates that this translation unit is part of Google Test's
-// implementation.  It must come before gtest-internal-inl.h is
-// included, or there will be a compiler error.  This trick is to
-// prevent a user from accidentally including gtest-internal-inl.h in
-// their code.
-#define GTEST_IMPLEMENTATION_ 1
 #include "src/gtest-internal-inl.h"
-#undef GTEST_IMPLEMENTATION_
 
 using std::make_pair;
 using std::pair;

--- a/googletest/test/gtest_color_test_.cc
+++ b/googletest/test/gtest_color_test_.cc
@@ -36,15 +36,7 @@
 #include <stdio.h>
 
 #include "gtest/gtest.h"
-
-// Indicates that this translation unit is part of Google Test's
-// implementation.  It must come before gtest-internal-inl.h is
-// included, or there will be a compiler error.  This trick is to
-// prevent a user from accidentally including gtest-internal-inl.h in
-// their code.
-#define GTEST_IMPLEMENTATION_ 1
 #include "src/gtest-internal-inl.h"
-#undef GTEST_IMPLEMENTATION_
 
 using testing::internal::ShouldUseColor;
 

--- a/googletest/test/gtest_env_var_test_.cc
+++ b/googletest/test/gtest_env_var_test_.cc
@@ -35,10 +35,7 @@
 #include "gtest/gtest.h"
 
 #include <iostream>
-
-#define GTEST_IMPLEMENTATION_ 1
 #include "src/gtest-internal-inl.h"
-#undef GTEST_IMPLEMENTATION_
 
 using ::std::cout;
 

--- a/googletest/test/gtest_environment_test.cc
+++ b/googletest/test/gtest_environment_test.cc
@@ -34,10 +34,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "gtest/gtest.h"
-
-#define GTEST_IMPLEMENTATION_ 1  // Required for the next #include.
 #include "src/gtest-internal-inl.h"
-#undef GTEST_IMPLEMENTATION_
 
 namespace testing {
 GTEST_DECLARE_string_(filter);

--- a/googletest/test/gtest_output_test_.cc
+++ b/googletest/test/gtest_output_test_.cc
@@ -37,15 +37,7 @@
 
 #include "gtest/gtest-spi.h"
 #include "gtest/gtest.h"
-
-// Indicates that this translation unit is part of Google Test's
-// implementation.  It must come before gtest-internal-inl.h is
-// included, or there will be a compiler error.  This trick is to
-// prevent a user from accidentally including gtest-internal-inl.h in
-// their code.
-#define GTEST_IMPLEMENTATION_ 1
 #include "src/gtest-internal-inl.h"
-#undef GTEST_IMPLEMENTATION_
 
 #include <stdlib.h>
 

--- a/googletest/test/gtest_repeat_test.cc
+++ b/googletest/test/gtest_repeat_test.cc
@@ -34,15 +34,7 @@
 #include <stdlib.h>
 #include <iostream>
 #include "gtest/gtest.h"
-
-// Indicates that this translation unit is part of Google Test's
-// implementation.  It must come before gtest-internal-inl.h is
-// included, or there will be a compiler error.  This trick is to
-// prevent a user from accidentally including gtest-internal-inl.h in
-// their code.
-#define GTEST_IMPLEMENTATION_ 1
 #include "src/gtest-internal-inl.h"
-#undef GTEST_IMPLEMENTATION_
 
 namespace testing {
 

--- a/googletest/test/gtest_stress_test.cc
+++ b/googletest/test/gtest_stress_test.cc
@@ -37,12 +37,7 @@
 #include <iostream>
 #include <vector>
 
-// We must define this macro in order to #include
-// gtest-internal-inl.h.  This is how Google Test prevents a user from
-// accidentally depending on its internal implementation.
-#define GTEST_IMPLEMENTATION_ 1
 #include "src/gtest-internal-inl.h"
-#undef GTEST_IMPLEMENTATION_
 
 #if GTEST_IS_THREADSAFE
 

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -66,15 +66,7 @@ TEST(CommandLineFlagsTest, CanBeAccessedInCodeOnceGTestHIsIncluded) {
 #include <ostream>
 
 #include "gtest/gtest-spi.h"
-
-// Indicates that this translation unit is part of Google Test's
-// implementation.  It must come before gtest-internal-inl.h is
-// included, or there will be a compiler error.  This trick is to
-// prevent a user from accidentally including gtest-internal-inl.h in
-// their code.
-#define GTEST_IMPLEMENTATION_ 1
 #include "src/gtest-internal-inl.h"
-#undef GTEST_IMPLEMENTATION_
 
 namespace testing {
 namespace internal {


### PR DESCRIPTION
gtest/src/gtest-internal-inl.h -- the preprocessor was being used as an
ad-hoc header file visibility mechanism. the mechanism feels outdated and quixotic.

