### PR TITLE
fix #907: add support for std::string_view

### DIFF
--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -116,6 +116,10 @@
 #include "absl/types/optional.h"
 #endif  // GTEST_HAS_ABSL
 
+#if GTEST_HAS_STD_STRINGVIEW
+#include <string_view>
+#endif  // GTEST_HAS_STD_STRINGVIEW
+
 namespace testing {
 
 // Definitions in the 'internal' and 'internal2' name spaces are
@@ -635,6 +639,13 @@ inline void PrintTo(absl::string_view sp, ::std::ostream* os) {
   PrintTo(::std::string(sp), os);
 }
 #endif  // GTEST_HAS_ABSL
+
+#if GTEST_HAS_STD_STRINGVIEW
+// Overload for std::string_view.
+inline void PrintTo(::std::string_view sp, ::std::ostream* os) {
+  PrintTo(::std::string(sp), os);
+}
+#endif  // GTEST_HAS_STD_STRINGVIEW
 
 #if GTEST_LANG_CXX11
 inline void PrintTo(std::nullptr_t, ::std::ostream* os) { *os << "(nullptr)"; }

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -550,6 +550,13 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
     (GTEST_HAS_STD_WSTRING && GTEST_HAS_GLOBAL_STRING)
 #endif  // GTEST_HAS_GLOBAL_WSTRING
 
+#ifndef GTEST_HAS_STD_STRINGVIEW
+// The user didn't tell us whether ::std::string_view is available, so we need
+// to figure it out.
+# define GTEST_HAS_STD_STRINGVIEW \
+    (__cplusplus >= 201703L)
+#endif  // GTEST_HAS_STD_STRINGVIEW
+
 // Determines whether RTTI is available.
 #ifndef GTEST_HAS_RTTI
 // The user didn't tell us whether RTTI is enabled, so we need to

--- a/googletest/test/gtest-printers_test.cc
+++ b/googletest/test/gtest-printers_test.cc
@@ -804,6 +804,23 @@ TEST(PrintStringViewTest, UnprintableCharacters) {
 
 #endif  // GTEST_HAS_ABSL
 
+#if GTEST_HAS_STD_STRINGVIEW
+
+// Tests printing ::std::string_view.
+
+TEST(PrintStdStringViewTest, SimpleStringView) {
+  const ::std::string_view sp = "Hello";
+  EXPECT_EQ("\"Hello\"", Print(sp));
+}
+
+TEST(PrintStdStringViewTest, UnprintableCharacters) {
+  const char str[] = "NUL (\0) and \r\t";
+  const ::std::string_view sp(str, sizeof(str) - 1);
+  EXPECT_EQ("\"NUL (\\0) and \\r\\t\"", Print(sp));
+}
+
+#endif  // GTEST_HAS_STD_STRINGVIEW
+
 // Tests printing STL containers.
 
 TEST(PrintStlContainerTest, EmptyDeque) {


### PR DESCRIPTION
Implementation is identical to absl::string_view.