### PR TITLE
Workaround nonportable operator<< assumptions in VS2017 15.8

### DIFF
--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -285,6 +285,13 @@ void DefaultPrintNonContainerTo(const T& value, ::std::ostream* os) {
   *os << value;
 }
 
+#if GTEST_LANG_CXX11
+inline void DefaultPrintNonContainerTo(nullptr_t, ::std::ostream* os) {
+  ::testing::internal2::TypeWithoutFormatter<nullptr_t,
+    ::testing::internal2::kOtherType>::PrintValue(nullptr, os);
+}
+#endif
+
 }  // namespace testing_internal
 
 namespace testing {

--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -286,8 +286,8 @@ void DefaultPrintNonContainerTo(const T& value, ::std::ostream* os) {
 }
 
 #if GTEST_LANG_CXX11
-inline void DefaultPrintNonContainerTo(nullptr_t, ::std::ostream* os) {
-  ::testing::internal2::TypeWithoutFormatter<nullptr_t,
+inline void DefaultPrintNonContainerTo(::std::nullptr_t, ::std::ostream* os) {
+  ::testing::internal2::TypeWithoutFormatter<::std::nullptr_t,
     ::testing::internal2::kOtherType>::PrintValue(nullptr, os);
 }
 #endif

--- a/googletest/test/gtest_output_test_.cc
+++ b/googletest/test/gtest_output_test_.cc
@@ -994,6 +994,15 @@ TEST_F(ExpectFailureTest, ExpectNonFatalFailureOnAllThreads) {
                                          "Some other non-fatal failure.");
 }
 
+#if GTEST_LANG_CXX11
+TEST(PrintableTypesTest, NullptrEmission) {
+  // tests that the following do not fail to compile due to ambiguities
+  void * nullyVoid = nullptr;
+  EXPECT_EQ(nullptr, nullyVoid);
+  EXPECT_EQ(nullyVoid, nullptr);
+  EXPECT_EQ(nullptr, nullptr);
+}
+#endif
 
 // Two test environments for testing testing::AddGlobalTestEnvironment().
 

--- a/googletest/test/gtest_output_test_.cc
+++ b/googletest/test/gtest_output_test_.cc
@@ -994,15 +994,6 @@ TEST_F(ExpectFailureTest, ExpectNonFatalFailureOnAllThreads) {
                                          "Some other non-fatal failure.");
 }
 
-#if GTEST_LANG_CXX11
-TEST(PrintableTypesTest, NullptrEmission) {
-  // tests that the following do not fail to compile due to ambiguities
-  void * nullyVoid = nullptr;
-  EXPECT_EQ(nullptr, nullyVoid);
-  EXPECT_EQ(nullyVoid, nullptr);
-  EXPECT_EQ(nullptr, nullptr);
-}
-#endif
 
 // Two test environments for testing testing::AddGlobalTestEnvironment().
 


### PR DESCRIPTION
This is a temporary workaround to get tests running again; issue #1616 isn't technically resolved.