### PR TITLE
Add option --color="force-ansi" to use ansi escape codes

### DIFF
--- a/googletest/test/gtest_color_test_.cc
+++ b/googletest/test/gtest_color_test_.cc
@@ -45,10 +45,12 @@ using testing::internal::ShouldUseColor;
 // works the same way as in a real Google-Test-based test.  We don't actual
 // run the TEST itself.
 TEST(GTestColorTest, Dummy) {
+  ASSERT_EQ(1, 1);
 }
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
+  RUN_ALL_TESTS();
 
   if (ShouldUseColor(true)) {
     // Google Test decides to use colors in the output (assuming it

--- a/googletest/test/gtest_color_test_.cc
+++ b/googletest/test/gtest_color_test_.cc
@@ -50,8 +50,8 @@ TEST(GTestColorTest, Dummy) {
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  RUN_ALL_TESTS();
-
+  if (RUN_ALL_TESTS() != 0)
+    return -1;
   if (ShouldUseColor(true)) {
     // Google Test decides to use colors in the output (assuming it
     // goes to a TTY).


### PR DESCRIPTION
System: 
   Windows 10
Problem:
   Running ctest --output-on-verbose shows the GTest output with no colors at all.

https://stackoverflow.com/questions/34253579/can-ctest-display-googletest-console-colors

GTEST_COLOR had no effect on my machine, since isatty() was returning 0 (no terminal) and SetConsoleTextAttribute requires a terminal as well

The solution I came up was using ansi escape codes, which windows 10 supports by setting
HKCU/Console/VirtualTerminalLevel = DWORD(1) in the registry, and this pull request adds a way to reliably get ansi codes from GTest

If there's a better way, please let me know!


