### PR TITLE
Add assertions for testing exception message strings

### DIFF
--- a/googlemock/docs/CheatSheet.md
+++ b/googlemock/docs/CheatSheet.md
@@ -233,6 +233,21 @@ syntax defined
 `StrCaseEq()`, `StrCaseNe()`, `StrEq()`, and `StrNe()` work for wide
 strings as well.
 
+### Testing Exception Messages ###
+
+Two macros are available for testing that an exception of a given type
+is not only thrown, but also has a message that meets certain expectations.
+These macros will work with any string matcher, e.g. `HasSubstr()` or `StrEq()`,
+and with composite matchers such as `AllOf()`.
+
+| `EXPECT_THROWS_WITH_MESSAGE_THAT(statement, type, matcher)` | Asserts that `statement` throws an exception of type `type`, and the exception's message type matches `matcher`. |
+|:------------------------------|:----------------------------------------|
+| `ASSERT_THROWS_WITH_MESSAGE_THAT(statement, type, matcher)` | The same as `EXPECT_THROWS_WITH_MESSAGE_THAT(statement, type, matcher)`, except that it generates a **fatal** failure. |
+
+These macros will work for any exception type that has a `what()` accessor,
+which returns a value convertible to string. This is true for all standard
+exceptions, where `what()` returns a pointer to a null-terminated string.
+
 ## Container Matchers ##
 
 Most STL-style containers support `==`, so you can use

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -63,6 +63,10 @@
 # include <type_traits>
 #endif
 
+#if GTEST_HAS_EXCEPTIONS
+# include <stdexcept>
+#endif
+
 namespace testing {
 namespace gmock_matchers_test {
 
@@ -6783,6 +6787,124 @@ TEST(NotTest, WorksOnMoveOnlyType) {
 }
 
 #endif  // GTEST_LANG_CXX11
+
+#if GTEST_HAS_EXCEPTIONS
+
+class ExceptionMessageTest : public Test
+{
+public:
+  static void throw_runtime_error() {
+    throw std::runtime_error("Hello, World!");
+  }
+
+  static void throw_int() {
+    throw 123;
+  }
+
+  static void no_throw() {}
+};
+
+// Tests that ASSERT_THROWS_WITH_MESSAGE_THAT() and
+// EXPECT_THROWS_WITH_MESSAGE_THAT() work when the exception type
+// is exactly correct and the message matches the matcher.
+TEST_F(ExceptionMessageTest, exception_thrown_correct_type_and_correct_message) {
+  ASSERT_THROWS_WITH_MESSAGE_THAT(
+    ExceptionMessageTest::throw_runtime_error(),
+    std::runtime_error,
+    StrEq("Hello, World!"));
+
+  EXPECT_THROWS_WITH_MESSAGE_THAT(
+    ExceptionMessageTest::throw_runtime_error(),
+    std::runtime_error,
+    HasSubstr("Hello"));
+}
+
+// Tests that ASSERT_THROWS_WITH_MESSAGE_THAT() and
+// EXPECT_THROWS_WITH_MESSAGE_THAT() work when the exception type
+// is a derived type of the one specified in the assertion,
+// and the message matches the matcher.
+TEST_F(ExceptionMessageTest, exception_thrown_derived_type_and_correct_message) {
+  ASSERT_THROWS_WITH_MESSAGE_THAT(
+    ExceptionMessageTest::throw_runtime_error(),
+    std::exception, // std::runtime_error is derived from std::exception
+    StrEq("Hello, World!"));
+
+  EXPECT_THROWS_WITH_MESSAGE_THAT(
+    ExceptionMessageTest::throw_runtime_error(),
+    std::exception, // std::runtime_error is derived from std::exception
+    StartsWith("Hello"));
+}
+
+// Tests that ASSERT_THROWS_WITH_MESSAGE_THAT() and
+// EXPECT_THROWS_WITH_MESSAGE_THAT() work when the exception type
+// is correct, but the message doesn't match the matcher.
+TEST_F(ExceptionMessageTest, exception_thrown_correct_type_but_incorrect_message) {
+  EXPECT_FATAL_FAILURE(
+    ASSERT_THROWS_WITH_MESSAGE_THAT(
+      ExceptionMessageTest::throw_runtime_error(),
+      std::runtime_error,
+      HasSubstr("xxx")),
+    "Incorrect throwing behaviour\n"
+    "      Expected: std::runtime_error whose message has substring \"xxx\"\n"
+    "Actual message: \"Hello, World!\"");
+
+  EXPECT_NONFATAL_FAILURE(
+    EXPECT_THROWS_WITH_MESSAGE_THAT(
+      ExceptionMessageTest::throw_runtime_error(),
+      std::runtime_error,
+      StartsWith("xxx")),
+    "Incorrect throwing behaviour\n"
+    "      Expected: std::runtime_error whose message starts with \"xxx\"\n"
+    "Actual message: \"Hello, World!\"");
+}
+
+// Tests that ASSERT_THROWS_WITH_MESSAGE_THAT() and
+// EXPECT_THROWS_WITH_MESSAGE_THAT() work when the exception type
+// is neither of the type provided in the assertion, or a derived type.
+TEST_F(ExceptionMessageTest, exception_thrown_unexpected_type) {
+  EXPECT_FATAL_FAILURE(
+    ASSERT_THROWS_WITH_MESSAGE_THAT(
+      ExceptionMessageTest::throw_int(),
+      std::runtime_error,
+      StrEq("Hello, World!")),
+    "Incorrect throwing behaviour\n"
+    "Expected: std::runtime_error whose message is equal to \"Hello, World!\"\n"
+    "  Actual: exception of an unexpected type was thrown");
+
+  EXPECT_NONFATAL_FAILURE(
+    EXPECT_THROWS_WITH_MESSAGE_THAT(
+      ExceptionMessageTest::throw_runtime_error(),
+      std::logic_error, // logic_error is not derived from std::runtime_error
+      AllOf(HasSubstr("World"), StartsWith("Hello"))),
+    "Incorrect throwing behaviour\n"
+    "Expected: std::logic_error whose message (has substring \"World\")"
+                                        " and (starts with \"Hello\")\n"
+    "  Actual: exception of an unexpected type was thrown");
+}
+
+// Tests that ASSERT_THROWS_WITH_MESSAGE_THAT() and
+// EXPECT_THROWS_WITH_MESSAGE_THAT() work when no exception is thrown.
+TEST_F(ExceptionMessageTest, exception_not_thrown) {
+  EXPECT_FATAL_FAILURE(
+    ASSERT_THROWS_WITH_MESSAGE_THAT(
+      ExceptionMessageTest::no_throw(),
+      std::runtime_error,
+      HasSubstr("xxx")),
+    "Incorrect throwing behaviour\n"
+    "Expected: std::runtime_error whose message has substring \"xxx\"\n"
+    "  Actual: No exception was thrown");
+
+  EXPECT_NONFATAL_FAILURE(
+    EXPECT_THROWS_WITH_MESSAGE_THAT(
+      ExceptionMessageTest::no_throw(),
+      std::runtime_error,
+      HasSubstr("xxx")),
+    "Incorrect throwing behaviour\n"
+    "Expected: std::runtime_error whose message has substring \"xxx\"\n"
+    "  Actual: No exception was thrown");
+}
+
+#endif  // GTEST_HAS_EXCEPTIONS
 
 }  // namespace gmock_matchers_test
 }  // namespace testing

