### PR TITLE
New command line parameter: Allows to see the location where tests are defined

### DIFF
--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -116,6 +116,11 @@ GTEST_DECLARE_string_(filter);
 // are actually run if the flag is provided.
 GTEST_DECLARE_bool_(list_tests);
 
+// This flag causes the Google Test to list tests with their location 
+// (file and line number). None of the tests listed
+// are actually run if the flag is provided.
+GTEST_DECLARE_bool_(list_tests_with_location);
+
 // This flag controls whether Google Test emits a detailed XML report to a file
 // in addition to its normal textual output.
 GTEST_DECLARE_string_(output);

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -84,6 +84,7 @@ const char kCatchExceptionsFlag[] = "catch_exceptions";
 const char kColorFlag[] = "color";
 const char kFilterFlag[] = "filter";
 const char kListTestsFlag[] = "list_tests";
+const char kListTestsWithLocationFlag[] = "list_tests_with_location";
 const char kOutputFlag[] = "output";
 const char kPrintTimeFlag[] = "print_time";
 const char kPrintUTF8Flag[] = "print_utf8";
@@ -165,6 +166,7 @@ class GTestFlagSaver {
     filter_ = GTEST_FLAG(filter);
     internal_run_death_test_ = GTEST_FLAG(internal_run_death_test);
     list_tests_ = GTEST_FLAG(list_tests);
+    list_tests_with_location_ = GTEST_FLAG(list_tests_with_location);
     output_ = GTEST_FLAG(output);
     print_time_ = GTEST_FLAG(print_time);
     print_utf8_ = GTEST_FLAG(print_utf8);
@@ -187,6 +189,7 @@ class GTestFlagSaver {
     GTEST_FLAG(filter) = filter_;
     GTEST_FLAG(internal_run_death_test) = internal_run_death_test_;
     GTEST_FLAG(list_tests) = list_tests_;
+    GTEST_FLAG(list_tests_with_location) = list_tests_with_location_;
     GTEST_FLAG(output) = output_;
     GTEST_FLAG(print_time) = print_time_;
     GTEST_FLAG(print_utf8) = print_utf8_;
@@ -209,6 +212,7 @@ class GTestFlagSaver {
   std::string filter_;
   std::string internal_run_death_test_;
   bool list_tests_;
+  bool list_tests_with_location_;  
   std::string output_;
   bool print_time_;
   bool print_utf8_;
@@ -722,7 +726,7 @@ class GTEST_API_ UnitTestImpl {
   int FilterTests(ReactionToSharding shard_tests);
 
   // Prints the names of the tests matching the user-specified filter flag.
-  void ListTestsMatchingFilter();
+  void ListTestsMatchingFilter(bool list_location);
 
   const TestCase* current_test_case() const { return current_test_case_; }
   TestInfo* current_test_info() { return current_test_info_; }


### PR DESCRIPTION
New command line parameter: list_tests_with_location.
Allows to see the location where tests are defined.
Fixes #1657 