### PR TITLE
FIX: Compilation warning. Initialize MutexBase's owner_ field to 0.

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -2093,7 +2093,7 @@ class MutexBase {
 // This allows initialization to work whether pthread_t is a scalar or struct.
 // The flag -Wmissing-field-initializers must not be specified for this to work.
 #  define GTEST_DEFINE_STATIC_MUTEX_(mutex) \
-     ::testing::internal::MutexBase mutex = { PTHREAD_MUTEX_INITIALIZER, false }
+     ::testing::internal::MutexBase mutex = { PTHREAD_MUTEX_INITIALIZER, false, 0 }
 
 // The Mutex class can only be used for mutexes created at runtime. It
 // shares its API with MutexBase otherwise.


### PR DESCRIPTION
This fixes a warning from GCC (using Qt Creator and Qt 5.9) that complains about a member not being initialised. Since the owner_ attribute is an unsigned long int redefined as pthread_t we can set the value to 0.