### PR TITLE
Adds stacktrace support from Abseil to Google Test

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -38,7 +38,7 @@ licenses(["notice"])
 
 config_setting(
     name = "windows",
-    values = { "cpu": "x64_windows" },
+    values = {"cpu": "x64_windows"},
 )
 
 config_setting(
@@ -50,7 +50,6 @@ config_setting(
     name = "has_absl",
     values = {"define": "absl=1"},
 )
-
 
 # Google Test including Google Mock
 cc_library(
@@ -70,7 +69,7 @@ cc_library(
             "googlemock/src/gmock_main.cc",
         ],
     ),
-    hdrs =glob([
+    hdrs = glob([
         "googletest/include/gtest/*.h",
         "googlemock/include/gmock/*.h",
     ]),
@@ -79,6 +78,14 @@ cc_library(
             ":windows": [],
             ":windows_msvc": [],
             "//conditions:default": ["-pthread"],
+        },
+    ),
+    defines = select(
+        {
+            ":has_absl": [
+                "GTEST_HAS_ABSL=1",
+            ],
+            "//conditions:default": [],
         },
     ),
     includes = [
@@ -94,21 +101,18 @@ cc_library(
             "-pthread",
         ],
     }),
-    defines = select ({
-        ":has_absl": [
-        "GTEST_HAS_ABSL=1",
-        ],
-        "//conditions:default": [],
-    }
+    deps = select(
+        {
+            ":has_absl": [
+                "@com_google_absl//absl/debugging:failure_signal_handler",
+                "@com_google_absl//absl/debugging:stacktrace",
+                "@com_google_absl//absl/debugging:symbolize",
+                "@com_google_absl//absl/strings",
+                "@com_google_absl//absl/types:optional",
+            ],
+            "//conditions:default": [],
+        },
     ),
-    deps = select ({
-        ":has_absl": [
-        "@com_google_absl//absl/types:optional",
-        "@com_google_absl//absl/strings"
-        ],
-        "//conditions:default": [],
-    }
-    )
 )
 
 cc_library(

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -284,7 +284,7 @@ if (gtest_build_tests)
   py_test(gtest_list_tests_unittest)
 
   cxx_executable(gtest_output_test_ test gtest)
-  py_test(gtest_output_test)
+  py_test(gtest_output_test --no_stacktrace_support)
 
   cxx_executable(gtest_shuffle_test_ test gtest)
   py_test(gtest_shuffle_test)
@@ -307,6 +307,6 @@ if (gtest_build_tests)
   py_test(gtest_json_outfiles_test)
 
   cxx_executable(gtest_xml_output_unittest_ test gtest)
-  py_test(gtest_xml_output_unittest)
+  py_test(gtest_xml_output_unittest --no_stacktrace_support)
   py_test(gtest_json_output_unittest)
 endif()

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -257,14 +257,14 @@ function(py_test name)
         add_test(
           NAME ${name}
           COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/${name}.py
-              --build_dir=${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
+              --build_dir=${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG> ${ARGN})
       else (CMAKE_CONFIGURATION_TYPES)
 	# Single-configuration build generators like Makefile generators
 	# don't have subdirs below CMAKE_CURRENT_BINARY_DIR.
         add_test(
           NAME ${name}
           COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/${name}.py
-              --build_dir=${CMAKE_CURRENT_BINARY_DIR})
+              --build_dir=${CMAKE_CURRENT_BINARY_DIR} ${ARGN})
       endif (CMAKE_CONFIGURATION_TYPES)
     else (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.1)
       # ${CMAKE_CURRENT_BINARY_DIR} is known at configuration time, so we can
@@ -274,7 +274,7 @@ function(py_test name)
       add_test(
         ${name}
         ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/${name}.py
-          --build_dir=${CMAKE_CURRENT_BINARY_DIR}/\${CTEST_CONFIGURATION_TYPE})
+          --build_dir=${CMAKE_CURRENT_BINARY_DIR}/\${CTEST_CONFIGURATION_TYPE} ${ARGN})
     endif (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.1)
   endif(PYTHONINTERP_FOUND)
 endfunction()

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -446,6 +446,16 @@ class OsStackTraceGetter : public OsStackTraceGetterInterface {
   virtual void UponLeavingGTest();
 
  private:
+#if GTEST_HAS_ABSL
+  Mutex mutex_;  // Protects all internal state.
+
+  // We save the stack frame below the frame that calls user code.
+  // We do this because the address of the frame immediately below
+  // the user code changes between the call to UponLeavingGTest()
+  // and any calls to the stack trace code from within the user code.
+  void* caller_frame_ = nullptr;
+#endif  // GTEST_HAS_ABSL
+
   GTEST_DISALLOW_COPY_AND_ASSIGN_(OsStackTraceGetter);
 };
 

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -139,6 +139,13 @@
 # define vsnprintf _vsnprintf
 #endif  // GTEST_OS_WINDOWS
 
+#if GTEST_HAS_ABSL
+#include "absl/debugging/failure_signal_handler.h"
+#include "absl/debugging/stacktrace.h"
+#include "absl/debugging/symbolize.h"
+#include "absl/strings/str_cat.h"
+#endif  // GTEST_HAS_ABSL
+
 namespace testing {
 
 using internal::CountIf;
@@ -227,6 +234,13 @@ GTEST_DEFINE_string_(
     "'-' and a : separated list of negative patterns (tests to "
     "exclude).  A test is run if it matches one of the positive "
     "patterns and does not match any of the negative patterns.");
+
+GTEST_DEFINE_bool_(
+    install_failure_signal_handler,
+    internal::BoolFromGTestEnv("install_failure_signal_handler", false),
+    "If true and supported on the current platform, " GTEST_NAME_ " should "
+    "install a signal handler that dumps debugging information when fatal "
+    "signals are raised.");
 
 GTEST_DEFINE_bool_(list_tests, false,
                    "List all tests without running them.");
@@ -4243,12 +4257,67 @@ void StreamingListener::SocketWriter::MakeConnection() {
 const char* const OsStackTraceGetterInterface::kElidedFramesMarker =
     "... " GTEST_NAME_ " internal frames ...";
 
-std::string OsStackTraceGetter::CurrentStackTrace(int /*max_depth*/,
-                                                  int /*skip_count*/) {
+std::string OsStackTraceGetter::CurrentStackTrace(int max_depth, int skip_count)
+    GTEST_LOCK_EXCLUDED_(mutex_) {
+#if GTEST_HAS_ABSL
+  std::string result;
+
+  if (max_depth <= 0) {
+    return result;
+  }
+
+  max_depth = std::min(max_depth, kMaxStackTraceDepth);
+
+  std::vector<void*> raw_stack(max_depth);
+  // Skips the frames requested by the caller, plus this function.
+  const int raw_stack_size =
+      absl::GetStackTrace(&raw_stack[0], max_depth, skip_count + 1);
+
+  void* caller_frame = nullptr;
+  {
+    MutexLock lock(&mutex_);
+    caller_frame = caller_frame_;
+  }
+
+  for (int i = 0; i < raw_stack_size; ++i) {
+    if (raw_stack[i] == caller_frame &&
+        !GTEST_FLAG(show_internal_stack_frames)) {
+      // Add a marker to the trace and stop adding frames.
+      absl::StrAppend(&result, kElidedFramesMarker, "\n");
+      break;
+    }
+
+    char tmp[1024];
+    const char* symbol = "(unknown)";
+    if (absl::Symbolize(raw_stack[i], tmp, sizeof(tmp))) {
+      symbol = tmp;
+    }
+
+    char line[1024];
+    snprintf(line, sizeof(line), "  %p: %s\n", raw_stack[i], symbol);
+    result += line;
+  }
+
+  return result;
+
+#else  // !GTEST_HAS_ABSL
+  static_cast<void>(max_depth);
+  static_cast<void>(skip_count);
   return "";
+#endif  // GTEST_HAS_ABSL
 }
 
-void OsStackTraceGetter::UponLeavingGTest() {}
+void OsStackTraceGetter::UponLeavingGTest() GTEST_LOCK_EXCLUDED_(mutex_) {
+#if GTEST_HAS_ABSL
+  void* caller_frame = nullptr;
+  if (absl::GetStackTrace(&caller_frame, 1, 3) <= 0) {
+    caller_frame = nullptr;
+  }
+
+  MutexLock lock(&mutex_);
+  caller_frame_ = caller_frame;
+#endif  // GTEST_HAS_ABSL
+}
 
 // A helper class that creates the premature-exit file in its
 // constructor and deletes the file in its destructor.
@@ -4865,6 +4934,13 @@ void UnitTestImpl::PostFlagParsingInit() {
     // Configures listeners for streaming test results to the specified server.
     ConfigureStreamingOutput();
 #endif  // GTEST_CAN_STREAM_RESULTS_
+
+#if GTEST_HAS_ABSL
+    if (GTEST_FLAG(install_failure_signal_handler)) {
+      absl::FailureSignalHandlerOptions options;
+      absl::InstallFailureSignalHandler(options);
+    }
+#endif  // GTEST_HAS_ABSL
   }
 }
 
@@ -5768,6 +5844,10 @@ void InitGoogleTestImpl(int* argc, CharType** argv) {
   for (int i = 0; i != *argc; i++) {
     g_argvs.push_back(StreamableToString(argv[i]));
   }
+
+#if GTEST_HAS_ABSL
+  absl::InitializeSymbolizer(g_argvs[0].c_str());
+#endif  // GTEST_HAS_ABSL
 
   ParseGoogleTestFlagsOnly(argc, argv);
   GetUnitTestImpl()->PostFlagParsingInit();

--- a/googletest/test/BUILD.bazel
+++ b/googletest/test/BUILD.bazel
@@ -34,35 +34,48 @@
 
 licenses(["notice"])
 
-""" gtest own tests """
+config_setting(
+    name = "windows",
+    values = {"cpu": "x64_windows"},
+)
+
+config_setting(
+    name = "windows_msvc",
+    values = {"cpu": "x64_windows_msvc"},
+)
+
+config_setting(
+    name = "has_absl",
+    values = {"define": "absl=1"},
+)
 
 #on windows exclude gtest-tuple.h and gtest-tuple_test.cc
 cc_test(
     name = "gtest_all_test",
     size = "small",
-    srcs =  glob(
-                    include = [
-                        "gtest-*.cc",
-                        "*.h",
-                        "googletest/include/gtest/**/*.h",
-                    ],
-                    exclude = [
-                        "gtest-unittest-api_test.cc",
-                        "gtest-tuple_test.cc",
-                        "googletest/src/gtest-all.cc",
-                        "gtest_all_test.cc",
-                        "gtest-death-test_ex_test.cc",
-                        "gtest-listener_test.cc",
-                        "gtest-unittest-api_test.cc",
-                        "gtest-param-test_test.cc",
-                    ],
-                ) + select({
+    srcs = glob(
+        include = [
+            "gtest-*.cc",
+            "*.h",
+            "googletest/include/gtest/**/*.h",
+        ],
+        exclude = [
+            "gtest-unittest-api_test.cc",
+            "gtest-tuple_test.cc",
+            "googletest/src/gtest-all.cc",
+            "gtest_all_test.cc",
+            "gtest-death-test_ex_test.cc",
+            "gtest-listener_test.cc",
+            "gtest-unittest-api_test.cc",
+            "gtest-param-test_test.cc",
+        ],
+    ) + select({
         "//:windows": [],
         "//:windows_msvc": [],
         "//conditions:default": [
             "gtest-tuple_test.cc",
         ],
-        }),
+    }),
     copts = select({
         "//:windows": ["-DGTEST_USE_OWN_TR1_TUPLE=0"],
         "//:windows_msvc": ["-DGTEST_USE_OWN_TR1_TUPLE=0"],
@@ -135,7 +148,6 @@ py_library(
     name = "gtest_test_utils",
     testonly = 1,
     srcs = ["gtest_test_utils.py"],
-
 )
 
 cc_binary(
@@ -144,6 +156,7 @@ cc_binary(
     srcs = ["gtest_help_test_.cc"],
     deps = ["//:gtest_main"],
 )
+
 py_test(
     name = "gtest_help_test",
     size = "small",
@@ -163,6 +176,10 @@ py_test(
     name = "gtest_output_test",
     size = "small",
     srcs = ["gtest_output_test.py"],
+    args = select({
+        ":has_absl": [],
+        "//conditions:default": ["--no_stacktrace_support"],
+    }),
     data = [
         "gtest_output_test_golden_lin.txt",
         ":gtest_output_test_",
@@ -176,6 +193,7 @@ cc_binary(
     srcs = ["gtest_color_test_.cc"],
     deps = ["//:gtest"],
 )
+
 py_test(
     name = "gtest_color_test",
     size = "small",
@@ -327,6 +345,10 @@ py_test(
         "gtest_xml_output_unittest.py",
         "gtest_xml_test_utils.py",
     ],
+    args = select({
+        ":has_absl": [],
+        "//conditions:default": ["--no_stacktrace_support"],
+    }),
     data = [
         # We invoke gtest_no_test_unittest to verify the XML output
         # when the test program contains no test definition.

--- a/googletest/test/gtest_output_test.py
+++ b/googletest/test/gtest_output_test.py
@@ -52,6 +52,9 @@ import gtest_test_utils
 GENGOLDEN_FLAG = '--gengolden'
 CATCH_EXCEPTIONS_ENV_VAR_NAME = 'GTEST_CATCH_EXCEPTIONS'
 
+# The flag indicating stacktraces are not supported
+NO_STACKTRACE_SUPPORT_FLAG = '--no_stacktrace_support'
+
 IS_LINUX = os.name == 'posix' and os.uname()[0] == 'Linux'
 IS_WINDOWS = os.name == 'nt'
 
@@ -252,13 +255,12 @@ test_list = GetShellCommandOutput(COMMAND_LIST_TESTS)
 SUPPORTS_DEATH_TESTS = 'DeathTest' in test_list
 SUPPORTS_TYPED_TESTS = 'TypedTest' in test_list
 SUPPORTS_THREADS = 'ExpectFailureWithThreadsTest' in test_list
-SUPPORTS_STACK_TRACES = IS_LINUX
+SUPPORTS_STACK_TRACES = NO_STACKTRACE_SUPPORT_FLAG not in sys.argv
 
 CAN_GENERATE_GOLDEN_FILE = (SUPPORTS_DEATH_TESTS and
                             SUPPORTS_TYPED_TESTS and
                             SUPPORTS_THREADS and
-                            SUPPORTS_STACK_TRACES and
-                            not IS_WINDOWS)
+                            SUPPORTS_STACK_TRACES)
 
 class GTestOutputTest(gtest_test_utils.TestCase):
   def RemoveUnsupportedTests(self, test_output):
@@ -325,7 +327,11 @@ class GTestOutputTest(gtest_test_utils.TestCase):
 
 
 if __name__ == '__main__':
-  if sys.argv[1:] == [GENGOLDEN_FLAG]:
+  if NO_STACKTRACE_SUPPORT_FLAG in sys.argv:
+    # unittest.main() can't handle unknown flags
+    sys.argv.remove(NO_STACKTRACE_SUPPORT_FLAG)
+
+  if GENGOLDEN_FLAG in sys.argv:
     if CAN_GENERATE_GOLDEN_FILE:
       output = GetOutputOfAllCommands()
       golden_file = open(GOLDEN_PATH, 'wb')

--- a/googletest/test/gtest_output_test_golden_lin.txt
+++ b/googletest/test/gtest_output_test_golden_lin.txt
@@ -4,10 +4,14 @@ gtest_output_test_.cc:#: Failure
 Value of: false
   Actual: false
 Expected: true
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Expected equality of these values:
   2
   3
+Stack trace: (omitted)
+
 [0;32m[==========] [mRunning 68 tests from 30 test cases.
 [0;32m[----------] [mGlobal test environment set-up.
 FooEnvironment::SetUp() called.
@@ -40,12 +44,16 @@ Expected equality of these values:
     Which is: "\"Line"
   actual
     Which is: "actual \"string\""
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Expected equality of these values:
   golden
     Which is: "\"Line"
   actual
     Which is: "actual \"string\""
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mNonfatalFailureTest.EscapesStringOperands
 [0;32m[ RUN      ] [mNonfatalFailureTest.DiffForLongStrings
 gtest_output_test_.cc:#: Failure
@@ -58,6 +66,8 @@ With diff:
 -\"Line\0 1\"
  Line 2
 
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mNonfatalFailureTest.DiffForLongStrings
 [0;32m[----------] [m3 tests from FatalFailureTest
 [0;32m[ RUN      ] [mFatalFailureTest.FatalFailureInSubroutine
@@ -67,6 +77,8 @@ Expected equality of these values:
   1
   x
     Which is: 2
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mFatalFailureTest.FatalFailureInSubroutine
 [0;32m[ RUN      ] [mFatalFailureTest.FatalFailureInNestedSubroutine
 (expecting a failure that x should be 1)
@@ -75,6 +87,8 @@ Expected equality of these values:
   1
   x
     Which is: 2
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mFatalFailureTest.FatalFailureInNestedSubroutine
 [0;32m[ RUN      ] [mFatalFailureTest.NonfatalFailureInSubroutine
 (expecting a failure on false)
@@ -82,6 +96,8 @@ gtest_output_test_.cc:#: Failure
 Value of: false
   Actual: false
 Expected: true
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mFatalFailureTest.NonfatalFailureInSubroutine
 [0;32m[----------] [m1 test from LoggingTest
 [0;32m[ RUN      ] [mLoggingTest.InterleavingLoggingAndAssertions
@@ -90,10 +106,14 @@ i == 0
 i == 1
 gtest_output_test_.cc:#: Failure
 Expected: (3) >= (a[i]), actual: 3 vs 9
+Stack trace: (omitted)
+
 i == 2
 i == 3
 gtest_output_test_.cc:#: Failure
 Expected: (3) >= (a[i]), actual: 3 vs 6
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mLoggingTest.InterleavingLoggingAndAssertions
 [0;32m[----------] [m7 tests from SCOPED_TRACETest
 [0;32m[ RUN      ] [mSCOPED_TRACETest.AcceptedValues
@@ -105,20 +125,28 @@ gtest_output_test_.cc:#: (null)
 gtest_output_test_.cc:#: 1337
 gtest_output_test_.cc:#: std::string
 gtest_output_test_.cc:#: literal string
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mSCOPED_TRACETest.AcceptedValues
 [0;32m[ RUN      ] [mSCOPED_TRACETest.ObeysScopes
 (expected to fail)
 gtest_output_test_.cc:#: Failure
 Failed
 This failure is expected, and shouldn't have a trace.
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 This failure is expected, and should have a trace.
 Google Test trace:
 gtest_output_test_.cc:#: Expected trace
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 This failure is expected, and shouldn't have a trace.
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mSCOPED_TRACETest.ObeysScopes
 [0;32m[ RUN      ] [mSCOPED_TRACETest.WorksInLoop
 (expected to fail)
@@ -129,6 +157,8 @@ Expected equality of these values:
     Which is: 1
 Google Test trace:
 gtest_output_test_.cc:#: i = 1
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Expected equality of these values:
   1
@@ -136,6 +166,8 @@ Expected equality of these values:
     Which is: 2
 Google Test trace:
 gtest_output_test_.cc:#: i = 2
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mSCOPED_TRACETest.WorksInLoop
 [0;32m[ RUN      ] [mSCOPED_TRACETest.WorksInSubroutine
 (expected to fail)
@@ -146,6 +178,8 @@ Expected equality of these values:
     Which is: 1
 Google Test trace:
 gtest_output_test_.cc:#: n = 1
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Expected equality of these values:
   1
@@ -153,6 +187,8 @@ Expected equality of these values:
     Which is: 2
 Google Test trace:
 gtest_output_test_.cc:#: n = 2
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mSCOPED_TRACETest.WorksInSubroutine
 [0;32m[ RUN      ] [mSCOPED_TRACETest.CanBeNested
 (expected to fail)
@@ -164,6 +200,8 @@ Expected equality of these values:
 Google Test trace:
 gtest_output_test_.cc:#: n = 2
 gtest_output_test_.cc:#: 
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mSCOPED_TRACETest.CanBeNested
 [0;32m[ RUN      ] [mSCOPED_TRACETest.CanBeRepeated
 (expected to fail)
@@ -172,12 +210,16 @@ Failed
 This failure is expected, and should contain trace point A.
 Google Test trace:
 gtest_output_test_.cc:#: A
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 This failure is expected, and should contain trace point A and B.
 Google Test trace:
 gtest_output_test_.cc:#: B
 gtest_output_test_.cc:#: A
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 This failure is expected, and should contain trace point A, B, and C.
@@ -185,6 +227,8 @@ Google Test trace:
 gtest_output_test_.cc:#: C
 gtest_output_test_.cc:#: B
 gtest_output_test_.cc:#: A
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 This failure is expected, and should contain trace point A, B, and D.
@@ -192,6 +236,8 @@ Google Test trace:
 gtest_output_test_.cc:#: D
 gtest_output_test_.cc:#: B
 gtest_output_test_.cc:#: A
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mSCOPED_TRACETest.CanBeRepeated
 [0;32m[ RUN      ] [mSCOPED_TRACETest.WorksConcurrently
 (expecting 6 failures)
@@ -200,27 +246,39 @@ Failed
 Expected failure #1 (in thread B, only trace B alive).
 Google Test trace:
 gtest_output_test_.cc:#: Trace B
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 Expected failure #2 (in thread A, trace A & B both alive).
 Google Test trace:
 gtest_output_test_.cc:#: Trace A
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 Expected failure #3 (in thread B, trace A & B both alive).
 Google Test trace:
 gtest_output_test_.cc:#: Trace B
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 Expected failure #4 (in thread B, only trace A alive).
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 Expected failure #5 (in thread A, only trace A alive).
 Google Test trace:
 gtest_output_test_.cc:#: Trace A
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 Expected failure #6 (in thread A, no trace alive).
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mSCOPED_TRACETest.WorksConcurrently
 [0;32m[----------] [m1 test from ScopedTraceTest
 [0;32m[ RUN      ] [mScopedTraceTest.WithExplicitFileAndLine
@@ -229,6 +287,8 @@ Failed
 Check that the trace is attached to a particular location.
 Google Test trace:
 explicit_file.cc:123: expected trace message
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mScopedTraceTest.WithExplicitFileAndLine
 [0;32m[----------] [m1 test from NonFatalFailureInFixtureConstructorTest
 [0;32m[ RUN      ] [mNonFatalFailureInFixtureConstructorTest.FailureInConstructor
@@ -236,18 +296,28 @@ explicit_file.cc:123: expected trace message
 gtest_output_test_.cc:#: Failure
 Failed
 Expected failure #1, in the test fixture c'tor.
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 Expected failure #2, in SetUp().
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 Expected failure #3, in the test body.
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 Expected failure #4, in TearDown.
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 Expected failure #5, in the test fixture d'tor.
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mNonFatalFailureInFixtureConstructorTest.FailureInConstructor
 [0;32m[----------] [m1 test from FatalFailureInFixtureConstructorTest
 [0;32m[ RUN      ] [mFatalFailureInFixtureConstructorTest.FailureInConstructor
@@ -255,9 +325,13 @@ Expected failure #5, in the test fixture d'tor.
 gtest_output_test_.cc:#: Failure
 Failed
 Expected failure #1, in the test fixture c'tor.
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 Expected failure #2, in the test fixture d'tor.
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mFatalFailureInFixtureConstructorTest.FailureInConstructor
 [0;32m[----------] [m1 test from NonFatalFailureInSetUpTest
 [0;32m[ RUN      ] [mNonFatalFailureInSetUpTest.FailureInSetUp
@@ -265,15 +339,23 @@ Expected failure #2, in the test fixture d'tor.
 gtest_output_test_.cc:#: Failure
 Failed
 Expected failure #1, in SetUp().
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 Expected failure #2, in the test function.
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 Expected failure #3, in TearDown().
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 Expected failure #4, in the test fixture d'tor.
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mNonFatalFailureInSetUpTest.FailureInSetUp
 [0;32m[----------] [m1 test from FatalFailureInSetUpTest
 [0;32m[ RUN      ] [mFatalFailureInSetUpTest.FailureInSetUp
@@ -281,18 +363,26 @@ Expected failure #4, in the test fixture d'tor.
 gtest_output_test_.cc:#: Failure
 Failed
 Expected failure #1, in SetUp().
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 Expected failure #2, in TearDown().
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 Expected failure #3, in the test fixture d'tor.
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mFatalFailureInSetUpTest.FailureInSetUp
 [0;32m[----------] [m1 test from AddFailureAtTest
 [0;32m[ RUN      ] [mAddFailureAtTest.MessageContainsSpecifiedFileAndLineNumber
 foo.cc:42: Failure
 Failed
 Expected failure in foo.cc
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mAddFailureAtTest.MessageContainsSpecifiedFileAndLineNumber
 [0;32m[----------] [m4 tests from MixedUpTestCaseTest
 [0;32m[ RUN      ] [mMixedUpTestCaseTest.FirstTestFromNamespaceFoo
@@ -309,6 +399,8 @@ using two different test fixture classes.  This can happen if
 the two classes are from different namespaces or translation
 units and have the same name.  You should probably rename one
 of the classes to put the tests into different test cases.
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mMixedUpTestCaseTest.ThisShouldFail
 [0;32m[ RUN      ] [mMixedUpTestCaseTest.ThisShouldFailToo
 gtest.cc:#: Failure
@@ -320,6 +412,8 @@ using two different test fixture classes.  This can happen if
 the two classes are from different namespaces or translation
 units and have the same name.  You should probably rename one
 of the classes to put the tests into different test cases.
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mMixedUpTestCaseTest.ThisShouldFailToo
 [0;32m[----------] [m2 tests from MixedUpTestCaseWithSameTestNameTest
 [0;32m[ RUN      ] [mMixedUpTestCaseWithSameTestNameTest.TheSecondTestWithThisNameShouldFail
@@ -334,6 +428,8 @@ using two different test fixture classes.  This can happen if
 the two classes are from different namespaces or translation
 units and have the same name.  You should probably rename one
 of the classes to put the tests into different test cases.
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mMixedUpTestCaseWithSameTestNameTest.TheSecondTestWithThisNameShouldFail
 [0;32m[----------] [m2 tests from TEST_F_before_TEST_in_same_test_case
 [0;32m[ RUN      ] [mTEST_F_before_TEST_in_same_test_case.DefinedUsingTEST_F
@@ -348,6 +444,8 @@ test DefinedUsingTEST_F is defined using TEST_F but
 test DefinedUsingTESTAndShouldFail is defined using TEST.  You probably
 want to change the TEST to TEST_F or move it to another test
 case.
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mTEST_F_before_TEST_in_same_test_case.DefinedUsingTESTAndShouldFail
 [0;32m[----------] [m2 tests from TEST_before_TEST_F_in_same_test_case
 [0;32m[ RUN      ] [mTEST_before_TEST_F_in_same_test_case.DefinedUsingTEST
@@ -362,6 +460,8 @@ test DefinedUsingTEST_FAndShouldFail is defined using TEST_F but
 test DefinedUsingTEST is defined using TEST.  You probably
 want to change the TEST to TEST_F or move it to another test
 case.
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mTEST_before_TEST_F_in_same_test_case.DefinedUsingTEST_FAndShouldFail
 [0;32m[----------] [m8 tests from ExpectNonfatalFailureTest
 [0;32m[ RUN      ] [mExpectNonfatalFailureTest.CanReferenceGlobalVariables
@@ -375,6 +475,8 @@ case.
 gtest.cc:#: Failure
 Expected: 1 non-fatal failure
   Actual: 0 failures
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mExpectNonfatalFailureTest.FailsWhenThereIsNoNonfatalFailure
 [0;32m[ RUN      ] [mExpectNonfatalFailureTest.FailsWhenThereAreTwoNonfatalFailures
 (expecting a failure)
@@ -384,10 +486,16 @@ Expected: 1 non-fatal failure
 gtest_output_test_.cc:#: Non-fatal failure:
 Failed
 Expected non-fatal failure 1.
+Stack trace: (omitted)
+
 
 gtest_output_test_.cc:#: Non-fatal failure:
 Failed
 Expected non-fatal failure 2.
+Stack trace: (omitted)
+
+
+Stack trace: (omitted)
 
 [0;31m[  FAILED  ] [mExpectNonfatalFailureTest.FailsWhenThereAreTwoNonfatalFailures
 [0;32m[ RUN      ] [mExpectNonfatalFailureTest.FailsWhenThereIsOneFatalFailure
@@ -398,6 +506,10 @@ Expected: 1 non-fatal failure
 gtest_output_test_.cc:#: Fatal failure:
 Failed
 Expected fatal failure.
+Stack trace: (omitted)
+
+
+Stack trace: (omitted)
 
 [0;31m[  FAILED  ] [mExpectNonfatalFailureTest.FailsWhenThereIsOneFatalFailure
 [0;32m[ RUN      ] [mExpectNonfatalFailureTest.FailsWhenStatementReturns
@@ -405,12 +517,16 @@ Expected fatal failure.
 gtest.cc:#: Failure
 Expected: 1 non-fatal failure
   Actual: 0 failures
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mExpectNonfatalFailureTest.FailsWhenStatementReturns
 [0;32m[ RUN      ] [mExpectNonfatalFailureTest.FailsWhenStatementThrows
 (expecting a failure)
 gtest.cc:#: Failure
 Expected: 1 non-fatal failure
   Actual: 0 failures
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mExpectNonfatalFailureTest.FailsWhenStatementThrows
 [0;32m[----------] [m8 tests from ExpectFatalFailureTest
 [0;32m[ RUN      ] [mExpectFatalFailureTest.CanReferenceGlobalVariables
@@ -424,6 +540,8 @@ Expected: 1 non-fatal failure
 gtest.cc:#: Failure
 Expected: 1 fatal failure
   Actual: 0 failures
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mExpectFatalFailureTest.FailsWhenThereIsNoFatalFailure
 [0;32m[ RUN      ] [mExpectFatalFailureTest.FailsWhenThereAreTwoFatalFailures
 (expecting a failure)
@@ -433,10 +551,16 @@ Expected: 1 fatal failure
 gtest_output_test_.cc:#: Fatal failure:
 Failed
 Expected fatal failure.
+Stack trace: (omitted)
+
 
 gtest_output_test_.cc:#: Fatal failure:
 Failed
 Expected fatal failure.
+Stack trace: (omitted)
+
+
+Stack trace: (omitted)
 
 [0;31m[  FAILED  ] [mExpectFatalFailureTest.FailsWhenThereAreTwoFatalFailures
 [0;32m[ RUN      ] [mExpectFatalFailureTest.FailsWhenThereIsOneNonfatalFailure
@@ -447,6 +571,10 @@ Expected: 1 fatal failure
 gtest_output_test_.cc:#: Non-fatal failure:
 Failed
 Expected non-fatal failure.
+Stack trace: (omitted)
+
+
+Stack trace: (omitted)
 
 [0;31m[  FAILED  ] [mExpectFatalFailureTest.FailsWhenThereIsOneNonfatalFailure
 [0;32m[ RUN      ] [mExpectFatalFailureTest.FailsWhenStatementReturns
@@ -454,12 +582,16 @@ Expected non-fatal failure.
 gtest.cc:#: Failure
 Expected: 1 fatal failure
   Actual: 0 failures
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mExpectFatalFailureTest.FailsWhenStatementReturns
 [0;32m[ RUN      ] [mExpectFatalFailureTest.FailsWhenStatementThrows
 (expecting a failure)
 gtest.cc:#: Failure
 Expected: 1 fatal failure
   Actual: 0 failures
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mExpectFatalFailureTest.FailsWhenStatementThrows
 [0;32m[----------] [m2 tests from TypedTest/0, where TypeParam = int
 [0;32m[ RUN      ] [mTypedTest/0.Success
@@ -471,6 +603,8 @@ Expected equality of these values:
   TypeParam()
     Which is: 0
 Expected failure
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mTypedTest/0.Failure, where TypeParam = int
 [0;32m[----------] [m2 tests from Unsigned/TypedTestP/0, where TypeParam = unsigned char
 [0;32m[ RUN      ] [mUnsigned/TypedTestP/0.Success
@@ -483,8 +617,10 @@ Expected equality of these values:
   TypeParam()
     Which is: '\0'
 Expected failure
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mUnsigned/TypedTestP/0.Failure, where TypeParam = unsigned char
-[0;32m[----------] [m2 tests from Unsigned/TypedTestP/1, where TypeParam = unsigned
+[0;32m[----------] [m2 tests from Unsigned/TypedTestP/1, where TypeParam = unsigned int
 [0;32m[ RUN      ] [mUnsigned/TypedTestP/1.Success
 [0;32m[       OK ] [mUnsigned/TypedTestP/1.Success
 [0;32m[ RUN      ] [mUnsigned/TypedTestP/1.Failure
@@ -495,7 +631,9 @@ Expected equality of these values:
   TypeParam()
     Which is: 0
 Expected failure
-[0;31m[  FAILED  ] [mUnsigned/TypedTestP/1.Failure, where TypeParam = unsigned
+Stack trace: (omitted)
+
+[0;31m[  FAILED  ] [mUnsigned/TypedTestP/1.Failure, where TypeParam = unsigned int
 [0;32m[----------] [m4 tests from ExpectFailureTest
 [0;32m[ RUN      ] [mExpectFailureTest.ExpectFatalFailure
 (expecting 1 failure)
@@ -504,6 +642,10 @@ Expected: 1 fatal failure
   Actual:
 gtest_output_test_.cc:#: Success:
 Succeeded
+Stack trace: (omitted)
+
+
+Stack trace: (omitted)
 
 (expecting 1 failure)
 gtest.cc:#: Failure
@@ -512,6 +654,10 @@ Expected: 1 fatal failure
 gtest_output_test_.cc:#: Non-fatal failure:
 Failed
 Expected non-fatal failure.
+Stack trace: (omitted)
+
+
+Stack trace: (omitted)
 
 (expecting 1 failure)
 gtest.cc:#: Failure
@@ -520,6 +666,10 @@ Expected: 1 fatal failure containing "Some other fatal failure expected."
 gtest_output_test_.cc:#: Fatal failure:
 Failed
 Expected fatal failure.
+Stack trace: (omitted)
+
+
+Stack trace: (omitted)
 
 [0;31m[  FAILED  ] [mExpectFailureTest.ExpectFatalFailure
 [0;32m[ RUN      ] [mExpectFailureTest.ExpectNonFatalFailure
@@ -529,6 +679,10 @@ Expected: 1 non-fatal failure
   Actual:
 gtest_output_test_.cc:#: Success:
 Succeeded
+Stack trace: (omitted)
+
+
+Stack trace: (omitted)
 
 (expecting 1 failure)
 gtest.cc:#: Failure
@@ -537,6 +691,10 @@ Expected: 1 non-fatal failure
 gtest_output_test_.cc:#: Fatal failure:
 Failed
 Expected fatal failure.
+Stack trace: (omitted)
+
+
+Stack trace: (omitted)
 
 (expecting 1 failure)
 gtest.cc:#: Failure
@@ -545,6 +703,10 @@ Expected: 1 non-fatal failure containing "Some other non-fatal failure."
 gtest_output_test_.cc:#: Non-fatal failure:
 Failed
 Expected non-fatal failure.
+Stack trace: (omitted)
+
+
+Stack trace: (omitted)
 
 [0;31m[  FAILED  ] [mExpectFailureTest.ExpectNonFatalFailure
 [0;32m[ RUN      ] [mExpectFailureTest.ExpectFatalFailureOnAllThreads
@@ -554,6 +716,10 @@ Expected: 1 fatal failure
   Actual:
 gtest_output_test_.cc:#: Success:
 Succeeded
+Stack trace: (omitted)
+
+
+Stack trace: (omitted)
 
 (expecting 1 failure)
 gtest.cc:#: Failure
@@ -562,6 +728,10 @@ Expected: 1 fatal failure
 gtest_output_test_.cc:#: Non-fatal failure:
 Failed
 Expected non-fatal failure.
+Stack trace: (omitted)
+
+
+Stack trace: (omitted)
 
 (expecting 1 failure)
 gtest.cc:#: Failure
@@ -570,6 +740,10 @@ Expected: 1 fatal failure containing "Some other fatal failure expected."
 gtest_output_test_.cc:#: Fatal failure:
 Failed
 Expected fatal failure.
+Stack trace: (omitted)
+
+
+Stack trace: (omitted)
 
 [0;31m[  FAILED  ] [mExpectFailureTest.ExpectFatalFailureOnAllThreads
 [0;32m[ RUN      ] [mExpectFailureTest.ExpectNonFatalFailureOnAllThreads
@@ -579,6 +753,10 @@ Expected: 1 non-fatal failure
   Actual:
 gtest_output_test_.cc:#: Success:
 Succeeded
+Stack trace: (omitted)
+
+
+Stack trace: (omitted)
 
 (expecting 1 failure)
 gtest.cc:#: Failure
@@ -587,6 +765,10 @@ Expected: 1 non-fatal failure
 gtest_output_test_.cc:#: Fatal failure:
 Failed
 Expected fatal failure.
+Stack trace: (omitted)
+
+
+Stack trace: (omitted)
 
 (expecting 1 failure)
 gtest.cc:#: Failure
@@ -595,6 +777,10 @@ Expected: 1 non-fatal failure containing "Some other non-fatal failure."
 gtest_output_test_.cc:#: Non-fatal failure:
 Failed
 Expected non-fatal failure.
+Stack trace: (omitted)
+
+
+Stack trace: (omitted)
 
 [0;31m[  FAILED  ] [mExpectFailureTest.ExpectNonFatalFailureOnAllThreads
 [0;32m[----------] [m2 tests from ExpectFailureWithThreadsTest
@@ -603,18 +789,26 @@ Expected non-fatal failure.
 gtest_output_test_.cc:#: Failure
 Failed
 Expected fatal failure.
+Stack trace: (omitted)
+
 gtest.cc:#: Failure
 Expected: 1 fatal failure
   Actual: 0 failures
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mExpectFailureWithThreadsTest.ExpectFatalFailure
 [0;32m[ RUN      ] [mExpectFailureWithThreadsTest.ExpectNonFatalFailure
 (expecting 2 failures)
 gtest_output_test_.cc:#: Failure
 Failed
 Expected non-fatal failure.
+Stack trace: (omitted)
+
 gtest.cc:#: Failure
 Expected: 1 non-fatal failure
   Actual: 0 failures
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mExpectFailureWithThreadsTest.ExpectNonFatalFailure
 [0;32m[----------] [m1 test from ScopedFakeTestPartResultReporterTest
 [0;32m[ RUN      ] [mScopedFakeTestPartResultReporterTest.InterceptOnlyCurrentThread
@@ -622,9 +816,13 @@ Expected: 1 non-fatal failure
 gtest_output_test_.cc:#: Failure
 Failed
 Expected fatal failure.
+Stack trace: (omitted)
+
 gtest_output_test_.cc:#: Failure
 Failed
 Expected non-fatal failure.
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mScopedFakeTestPartResultReporterTest.InterceptOnlyCurrentThread
 [0;32m[----------] [m1 test from PrintingFailingParams/FailingParamTest
 [0;32m[ RUN      ] [mPrintingFailingParams/FailingParamTest.Fails/0
@@ -633,6 +831,8 @@ Expected equality of these values:
   1
   GetParam()
     Which is: 2
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mPrintingFailingParams/FailingParamTest.Fails/0, where GetParam() = 2
 [0;32m[----------] [m2 tests from PrintingStrings/ParamTest
 [0;32m[ RUN      ] [mPrintingStrings/ParamTest.Success/a
@@ -644,16 +844,22 @@ Expected equality of these values:
   GetParam()
     Which is: "a"
 Expected failure
+Stack trace: (omitted)
+
 [0;31m[  FAILED  ] [mPrintingStrings/ParamTest.Failure/a, where GetParam() = "a"
 [0;32m[----------] [mGlobal test environment tear-down
 BarEnvironment::TearDown() called.
 gtest_output_test_.cc:#: Failure
 Failed
 Expected non-fatal failure.
+Stack trace: (omitted)
+
 FooEnvironment::TearDown() called.
 gtest_output_test_.cc:#: Failure
 Failed
 Expected fatal failure.
+Stack trace: (omitted)
+
 [0;32m[==========] [m68 tests from 30 test cases ran.
 [0;32m[  PASSED  ] [m22 tests.
 [0;31m[  FAILED  ] [m46 tests, listed below:
@@ -693,7 +899,7 @@ Expected fatal failure.
 [0;31m[  FAILED  ] [mExpectFatalFailureTest.FailsWhenStatementThrows
 [0;31m[  FAILED  ] [mTypedTest/0.Failure, where TypeParam = int
 [0;31m[  FAILED  ] [mUnsigned/TypedTestP/0.Failure, where TypeParam = unsigned char
-[0;31m[  FAILED  ] [mUnsigned/TypedTestP/1.Failure, where TypeParam = unsigned
+[0;31m[  FAILED  ] [mUnsigned/TypedTestP/1.Failure, where TypeParam = unsigned int
 [0;31m[  FAILED  ] [mExpectFailureTest.ExpectFatalFailure
 [0;31m[  FAILED  ] [mExpectFailureTest.ExpectNonFatalFailure
 [0;31m[  FAILED  ] [mExpectFailureTest.ExpectFatalFailureOnAllThreads
@@ -718,6 +924,8 @@ Expected equality of these values:
   1
   x
     Which is: 2
+Stack trace: (omitted)
+
 [  FAILED  ] FatalFailureTest.FatalFailureInSubroutine (? ms)
 [ RUN      ] FatalFailureTest.FatalFailureInNestedSubroutine
 (expecting a failure that x should be 1)
@@ -726,6 +934,8 @@ Expected equality of these values:
   1
   x
     Which is: 2
+Stack trace: (omitted)
+
 [  FAILED  ] FatalFailureTest.FatalFailureInNestedSubroutine (? ms)
 [ RUN      ] FatalFailureTest.NonfatalFailureInSubroutine
 (expecting a failure on false)
@@ -733,6 +943,8 @@ gtest_output_test_.cc:#: Failure
 Value of: false
   Actual: false
 Expected: true
+Stack trace: (omitted)
+
 [  FAILED  ] FatalFailureTest.NonfatalFailureInSubroutine (? ms)
 [----------] 3 tests from FatalFailureTest (? ms total)
 
@@ -743,10 +955,14 @@ i == 0
 i == 1
 gtest_output_test_.cc:#: Failure
 Expected: (3) >= (a[i]), actual: 3 vs 9
+Stack trace: (omitted)
+
 i == 2
 i == 3
 gtest_output_test_.cc:#: Failure
 Expected: (3) >= (a[i]), actual: 3 vs 6
+Stack trace: (omitted)
+
 [  FAILED  ] LoggingTest.InterleavingLoggingAndAssertions (? ms)
 [----------] 1 test from LoggingTest (? ms total)
 

--- a/googletest/test/gtest_xml_output_unittest.py
+++ b/googletest/test/gtest_xml_output_unittest.py
@@ -47,17 +47,22 @@ GTEST_OUTPUT_FLAG = '--gtest_output'
 GTEST_DEFAULT_OUTPUT_FILE = 'test_detail.xml'
 GTEST_PROGRAM_NAME = 'gtest_xml_output_unittest_'
 
+# The flag indicating stacktraces are not supported
+NO_STACKTRACE_SUPPORT_FLAG = '--no_stacktrace_support'
+
 # The environment variables for test sharding.
 TOTAL_SHARDS_ENV_VAR = 'GTEST_TOTAL_SHARDS'
 SHARD_INDEX_ENV_VAR = 'GTEST_SHARD_INDEX'
 SHARD_STATUS_FILE_ENV_VAR = 'GTEST_SHARD_STATUS_FILE'
 
-SUPPORTS_STACK_TRACES = False
+SUPPORTS_STACK_TRACES = NO_STACKTRACE_SUPPORT_FLAG not in sys.argv
 
 if SUPPORTS_STACK_TRACES:
   STACK_TRACE_TEMPLATE = '\nStack trace:\n*'
 else:
   STACK_TRACE_TEMPLATE = ''
+  # unittest.main() can't handle unknown flags
+  sys.argv.remove(NO_STACKTRACE_SUPPORT_FLAG)
 
 EXPECTED_NON_EMPTY_XML = """<?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="23" failures="4" disabled="2" errors="0" time="*" timestamp="*" name="AllTests" ad_hoc_property="42">


### PR DESCRIPTION
This change adds the ability to generate stacktraces in Google Test on
both failures of assertions/expectations and on crashes. The
stacktrace support is conditionally available only when using Abseil
with Google Test.

To use this support, run the test under Bazel with a command like this:

bazel test --define absl=1 --test_env=GTEST_INSTALL_FAILURE_SIGNAL_HANDLER=1 //path/to/your:test

The "--define absl=1" part enables stacktraces on assertion/expectation
failures.

The "--test_env=GTEST_INSTALL_FAILURE_SIGNAL_HANDLER=1" part enables
the signal handler that logs a stacktrace in the event of a crash
(this also requires the "--define absl=1" part). This is not the
default since it may interfere with existing tests.

cl/203813940