### PR TITLE
Do not attempt to redefine std::tr1::tuple

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -704,7 +704,7 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 
 # if GTEST_USE_OWN_TR1_TUPLE
 #  include "gtest/internal/gtest-tuple.h"  // IWYU pragma: export  // NOLINT
-# elif GTEST_ENV_HAS_STD_TUPLE_
+# elif GTEST_ENV_HAS_STD_TUPLE_ && !GTEST_ENV_HAS_TR1_TUPLE_
 #  include <tuple>
 // C++11 puts its tuple into the ::std namespace rather than
 // ::std::tr1.  gtest expects tuple to live in ::std::tr1, so put it there.


### PR DESCRIPTION
Fixes errors like:

	include/gtest/internal/gtest-port.h:700:14: error: target of using declaration conflicts with declaration already in scope
	using ::std::tuple;
				 ^
	/usr/lib/gcc/x86_64-pc-linux-gnu/6.4.0/include/g++-v6/tuple:554:11: note: target of using declaration
		class tuple : public _Tuple_impl<0, _Elements...>
			  ^
	/usr/lib/gcc/x86_64-pc-linux-gnu/6.4.0/include/g++-v6/tr1/tuple:130:11: note: conflicting declaration
		class tuple : public _Tuple_impl<0, _Elements...>
			  ^