--- a/googletest/docs/advanced.md
+++ b/googletest/docs/advanced.md
@@ -83,6 +83,11 @@ EXPECT_NO_THROW({
 **Availability**: Linux, Windows, Mac; requires exceptions to be enabled in the
 build environment (note that `google3` **disables** exceptions).
 
+Additionally, `gmock.h` also makes available the assertions
+ASSERT_THROWS_WITH_MESSAGE_THAT and EXPECT_THROWS_WITH_MESSAGE_THAT, which
+allow you to directly test an exception's message string returned by the
+`what()` member function that all standard exceptions have.
+
 ### Predicate Assertions for Better Error Messages
 
 Even though googletest has a rich set of assertions, they can never be complete,


### PR DESCRIPTION
This adds macros two macros for testing exception explanatory strings using string matchers. The macros are closely analogous to {ASSERT|EXPECT}_THAT, save for the additional argument and the fact that the matcher is evaluated against `string(e.what())`, provided an exception `e` of the correct type had been caught.

```
ASSERT_THROWS_WITH_MESSAGE_THAT(statement, exception_type, matcher);
EXPECT_THROWS_WITH_MESSAGE_THAT(statement, exception_type, matcher);
```

Docs have been updated.

Example:

```
using namespace ::testing;

auto throwsWhenCalled = [](){ throw std::runtime_error("Exception explanatory string."); };

ASSERT_THROWS_WITH_MESSAGE_THAT(throwsWhenCalled(), std::exception, HasSubstr("explanatory"));
```

Fixes #285