### PR TITLE
Guard possibly unused static functions to avoid -Werror=unused-function.

### DIFF
--- a/googletest/src/gtest-death-test.cc
+++ b/googletest/src/gtest-death-test.cc
@@ -983,6 +983,7 @@ static int ExecDeathTestChildMain(void* child_arg) {
 }
 #  endif  // !GTEST_OS_QNX
 
+#if !GTEST_ON_QNX && GTEST_HAS_CLONE
 // Two utility routines that together determine the direction the stack
 // grows.
 // This could be accomplished more elegantly by a single recursive
@@ -1007,6 +1008,7 @@ static bool StackGrowsDown() {
   StackLowerThanAddress(&dummy, &result);
   return result;
 }
+#endif  // !GTEST_ON_QNX && GTEST_HAS_CLONE
 
 // Spawns a child process with the same executable as the current process in
 // a thread-safe manner and instructs it to run the death test.  The


### PR DESCRIPTION
Most GCC versions pass -Wunused-function when -Wall is specified.
This results in build failures on OS X w/ GCC. Specifically in
gtest-death-test.cc.

This patch fixes the warning by correctly guarding the unused
functions inside conditional compilation blocks.