### PR TITLE
[Bazel] Detect Windows with cpu value x64_windows and x64_windows_msvc

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,7 +37,12 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])
 
 config_setting(
-    name = "win",
+    name = "windows",
+    values = { "cpu": "x64_windows" },
+)
+
+config_setting(
+    name = "windows_msvc",
     values = {"cpu": "x64_windows_msvc"},
 )
 
@@ -65,7 +70,8 @@ cc_library(
     ]),
     copts = select(
         {
-            ":win": [],
+            ":windows": [],
+            ":windows_msvc": [],
             "//conditions:default": ["-pthread"],
         },
     ),
@@ -76,7 +82,8 @@ cc_library(
         "googletest/include",
     ],
     linkopts = select({
-        ":win": [],
+        ":windows": [],
+        ":windows_msvc": [],
         "//conditions:default": [
             "-pthread",
         ],

--- a/googlemock/test/BUILD.bazel
+++ b/googlemock/test/BUILD.bazel
@@ -45,7 +45,8 @@ cc_test(
         ],
     ),
     linkopts = select({
-        "//:win": [],
+        "//:windows": [],
+        "//:windows_msvc": [],
         "//conditions:default": [
             "-pthread",
         ],

--- a/googletest/test/BUILD.bazel
+++ b/googletest/test/BUILD.bazel
@@ -57,13 +57,15 @@ cc_test(
                         "gtest-param-test_test.cc",
                     ],
                 ) + select({
-        "//:win": [],
+        "//:windows": [],
+        "//:windows_msvc": [],
         "//conditions:default": [
             "gtest-tuple_test.cc",
         ],
         }),
     copts = select({
-        "//:win": ["-DGTEST_USE_OWN_TR1_TUPLE=0"],
+        "//:windows": ["-DGTEST_USE_OWN_TR1_TUPLE=0"],
+        "//:windows_msvc": ["-DGTEST_USE_OWN_TR1_TUPLE=0"],
         "//conditions:default": ["-DGTEST_USE_OWN_TR1_TUPLE=1"],
     }),
     includes = [
@@ -73,7 +75,8 @@ cc_test(
         "googletest/test",
     ],
     linkopts = select({
-        "//:win": [],
+        "//:windows": [],
+        "//:windows_msvc": [],
         "//conditions:default": [
             "-pthread",
         ],


### PR DESCRIPTION
Recent versions of Bazel on Windows default to `--cpu=x64_windows` instead of `--cpu=x64_windows_msvc`. Tensorflow and Protobuf handle both with two `config_setting`. We should do the same for googletest.