### PR TITLE
Include cstring istead of string.h for compatibility

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -266,7 +266,7 @@
 #include <stddef.h>  // for ptrdiff_t
 #include <stdlib.h>
 #include <stdio.h>
-#include <string.h>
+#include <cstring>
 #ifndef _WIN32_WCE
 # include <sys/types.h>
 # include <sys/stat.h>


### PR DESCRIPTION
One specific compiler we use (for an embedded platform) does not have a string.h in it's library. It does have cstring. 

Using cstring is the normal C++ way to do it anyway, so I seems a reasonable thing to use it instead of string.h - it will probably increase the probability of gtest being portable to other compilers/libraries as well. 

I know it is not a priority of gtest to support all platforms, but this should be a zero cost change for others while benefiting the embedded space (since it will help us not having to maintain an inhouse fork of the project).

