### PR TITLE
Std lib versioning

### DIFF
--- a/googletest/include/gtest/internal/gtest-type-util.h
+++ b/googletest/include/gtest/internal/gtest-type-util.h
@@ -62,12 +62,12 @@ namespace internal {
 // used by various standard libraries (e.g., `std::__1`).  Names outside
 // of namespace std are returned unmodified.
 inline std::string CanonicalizeForStdLibVersioning(std::string s) {
-  static constexpr char prefix[] = "std::__";
+  static const char prefix[] = "std::__";
   if (s.compare(0, strlen(prefix), prefix) == 0) {
-    auto end = s.find("::", strlen(prefix));
+    std::string::size_type end = s.find("::", strlen(prefix));
     if (end != s.npos) {
-      // Erase the `::__` plus whatever was between that and the next `::`.
-      s.erase(strlen("std"), strlen("::__") + end - strlen(prefix));
+      // Erase everything between the initial `std` and the second `::`.
+      s.erase(strlen("std"), end - strlen("std"));
     }
   }
   return s;
@@ -89,9 +89,9 @@ std::string GetTypeName() {
   using abi::__cxa_demangle;
 #   endif  // GTEST_HAS_CXXABI_H_
   char* const readable_name = __cxa_demangle(name, 0, 0, &status);
-  std::string name_str(status == 0 ? readable_name : name);
+  const std::string name_str(status == 0 ? readable_name : name);
   free(readable_name);
-  return CanonicalizeForStdLibVersioning(std::move(name_str));
+  return CanonicalizeForStdLibVersioning(name_str);
 #  else
   return name;
 #  endif  // GTEST_HAS_CXXABI_H_ || __HP_aCC

--- a/googletest/include/gtest/internal/gtest-type-util.h
+++ b/googletest/include/gtest/internal/gtest-type-util.h
@@ -56,6 +56,22 @@
 
 namespace testing {
 namespace internal {
+  
+// Canonicalizes a given name with respect to the Standard C++ Library.
+// This handles removing the inline namespace within `std` that is
+// used by various standard libraries (e.g., `std::__1`).  Names outside
+// of namespace std are returned unmodified.
+inline std::string CanonicalizeForStdLibVersioning(std::string s) {
+  static constexpr char prefix[] = "std::__";
+  if (s.compare(0, strlen(prefix), prefix) == 0) {
+    auto end = s.find("::", strlen(prefix));
+    if (end != s.npos) {
+      // Erase the `::__` plus whatever was between that and the next `::`.
+      s.erase(strlen("std"), strlen("::__") + end - strlen(prefix));
+    }
+  }
+  return s;
+}
 
 // GetTypeName<T>() returns a human-readable name of type T.
 // NB: This function is also used in Google Mock, so don't move it inside of
@@ -73,9 +89,9 @@ std::string GetTypeName() {
   using abi::__cxa_demangle;
 #   endif  // GTEST_HAS_CXXABI_H_
   char* const readable_name = __cxa_demangle(name, 0, 0, &status);
-  const std::string name_str(status == 0 ? readable_name : name);
+  std::string name_str(status == 0 ? readable_name : name);
   free(readable_name);
-  return name_str;
+  return CanonicalizeForStdLibVersioning(std::move(name_str));
 #  else
   return name;
 #  endif  // GTEST_HAS_CXXABI_H_ || __HP_aCC

--- a/googletest/include/gtest/internal/gtest-type-util.h.pump
+++ b/googletest/include/gtest/internal/gtest-type-util.h.pump
@@ -54,6 +54,22 @@ $var n = 50  $$ Maximum length of type lists we want to support.
 
 namespace testing {
 namespace internal {
+  
+// Canonicalizes a given name with respect to the Standard C++ Library.
+// This handles removing the inline namespace within `std` that is
+// used by various standard libraries (e.g., `std::__1`).  Names outside
+// of namespace std are returned unmodified.
+inline std::string CanonicalizeForStdLibVersioning(std::string s) {
+  static constexpr char prefix[] = "std::__";
+  if (s.compare(0, strlen(prefix), prefix) == 0) {
+    auto end = s.find("::", strlen(prefix));
+    if (end != s.npos) {
+      // Erase the `::__` plus whatever was between that and the next `::`.
+      s.erase(strlen("std"), strlen("::__") + end - strlen(prefix));
+    }
+  }
+  return s;
+}
 
 // GetTypeName<T>() returns a human-readable name of type T.
 // NB: This function is also used in Google Mock, so don't move it inside of
@@ -71,9 +87,9 @@ std::string GetTypeName() {
   using abi::__cxa_demangle;
 #   endif  // GTEST_HAS_CXXABI_H_
   char* const readable_name = __cxa_demangle(name, 0, 0, &status);
-  const std::string name_str(status == 0 ? readable_name : name);
+  std::string name_str(status == 0 ? readable_name : name);
   free(readable_name);
-  return name_str;
+  return CanonicalizeForStdLibVersioning(std::move(name_str));
 #  else
   return name;
 #  endif  // GTEST_HAS_CXXABI_H_ || __HP_aCC

--- a/googletest/include/gtest/internal/gtest-type-util.h.pump
+++ b/googletest/include/gtest/internal/gtest-type-util.h.pump
@@ -60,12 +60,12 @@ namespace internal {
 // used by various standard libraries (e.g., `std::__1`).  Names outside
 // of namespace std are returned unmodified.
 inline std::string CanonicalizeForStdLibVersioning(std::string s) {
-  static constexpr char prefix[] = "std::__";
+  static const char prefix[] = "std::__";
   if (s.compare(0, strlen(prefix), prefix) == 0) {
-    auto end = s.find("::", strlen(prefix));
+    std::string::size_type end = s.find("::", strlen(prefix));
     if (end != s.npos) {
-      // Erase the `::__` plus whatever was between that and the next `::`.
-      s.erase(strlen("std"), strlen("::__") + end - strlen(prefix));
+      // Erase everything between the initial `std` and the second `::`.
+      s.erase(strlen("std"), end - strlen("std"));
     }
   }
   return s;
@@ -87,9 +87,9 @@ std::string GetTypeName() {
   using abi::__cxa_demangle;
 #   endif  // GTEST_HAS_CXXABI_H_
   char* const readable_name = __cxa_demangle(name, 0, 0, &status);
-  std::string name_str(status == 0 ? readable_name : name);
+  const std::string name_str(status == 0 ? readable_name : name);
   free(readable_name);
-  return CanonicalizeForStdLibVersioning(std::move(name_str));
+  return CanonicalizeForStdLibVersioning(name_str);
 #  else
   return name;
 #  endif  // GTEST_HAS_CXXABI_H_ || __HP_aCC

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -380,6 +380,31 @@ TEST(GetTestTypeIdTest, ReturnsTheSameValueInsideOrOutsideOfGoogleTest) {
   EXPECT_EQ(kTestTypeIdInGoogleTest, GetTestTypeId());
 }
 
+// Tests CanonicalizeForStdLibVersioning.
+
+using ::testing::internal::CanonicalizeForStdLibVersioning;
+
+TEST(CanonicalizeForStdLibVersioning, LeavesUnversionedNamesUnchanged) {
+  EXPECT_EQ("std::bind", CanonicalizeForStdLibVersioning("std::bind"));
+  EXPECT_EQ("std::_", CanonicalizeForStdLibVersioning("std::_"));
+  EXPECT_EQ("std::__foo", CanonicalizeForStdLibVersioning("std::__foo"));
+  EXPECT_EQ("gtl::__1::x", CanonicalizeForStdLibVersioning("gtl::__1::x"));
+  EXPECT_EQ("__1::x", CanonicalizeForStdLibVersioning("__1::x"));
+  EXPECT_EQ("::__1::x", CanonicalizeForStdLibVersioning("::__1::x"));
+}
+
+TEST(CanonicalizeForStdLibVersioning, ElidesDoubleUnderNames) {
+  EXPECT_EQ("std::bind", CanonicalizeForStdLibVersioning("std::__1::bind"));
+  EXPECT_EQ("std::_", CanonicalizeForStdLibVersioning("std::__1::_"));
+
+  EXPECT_EQ("std::bind", CanonicalizeForStdLibVersioning("std::__g::bind"));
+  EXPECT_EQ("std::_", CanonicalizeForStdLibVersioning("std::__g::_"));
+
+  EXPECT_EQ("std::bind",
+            CanonicalizeForStdLibVersioning("std::__google::bind"));
+  EXPECT_EQ("std::_", CanonicalizeForStdLibVersioning("std::__google::_"));
+}
+  
 // Tests FormatTimeInMillisAsSeconds().
 
 TEST(FormatTimeInMillisAsSecondsTest, FormatsZero) {


### PR DESCRIPTION
Add support for versioned standard libraries.

This canonicalizes demangled names by omitting a nested inline namespace within namespace std if the name of the nested namespace begins with a double underscore.  This improves compatibility with libc++.
