### PR TITLE
Adds the UniversalPrinter for absl::variant.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -38,7 +38,7 @@ licenses(["notice"])
 
 config_setting(
     name = "windows",
-    values = { "cpu": "x64_windows" },
+    values = {"cpu": "x64_windows"},
 )
 
 config_setting(
@@ -50,7 +50,6 @@ config_setting(
     name = "has_absl",
     values = {"define": "absl=1"},
 )
-
 
 # Google Test including Google Mock
 cc_library(
@@ -70,7 +69,7 @@ cc_library(
             "googlemock/src/gmock_main.cc",
         ],
     ),
-    hdrs =glob([
+    hdrs = glob([
         "googletest/include/gtest/*.h",
         "googlemock/include/gmock/*.h",
     ]),
@@ -79,6 +78,14 @@ cc_library(
             ":windows": [],
             ":windows_msvc": [],
             "//conditions:default": ["-pthread"],
+        },
+    ),
+    defines = select(
+        {
+            ":has_absl": [
+                "GTEST_HAS_ABSL=1",
+            ],
+            "//conditions:default": [],
         },
     ),
     includes = [
@@ -94,21 +101,16 @@ cc_library(
             "-pthread",
         ],
     }),
-    defines = select ({
-        ":has_absl": [
-        "GTEST_HAS_ABSL=1",
-        ],
-        "//conditions:default": [],
-    }
+    deps = select(
+        {
+            ":has_absl": [
+                "@com_google_absl//absl/types:optional",
+                "@com_google_absl//absl/types:variant",
+                "@com_google_absl//absl/strings",
+            ],
+            "//conditions:default": [],
+        },
     ),
-    deps = select ({
-        ":has_absl": [
-        "@com_google_absl//absl/types:optional",
-        "@com_google_absl//absl/strings"
-        ],
-        "//conditions:default": [],
-    }
-    )
 )
 
 cc_library(

--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -114,6 +114,7 @@
 #if GTEST_HAS_ABSL
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
+#include "absl/types/variant.h"
 #endif  // GTEST_HAS_ABSL
 
 namespace testing {
@@ -785,6 +786,28 @@ class UniversalPrinter<::absl::optional<T>> {
     }
     *os << ')';
   }
+};
+
+// Printer for absl::variant
+
+template <typename... T>
+class UniversalPrinter<::absl::variant<T...>> {
+ public:
+  static void Print(const ::absl::variant<T...>& value, ::std::ostream* os) {
+    *os << '(';
+    absl::visit(Visitor{os}, value);
+    *os << ')';
+  }
+
+ private:
+  struct Visitor {
+    template <typename U>
+    void operator()(const U& u) const {
+      *os << "'" << GetTypeName<U>() << "' with value ";
+      UniversalPrint(u, os);
+    }
+    ::std::ostream* os;
+  };
 };
 
 #endif  // GTEST_HAS_ABSL


### PR DESCRIPTION
The BUILD.bazel file was automatically reformatted by `buildifier`.