### PR TITLE
Removed trailing comma in enum

### DIFF
--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1050,7 +1050,7 @@ class NativeArray {
  private:
   enum {
     kCheckTypeIsNotConstOrAReference = StaticAssertTypeEqHelper<
-        Element, GTEST_REMOVE_REFERENCE_AND_CONST_(Element)>::value,
+        Element, GTEST_REMOVE_REFERENCE_AND_CONST_(Element)>::value
   };
 
   // Initializes this object with a copy of the input.


### PR DESCRIPTION
Trailing commas are allowed since C99 and C++ standards since. It is not allowed in C++ 98. To make gtest  compatible with C++98 this has to go. It causes issues for some less common compilers.