### PR TITLE
Printers test: fixed compilation bug, due to unnecessary parentheses in declaration

### DIFF
--- a/googletest/test/googletest-printers-test.cc
+++ b/googletest/test/googletest-printers-test.cc
@@ -572,7 +572,7 @@ struct Foo {
 TEST(PrintPointerTest, MemberVariablePointer) {
   EXPECT_TRUE(HasPrefix(Print(&Foo::value),
                         Print(sizeof(&Foo::value)) + "-byte object "));
-  int (Foo::*p) = NULL;  // NOLINT
+  int Foo::*p = NULL;  // NOLINT
   EXPECT_TRUE(HasPrefix(Print(p),
                         Print(sizeof(p)) + "-byte object "));
 }
@@ -1250,7 +1250,7 @@ TEST(PrintReferenceTest, HandlesMemberFunctionPointer) {
 // Tests that the universal printer prints a member variable pointer
 // passed by reference.
 TEST(PrintReferenceTest, HandlesMemberVariablePointer) {
-  int (Foo::*p) = &Foo::value;  // NOLINT
+  int Foo::*p = &Foo::value;  // NOLINT
   EXPECT_TRUE(HasPrefix(
       PrintByRef(p),
       "@" + PrintPointer(&p) + " " + Print(sizeof(p)) + "-byte object "));


### PR DESCRIPTION
Fixes google/googletest#1672