### PR TITLE
Optimize build matrix on pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,19 +38,19 @@ matrix:
     - os: osx
       compiler: gcc
       env: BUILD_TYPE=Debug VERBOSE=1
-      if: event != pull_request
+      if: type != pull_request
     - os: osx
       compiler: gcc
       env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11
-      if: event != pull_request
+      if: type != pull_request
     - os: osx
       compiler: clang
       env: BUILD_TYPE=Debug VERBOSE=1
-      if: event != pull_request
+      if: type != pull_request
     - os: osx
       compiler: clang
       env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11
-      if: event != pull_request
+      if: type != pull_request
 
 # These are the install and build (script) phases for the most common entries in the matrix.  They could be included
 # in each entry in the matrix, but that is just repetitive.

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,15 +38,19 @@ matrix:
     - os: osx
       compiler: gcc
       env: BUILD_TYPE=Debug VERBOSE=1
+      if: event != pull_request
     - os: osx
       compiler: gcc
       env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11
+      if: event != pull_request
     - os: osx
       compiler: clang
       env: BUILD_TYPE=Debug VERBOSE=1
+      if: event != pull_request
     - os: osx
       compiler: clang
       env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11
+      if: event != pull_request
 
 # These are the install and build (script) phases for the most common entries in the matrix.  They could be included
 # in each entry in the matrix, but that is just repetitive.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ environment:
     - compiler: msvc-15-seh
       generator: "Visual Studio 15 2017 Win64"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      enabled_on_pr: yes
 
     - compiler: msvc-14-seh
       generator: "Visual Studio 14 2015"
@@ -43,7 +44,6 @@ environment:
 
 configuration:
   - Debug
-  #- Release
 
 build:
   verbosity: minimal
@@ -52,6 +52,16 @@ install:
 - ps: |
     Write-Output "Compiler: $env:compiler"
     Write-Output "Generator: $env:generator"
+    Write-Output "Pull Request: <$env:APPVEYOR_PULL_REQUEST_NUMBER>"
+    Write-Output "Enabled on PR: <$env:enabled_on_pr>"
+    if (-not (Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER)) {
+      Write-Output "This is a pull request build"
+      if (-not (Test-Path env:enabled_on_pr) -or $env:enabled_on_pr -ne "yes") {
+        Write-Output "PR builds are *NOT* explicitly enabled"
+      }
+    } else {
+      Write-Output "This is *NOT* a pull request build"
+    }
 
     # git bash conflicts with MinGW makefiles
     if ($env:generator -eq "MinGW Makefiles") {
@@ -63,6 +73,10 @@ install:
 
 build_script:
 - ps: |
+    # Only enable some builds for pull requests, the AppVeyor queue is too long.
+    if (-not (Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER) -And (-not (Test-Path env:enabled_on_pr) -or $env:enabled_on_pr -ne "")) {
+      return
+    }
     md _build -Force | Out-Null
     cd _build
 
@@ -81,6 +95,10 @@ build_script:
 
 test_script:
 - ps: |
+    # Only enable some builds for pull requests, the AppVeyor queue is too long.
+    if (-not (Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER) -And (-not (Test-Path env:enabled_on_pr) -or $env:enabled_on_pr -ne "")) {
+      return
+    }
     if ($env:generator -eq "MinGW Makefiles") {
         return # No test available for MinGW
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,15 +52,13 @@ install:
 - ps: |
     Write-Output "Compiler: $env:compiler"
     Write-Output "Generator: $env:generator"
-    Write-Output "Pull Request: <$env:APPVEYOR_PULL_REQUEST_NUMBER>"
-    Write-Output "Enabled on PR: <$env:enabled_on_pr>"
     if (-not (Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER)) {
+      Write-Output "This is *NOT* a pull request build"
+    } else {
       Write-Output "This is a pull request build"
       if (-not (Test-Path env:enabled_on_pr) -or $env:enabled_on_pr -ne "yes") {
         Write-Output "PR builds are *NOT* explicitly enabled"
       }
-    } else {
-      Write-Output "This is *NOT* a pull request build"
     }
 
     # git bash conflicts with MinGW makefiles
@@ -74,7 +72,7 @@ install:
 build_script:
 - ps: |
     # Only enable some builds for pull requests, the AppVeyor queue is too long.
-    if (-not (Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER) -And (-not (Test-Path env:enabled_on_pr) -or $env:enabled_on_pr -ne "")) {
+    if (-not (Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER) -And (-not (Test-Path env:enabled_on_pr) -or $env:enabled_on_pr -ne "yes")) {
       return
     }
     md _build -Force | Out-Null
@@ -96,7 +94,7 @@ build_script:
 test_script:
 - ps: |
     # Only enable some builds for pull requests, the AppVeyor queue is too long.
-    if (-not (Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER) -And (-not (Test-Path env:enabled_on_pr) -or $env:enabled_on_pr -ne "")) {
+    if (-not (Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER) -And (-not (Test-Path env:enabled_on_pr) -or $env:enabled_on_pr -ne "yes")) {
       return
     }
     if ($env:generator -eq "MinGW Makefiles") {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,7 +72,7 @@ install:
 build_script:
 - ps: |
     # Only enable some builds for pull requests, the AppVeyor queue is too long.
-    if (-not (Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER) -And (-not (Test-Path env:enabled_on_pr) -or $env:enabled_on_pr -ne "yes")) {
+    if ((Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER) -And (-not (Test-Path env:enabled_on_pr) -or $env:enabled_on_pr -ne "yes")) {
       return
     }
     md _build -Force | Out-Null
@@ -94,7 +94,7 @@ build_script:
 test_script:
 - ps: |
     # Only enable some builds for pull requests, the AppVeyor queue is too long.
-    if (-not (Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER) -And (-not (Test-Path env:enabled_on_pr) -or $env:enabled_on_pr -ne "yes")) {
+    if ((Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER) -And (-not (Test-Path env:enabled_on_pr) -or $env:enabled_on_pr -ne "yes")) {
       return
     }
     if ($env:generator -eq "MinGW Makefiles") {


### PR DESCRIPTION
After this change is merged the pull requests will have reduced / faster builds:

- On Travis, only the Linux builds will be scheduled, which rarely have a backlog.
- On AppVeyor, all builds are scheduled, but only the MSVC 2017 builds run.

Regular builds on `master` or any branch execute the full build matrix.  To see the effect look at these builds for a PR:

https://ci.appveyor.com/project/coryan/googletest/build/18
https://travis-ci.org/coryan/googletest/builds/325820471

And compare against the builds for the branch:

https://ci.appveyor.com/project/coryan/googletest/build/16
https://travis-ci.org/coryan/googletest/builds/325587781

