### PR TITLE
suppress warning C4819 for vs2015 or later.

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -87,6 +87,11 @@ macro(config_compiler_and_linker)
       # http://stackoverflow.com/questions/3232669 explains the issue.
       set(cxx_base_flags "${cxx_base_flags} -wd4702")
     endif()
+    if (NOT (MSVC_VERSION LESS 1900))  # 1900 is Visual Studio 2015.
+	  # Suppress warning C4819 for none-English environment.
+      # see https://github.com/google/googletest/pull/1606#issuecomment-401526516
+	  set(cxx_base_flags "${cxx_base_flags} -utf-8")
+    endif()
 
     set(cxx_base_flags "${cxx_base_flags} -D_UNICODE -DUNICODE -DWIN32 -D_WIN32")
     set(cxx_base_flags "${cxx_base_flags} -DSTRICT -DWIN32_LEAN_AND_MEAN")


### PR DESCRIPTION
To suppress C4819, adding compiler option ['-utf-8'](https://msdn.microsoft.com/ja-jp/library/mt708821.aspx).

message of th warning C4819 
> The file contains a character that cannot be represented in the current code page (932).
> Save the file in Unicode format to prevent data loss

Because compiler option '-WX' is enabled, any warning will be treated as ERROR.
i think enabling '-WX' is good manner, but I'm stumped that I can't compile the googletest.
https://github.com/google/googletest/blob/2a151c93c180ac765c27c5f2e37af9366abd4d55/googletest/cmake/internal_utils.cmake#L61-L65

this is related #1668, #1606. trying replace none-ASCII character to ASCII string.
this commit changes compiler option without changing any code.

here is the result of my test builds 

condition | what is change | build result
---- | ---- | ----
[current master](https://github.com/google/googletest/commit/2a151c93c180ac765c27c5f2e37af9366abd4d55) with cp change | [7a309217](https://github.com/berryzplus/googletest/commit/7a309217d4301201a7801c26a3ac67eeb5a6a18a) | [failed](https://ci.appveyor.com/project/berryzplus/googletest/build/2)
above + this commit | [3f723e23](https://github.com/berryzplus/googletest/commit/3f723e23a08b1aaa28936042fc9d8bf0bf405352)  | [ok](https://ci.appveyor.com/project/berryzplus/googletest/build/4)

