### PR TITLE
Fix GCC 7.2 warnings

### DIFF
--- a/googletest/test/gtest-death-test_test.cc
+++ b/googletest/test/gtest-death-test_test.cc
@@ -278,9 +278,10 @@ TEST(ExitStatusPredicateTest, KilledBySignal) {
 // be followed by operator<<, and that in either case the complete text
 // comprises only a single C++ statement.
 TEST_F(TestForDeathTest, SingleStatement) {
-  if (AlwaysFalse())
+  if (AlwaysFalse()) {
     // This would fail if executed; this is a compilation test only
     ASSERT_DEATH(return, "");
+  }
 
   if (AlwaysTrue())
     EXPECT_DEATH(_exit(1), "");
@@ -289,8 +290,9 @@ TEST_F(TestForDeathTest, SingleStatement) {
     // doesn't expand into an "if" statement without an "else"
     ;
 
-  if (AlwaysFalse())
+  if (AlwaysFalse()) {
     ASSERT_DEATH(return, "") << "did not die";
+  }
 
   if (AlwaysFalse())
     ;
@@ -1373,9 +1375,10 @@ TEST(ConditionalDeathMacrosTest, AssertDeatDoesNotReturnhIfUnsupported) {
 //
 // The syntax should work whether death tests are available or not.
 TEST(ConditionalDeathMacrosSyntaxDeathTest, SingleStatement) {
-  if (AlwaysFalse())
+  if (AlwaysFalse()) {
     // This would fail if executed; this is a compilation test only
     ASSERT_DEATH_IF_SUPPORTED(return, "");
+  }
 
   if (AlwaysTrue())
     EXPECT_DEATH_IF_SUPPORTED(_exit(1), "");
@@ -1384,8 +1387,9 @@ TEST(ConditionalDeathMacrosSyntaxDeathTest, SingleStatement) {
     // doesn't expand into an "if" statement without an "else"
     ;  // NOLINT
 
-  if (AlwaysFalse())
+  if (AlwaysFalse()) {
     ASSERT_DEATH_IF_SUPPORTED(return, "") << "did not die";
+  }
 
   if (AlwaysFalse())
     ;  // NOLINT

--- a/googletest/test/gtest-port_test.cc
+++ b/googletest/test/gtest-port_test.cc
@@ -230,9 +230,10 @@ TEST(ScopedPtrTest, DefinesElementType) {
 // TODO(vladl@google.com): Implement THE REST of scoped_ptr tests.
 
 TEST(GtestCheckSyntaxTest, BehavesLikeASingleStatement) {
-  if (AlwaysFalse())
+  if (AlwaysFalse()) {
     GTEST_CHECK_(false) << "This should never be executed; "
                            "It's a compilation test only.";
+  }
 
   if (AlwaysTrue())
     GTEST_CHECK_(true);

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -4063,17 +4063,19 @@ TEST(HRESULTAssertionTest, Streaming) {
 
 // Tests that the assertion macros behave like single statements.
 TEST(AssertionSyntaxTest, BasicAssertionsBehavesLikeSingleStatement) {
-  if (AlwaysFalse())
+  if (AlwaysFalse()) {
     ASSERT_TRUE(false) << "This should never be executed; "
                           "It's a compilation test only.";
+  }
 
   if (AlwaysTrue())
     EXPECT_FALSE(false);
   else
     ;  // NOLINT
 
-  if (AlwaysFalse())
+  if (AlwaysFalse()) {
     ASSERT_LT(1, 3);
+  }
 
   if (AlwaysFalse())
     ;  // NOLINT
@@ -4097,24 +4099,27 @@ TEST(ExpectThrowTest, DoesNotGenerateUnreachableCodeWarning) {
 }
 
 TEST(AssertionSyntaxTest, ExceptionAssertionsBehavesLikeSingleStatement) {
-  if (AlwaysFalse())
+  if (AlwaysFalse()) {
     EXPECT_THROW(ThrowNothing(), bool);
+  }
 
   if (AlwaysTrue())
     EXPECT_THROW(ThrowAnInteger(), int);
   else
     ;  // NOLINT
 
-  if (AlwaysFalse())
+  if (AlwaysFalse()) {
     EXPECT_NO_THROW(ThrowAnInteger());
+  }
 
   if (AlwaysTrue())
     EXPECT_NO_THROW(ThrowNothing());
   else
     ;  // NOLINT
 
-  if (AlwaysFalse())
+  if (AlwaysFalse()) {
     EXPECT_ANY_THROW(ThrowNothing());
+  }
 
   if (AlwaysTrue())
     EXPECT_ANY_THROW(ThrowAnInteger());


### PR DESCRIPTION
GCC 7..2 triggered warnings while building gtest's unit tests.
```
[ 60%] Building CXX object googlemock/gtest/CMakeFiles/gtest-death-test_test.dir/test/gtest-death-test_test.cc.o
/home/matt/Documents/conan/googletest/googletest/test/gtest-death-test_test.cc: In member function ‘virtual void TestForDeathTest_SingleStatement_Test::TestBody()’:
/home/matt/Documents/conan/googletest/googletest/test/gtest-death-test_test.cc:281:6: warning: suggest explicit braces to avoid ambiguous ‘else’ [-Wdangling-else]
   if (AlwaysFalse())
      ^
/home/matt/Documents/conan/googletest/googletest/test/gtest-death-test_test.cc:292:6: warning: suggest explicit braces to avoid ambiguous ‘else’ [-Wdangling-else]
   if (AlwaysFalse())
      ^
/home/matt/Documents/conan/googletest/googletest/test/gtest-death-test_test.cc: In member function ‘virtual void ConditionalDeathMacrosSyntaxDeathTest_SingleStatement_Test::TestBody()’:
/home/matt/Documents/conan/googletest/googletest/test/gtest-death-test_test.cc:1376:6: warning: suggest explicit braces to avoid ambiguous ‘else’ [-Wdangling-else]
   if (AlwaysFalse())
      ^
/home/matt/Documents/conan/googletest/googletest/test/gtest-death-test_test.cc:1387:6: warning: suggest explicit braces to avoid ambiguous ‘else’ [-Wdangling-else]
   if (AlwaysFalse())
      ^
```