### PR TITLE
VS2005 with SP1(_MSC_VER=1400) already supports __pragma

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -313,7 +313,7 @@
 //   GTEST_DISABLE_MSC_WARNINGS_PUSH_(4800 4385)
 //   /* code that triggers warnings C4800 and C4385 */
 //   GTEST_DISABLE_MSC_WARNINGS_POP_()
-#if _MSC_VER >= 1500
+#if _MSC_VER >= 1400
 # define GTEST_DISABLE_MSC_WARNINGS_PUSH_(warnings) \
     __pragma(warning(push))                        \
     __pragma(warning(disable: warnings))


### PR DESCRIPTION
When I include the gtest.cc to my project and compile it with vs2005 sp1, I got a few of warnings like these :
```
1>..\googletest\include\gtest\internal\gtest-port.h(2489) : warning C4996: 'strncpy': This function or variable may be unsafe. Consider using strncpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
1>        c:\program files (x86)\microsoft visual studio 8\vc\include\string.h(157) : see declaration of 'strncpy'
1>..\googletest\include\gtest\internal\gtest-port.h(2497) : warning C4996: 'chdir': The POSIX name for this item is deprecated. Instead, use the ISO C++ conformant name: _chdir. See online help for details.
1>        c:\program files (x86)\microsoft visual studio 8\vc\include\direct.h(127) : see declaration of 'chdir'
1>..\googletest\include\gtest\internal\gtest-port.h(2500) : warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
1>        c:\program files (x86)\microsoft visual studio 8\vc\include\stdio.h(234) : see declaration of 'fopen'
1>..\googletest\include\gtest\internal\gtest-port.h(2504) : warning C4996: 'freopen': This function or variable may be unsafe. Consider using freopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
1>        c:\program files (x86)\microsoft visual studio 8\vc\include\stdio.h(245) : see declaration of 'freopen'
1>..\googletest\include\gtest\internal\gtest-port.h(2506) : warning C4996: 'fdopen': The POSIX name for this item is deprecated. Instead, use the ISO C++ conformant name: _fdopen. See online help for details.
1>        c:\program files (x86)\microsoft visual studio 8\vc\include\stdio.h(686) : see declaration of 'fdopen'
1>..\googletest\include\gtest\internal\gtest-port.h(2511) : warning C4996: 'read': The POSIX name for this item is deprecated. Instead, use the ISO C++ conformant name: _read. See online help for details.
1>        c:\program files (x86)\microsoft visual studio 8\vc\include\io.h(329) : see declaration of 'read'
1>..\googletest\include\gtest\internal\gtest-port.h(2514) : warning C4996: 'write': The POSIX name for this item is deprecated. Instead, use the ISO C++ conformant name: _write. See online help for details.
1>        c:\program files (x86)\microsoft visual studio 8\vc\include\io.h(334) : see declaration of 'write'
1>..\googletest\include\gtest\internal\gtest-port.h(2516) : warning C4996: 'close': The POSIX name for this item is deprecated. Instead, use the ISO C++ conformant name: _close. See online help for details.
1>        c:\program files (x86)\microsoft visual studio 8\vc\include\io.h(318) : see declaration of 'close'
1>..\googletest\include\gtest\internal\gtest-port.h(2517) : warning C4996: 'strerror': This function or variable may be unsafe. Consider using strerror_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
1>        c:\program files (x86)\microsoft visual studio 8\vc\include\string.h(126) : see declaration of 'strerror'
1>..\googletest\include\gtest\internal\gtest-port.h(2530) : warning C4996: 'getenv': This function or variable may be unsafe. Consider using _dupenv_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
```

The GTEST_DISABLE_MSC_WARNINGS_PUSH_ and GTEST_DISABLE_MSC_WARNINGS_POP_ macro which define in gtest-port.h seems to be something wrong：
```
#if _MSC_VER >= 1500     <-- here is the problem
# define GTEST_DISABLE_MSC_WARNINGS_PUSH_(warnings) \
    __pragma(warning(push))                        \
    __pragma(warning(disable: warnings))
# define GTEST_DISABLE_MSC_WARNINGS_POP_()          \
    __pragma(warning(pop))
#else
// Older versions of MSVC don't have __pragma.
# define GTEST_DISABLE_MSC_WARNINGS_PUSH_(warnings)
# define GTEST_DISABLE_MSC_WARNINGS_POP_()
#endif
```
In fact, VS2005 with SP1(_MSC_VER=1400) already supports __pragma. So in order to remove the warning, I change 1500 to 1400. That is all.