### PR TITLE
Fix unused function warning on Mac OS.

### DIFF
--- a/googletest/src/gtest-death-test.cc
+++ b/googletest/src/gtest-death-test.cc
@@ -983,6 +983,7 @@ static int ExecDeathTestChildMain(void* child_arg) {
 }
 #  endif  // !GTEST_OS_QNX
 
+#  if GTEST_HAS_CLONE
 // Two utility routines that together determine the direction the stack
 // grows.
 // This could be accomplished more elegantly by a single recursive
@@ -1007,6 +1008,7 @@ static bool StackGrowsDown() {
   StackLowerThanAddress(&dummy, &result);
   return result;
 }
+#  endif  // GTEST_HAS_CLONE
 
 // Spawns a child process with the same executable as the current process in
 // a thread-safe manner and instructs it to run the death test.  The


### PR DESCRIPTION
As of recently, Google Test fails to compile with the warning below when used in projects with strict warning settings.

googletest/src/gtest-death-test.cc:1004:13: error: unused function 'StackGrowsDown' [-Werror,-Wunused-function]