### PR TITLE
provide alternative for DebugBreak()

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -4549,6 +4549,9 @@ void UnitTest::AddTestPartResult(
       // when a failure happens and both the --gtest_break_on_failure and
       // the --gtest_catch_exceptions flags are specified.
       DebugBreak();
+#elif (defined(__clang__) || defined(__GNUC__)) && (defined(__x86_64__) || defined(__i386__))
+      // with clang/gcc we can acchieve the same effect on x86 by invoking int3
+      asm("int3");
 #else
       // Dereference NULL through a volatile pointer to prevent the compiler
       // from removing. We use this rather than abort() or __builtin_trap() for

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -4550,7 +4550,7 @@ void UnitTest::AddTestPartResult(
       // the --gtest_catch_exceptions flags are specified.
       DebugBreak();
 #elif (defined(__clang__) || defined(__GNUC__)) && (defined(__x86_64__) || defined(__i386__))
-      // with clang/gcc we can acchieve the same effect on x86 by invoking int3
+      // with clang/gcc we can achieve the same effect on x86 by invoking int3
       asm("int3");
 #else
       // Dereference NULL through a volatile pointer to prevent the compiler


### PR DESCRIPTION
This uses asm("int3") for clang/gcc on x86 as alternative for DebugBreak()