### PR TITLE
Reduce the number of strcmp calling while initialization

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -4907,11 +4907,11 @@ TestCase* UnitTestImpl::GetTestCase(const char* test_case_name,
                                     Test::SetUpTestCaseFunc set_up_tc,
                                     Test::TearDownTestCaseFunc tear_down_tc) {
   // Can we find a TestCase with the given name?
-  const std::vector<TestCase*>::const_iterator test_case =
-      std::find_if(test_cases_.begin(), test_cases_.end(),
+  const std::vector<TestCase*>::const_reverse_iterator test_case =
+      std::find_if(test_cases_.rbegin(), test_cases_.rend(),
                    TestCaseNameIs(test_case_name));
 
-  if (test_case != test_cases_.end())
+  if (test_case != test_cases_.rend())
     return *test_case;
 
   // No.  Let's create one.


### PR DESCRIPTION
When we do parallel test execution with a process for a test,
initialization of gtest become performance bottleneck when the test
binary contains many testcases.

Especially, some parameterlized test in chromium browser affected by
largely when address sanitizer is enabled.
Address sanitizer does not allow using optimized strcmp function and
test addition in parameterized test require lookup of test case using
strcmp.

This patch reduces the number of strcmp, it is called when registering
parameterized test. Using reverse iterator improves the time to find
registered tests in such case.

Some tests for chromium browser using address sanitizer finished 2x
faster with this patch.