### PR TITLE
Add preprocessor macro for default death test style.

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -107,6 +107,12 @@
 //   GTEST_CREATE_SHARED_LIBRARY
 //                            - Define to 1 when compiling Google Test itself
 //                              as a shared library.
+//   GTEST_DEFAULT_DEATH_TEST_STYLE
+//                            - The default value of --gtest_death_test_style.
+//                              The legacy default has been "fast" in the open
+//                              source version since 2008. The recommended value
+//                              is "threadsafe", and can be set in
+//                              custom/gtest-port.h.
 
 // Platform-indicating macros
 // --------------------------
@@ -973,6 +979,10 @@ using ::std::tuple_size;
 #ifndef GTEST_API_
 # define GTEST_API_
 #endif // GTEST_API_
+
+#ifndef GTEST_DEFAULT_DEATH_TEST_STYLE
+# define GTEST_DEFAULT_DEATH_TEST_STYLE  "fast"
+#endif  // GTEST_DEFAULT_DEATH_TEST_STYLE
 
 #ifdef __GNUC__
 // Ask the compiler to never inline a given function.

--- a/googletest/src/gtest-death-test.cc
+++ b/googletest/src/gtest-death-test.cc
@@ -73,7 +73,11 @@ namespace testing {
 // Constants.
 
 // The default death test style.
-static const char kDefaultDeathTestStyle[] = "threadsafe";
+//
+// This is defined in internal/gtest-port.h as "fast", but can be overridden by
+// a definition in internal/custom/gtest-port.h. The recommended value, which is
+// used internally at Google, is "threadsafe".
+static const char kDefaultDeathTestStyle[] = GTEST_DEFAULT_DEATH_TEST_STYLE;
 
 GTEST_DEFINE_string_(
     death_test_style,

--- a/googletest/test/gtest_env_var_test.py
+++ b/googletest/test/gtest_env_var_test.py
@@ -92,7 +92,7 @@ class GTestEnvVarTest(gtest_test_utils.TestCase):
     TestFlag('print_time', '0', '1')
     TestFlag('repeat', '999', '1')
     TestFlag('throw_on_failure', '1', '0')
-    TestFlag('death_test_style', 'fast', 'threadsafe')
+    TestFlag('death_test_style', 'threadsafe', 'fast')
     TestFlag('catch_exceptions', '0', '1')
 
     if IS_LINUX:


### PR DESCRIPTION
Google Test has recently (02/09/2018) switched the default death test style from "fast" to "threadsafe" in https://github.com/google/googletest/commit/ec7faa943d7817c81ce7bdf71a21ebc9244dc8de

Threadsafe death tests have been used internally for a while, and are proven to be a better default.

However, adopting this better default can be challenging for large projects with a significant investment in custom infrastructure built on top of Google Test.  The same custom infrastructure can make it difficult for large projects to switch back to the old default by passing in `--gtest_death_test_style=fast`.

For this reason, the default switch is considered too disruptive, and this PR reverts it. This PR also introduces the `GTEST_DEFAULT_DEATH_TEST_STYLE` preprocesor macro, which replaces the hard-coded default. The macro can be defined in `gtest/internal/custom/gtest-port.h` by projects that are ready to migrate to thread-safe death tests.