### PR TITLE
Changed some URLs to HTTPS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Build matrix / environment variable are explained on:
 # https://docs.travis-ci.com/user/customizing-the-build/
 # This file can be validated on:
-# http://lint.travis-ci.org/
+# https://lint.travis-ci.org/
 
 sudo: false
 language: cpp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,10 +46,10 @@ request here.
 ## The Google Test and Google Mock Communities ##
 
 The Google Test community exists primarily through the
-[discussion group](http://groups.google.com/group/googletestframework)
+[discussion group](https://groups.google.com/forum/#!forum/googletestframework)
 and the GitHub repository.
 Likewise, the Google Mock community exists primarily through their own
-[discussion group](http://groups.google.com/group/googlemock).
+[discussion group](https://groups.google.com/forum/#!forum/googlemock).
 You are definitely encouraged to contribute to the
 discussion and you can also help us to keep the effectiveness of the
 group high by following and promoting the guidelines listed here.

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ Google test has been used on a variety of platforms:
 In addition to many internal projects at Google, Google Test is also used by
 the following notable projects:
 
-  * The [Chromium projects](http://www.chromium.org/) (behind the Chrome
+  * The [Chromium projects](https://www.chromium.org/) (behind the Chrome
     browser and Chrome OS).
-  * The [LLVM](http://llvm.org/) compiler.
+  * The [LLVM](https://llvm.org/) compiler.
   * [Protocol Buffers](https://github.com/google/protobuf), Google's data
     interchange format.
-  * The [OpenCV](http://opencv.org/) computer vision library.
+  * The [OpenCV](https://opencv.org/) computer vision library.
   * [tiny-dnn](https://github.com/tiny-dnn/tiny-dnn): header only, dependency-free deep learning framework in C++11.
 
 ## Related Open Source Projects ##

--- a/ci/install-linux.sh
+++ b/ci/install-linux.sh
@@ -38,7 +38,7 @@ fi
 
 
 if [ "${TRAVIS_SUDO}" = "true" ]; then
-    echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | \
+    echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | \
         sudo tee /etc/apt/sources.list.d/bazel.list
     curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
     sudo apt-get update && sudo apt-get install -y bazel gcc-4.9 g++-4.9 clang-3.7

--- a/googlemock/README.md
+++ b/googlemock/README.md
@@ -11,7 +11,7 @@ It is inspired by:
 
   * [jMock](http://www.jmock.org/),
   * [EasyMock](http://www.easymock.org/), and
-  * [Hamcrest](http://code.google.com/p/hamcrest/),
+  * [Hamcrest](https://code.google.com/archive/p/hamcrest/),
 
 and designed with C++'s specifics in mind.
 
@@ -45,7 +45,7 @@ also an IRC channel on OFTC (irc.oftc.net) #gtest available.  Please
 join us!
 
 Please note that code under [scripts/generator](scripts/generator/) is
-from [cppclean](http://code.google.com/p/cppclean/) and released under
+from [cppclean](https://code.google.com/archive/p/cppclean/) and released under
 the Apache License, which is different from Google Mock's license.
 
 ## Getting Started ##
@@ -58,7 +58,7 @@ documentation in the following order:
   * Read [Google Mock for Dummies](../../master/googlemock/docs/ForDummies.md).
   * Read the instructions below on how to build Google Mock.
 
-You can also watch Zhanyong's [talk](http://www.youtube.com/watch?v=sYpCyLI47rM) on Google Mock's usage and implementation.
+You can also watch Zhanyong's [talk](https://www.youtube.com/watch?v=sYpCyLI47rM) on Google Mock's usage and implementation.
 
 Once you understand the basics, check out the rest of the docs:
 
@@ -71,7 +71,7 @@ If you need help, please check the
 [KnownIssues](docs/KnownIssues.md) and
 [FrequentlyAskedQuestions](docs/FrequentlyAskedQuestions.md) before
 posting a question on the
-[discussion group](http://groups.google.com/group/googlemock).
+[discussion group](https://groups.google.com/forum/#!forum/googlemock).
 
 
 ### Using Google Mock Without Google Test ###
@@ -84,7 +84,7 @@ you can also use it with [any C++ testing framework](../../master/googlemock/doc
 ### Requirements for End Users ###
 
 Google Mock is implemented on top of [Google Test](
-http://github.com/google/googletest/), and depends on it.
+https://github.com/google/googletest/), and depends on it.
 You must use the bundled version of Google Test when using Google Mock.
 
 You can also easily configure Google Mock to work with another testing
@@ -293,7 +293,7 @@ their own tuple library, just add
 to the compiler flags instead.
 
 If you want to use Boost's TR1 tuple library with Google Mock, please
-refer to the Boost website (http://www.boost.org/) for how to obtain
+refer to the Boost website (https://www.boost.org/) for how to obtain
 it and set it up.
 
 ### As a Shared Library (DLL) ###

--- a/googlemock/docs/ForDummies.md
+++ b/googlemock/docs/ForDummies.md
@@ -101,7 +101,7 @@ class MockTurtle : public Turtle {
 You don't need to define these mock methods somewhere else - the `MOCK_METHOD*` macros will generate the definitions for you. It's that simple! Once you get the hang of it, you can pump out mock classes faster than your source-control system can handle your check-ins.
 
 **Tip:** If even this is too much work for you, you'll find the
-`gmock_gen.py` tool in Google Mock's `scripts/generator/` directory (courtesy of the [cppclean](http://code.google.com/p/cppclean/) project) useful.  This command-line
+`gmock_gen.py` tool in Google Mock's `scripts/generator/` directory (courtesy of the [cppclean](https://code.google.com/archive/p/cppclean/) project) useful.  This command-line
 tool requires that you have Python 2.4 installed.  You give it a C++ file and the name of an abstract class defined in it,
 and it will print the definition of the mock class for you.  Due to the
 complexity of the C++ language, this script may not always work, but
@@ -169,7 +169,7 @@ This means `EXPECT_CALL()` should be read as expecting that a call will occur _i
 Admittedly, this test is contrived and doesn't do much. You can easily achieve the same effect without using Google Mock. However, as we shall reveal soon, Google Mock allows you to do _much more_ with the mocks.
 
 ## Using Google Mock with Any Testing Framework ##
-If you want to use something other than Google Test (e.g. [CppUnit](http://sourceforge.net/projects/cppunit/) or
+If you want to use something other than Google Test (e.g. [CppUnit](https://sourceforge.net/projects/cppunit/) or
 [CxxTest](https://cxxtest.com/)) as your testing framework, just change the `main()` function in the previous section to:
 ```
 int main(int argc, char** argv) {
@@ -442,6 +442,6 @@ A mock object may have many methods, and not all of them are that interesting. F
 In Google Mock, if you are not interested in a method, just don't say anything about it. If a call to this method occurs, you'll see a warning in the test output, but it won't be a failure.
 
 # What Now? #
-Congratulations! You've learned enough about Google Mock to start using it. Now, you might want to join the [googlemock](http://groups.google.com/group/googlemock) discussion group and actually write some tests using Google Mock - it will be fun. Hey, it may even be addictive - you've been warned.
+Congratulations! You've learned enough about Google Mock to start using it. Now, you might want to join the [googlemock](https://groups.google.com/forum/#!forum/googlemock) discussion group and actually write some tests using Google Mock - it will be fun. Hey, it may even be addictive - you've been warned.
 
 Then, if you feel like increasing your mock quotient, you should move on to the [CookBook](CookBook.md). You can learn many advanced features of Google Mock there -- and advance your level of enjoyment and testing bliss.

--- a/googlemock/docs/FrequentlyAskedQuestions.md
+++ b/googlemock/docs/FrequentlyAskedQuestions.md
@@ -1,7 +1,7 @@
 
 
 Please send your questions to the
-[googlemock](http://groups.google.com/group/googlemock) discussion
+[googlemock](https://groups.google.com/forum/#!forum/googlemock) discussion
 group. If you need help with compiler errors, make sure you have
 tried [Google Mock Doctor](#How_am_I_supposed_to_make_sense_of_these_horrible_template_error.md) first.
 
@@ -607,8 +607,8 @@ See this [recipe](CookBook.md#mocking_side_effects) for more details and an exam
 If you cannot find the answer to your question in this FAQ, there are
 some other resources you can use:
 
-  1. search the mailing list [archive](http://groups.google.com/group/googlemock/topics),
-  1. ask it on [googlemock@googlegroups.com](mailto:googlemock@googlegroups.com) and someone will answer it (to prevent spam, we require you to join the [discussion group](http://groups.google.com/group/googlemock) before you can post.).
+  1. search the mailing list [archive](https://groups.google.com/forum/#!forum/googlemock),
+  1. ask it on [googlemock@googlegroups.com](mailto:googlemock@googlegroups.com) and someone will answer it (to prevent spam, we require you to join the [discussion group](https://groups.google.com/forum/#!forum/googlemock) before you can post.).
 
 Please note that creating an issue in the
 [issue tracker](https://github.com/google/googletest/issues) is _not_

--- a/googlemock/docs/KnownIssues.md
+++ b/googlemock/docs/KnownIssues.md
@@ -14,6 +14,6 @@ The `README` file in release 1.1.0 still says that Google Mock only works with G
 
 This only applies if you manually built and installed Google Test, and then built a Google Mock against it (either explicitly, or because gtest-config was in your path post-install). In this situation, Libtool has a known issue with certain systems' ldconfig setup:
 
-http://article.gmane.org/gmane.comp.sysutils.automake.general/9025
+https://article.gmane.org/gmane.comp.sysutils.automake.general/9025
 
 This requires a manual run of "sudo ldconfig" after the "sudo make install" for Google Test before any binaries which link against it can be executed. This isn't a bug in our install, but we should at least have documented it or hacked a work-around into our install. We should have one of these solutions in our next release.

--- a/googlemock/scripts/generator/README
+++ b/googlemock/scripts/generator/README
@@ -1,10 +1,10 @@
 
 The Google Mock class generator is an application that is part of cppclean.
-For more information about cppclean, visit http://code.google.com/p/cppclean/
+For more information about cppclean, visit https://code.google.com/archive/p/cppclean/
 
 The mock generator requires Python 2.3.5 or later.  If you don't have Python
 installed on your system, you will also need to install it.  You can download
-Python from:  http://www.python.org/download/releases/
+Python from:  https://www.python.org/download/releases/
 
 To use the Google Mock class generator, you need to call it
 on the command line passing the header file and class for which you want

--- a/googlemock/scripts/generator/README.cppclean
+++ b/googlemock/scripts/generator/README.cppclean
@@ -6,7 +6,7 @@ Goal:
   to unnecessary #include directives.  Unnecessary #includes can cause
   considerable extra compiles increasing the edit-compile-run cycle.
 
-  The project home page is:   http://code.google.com/p/cppclean/
+  The project home page is:   https://code.google.com/archive/p/cppclean/
 
 
 Features:
@@ -26,7 +26,7 @@ Features:
  * (planned) Store AST in a SQL database so relationships can be queried
 
 AST is Abstract Syntax Tree, a representation of parsed source code.
-http://en.wikipedia.org/wiki/Abstract_syntax_tree
+https://en.wikipedia.org/wiki/Abstract_syntax_tree
 
 
 System Requirements:

--- a/googlemock/src/gmock-matchers.cc
+++ b/googlemock/src/gmock-matchers.cc
@@ -229,7 +229,7 @@ GTEST_API_ std::string FormatMatcherDescription(bool negation,
 //   [1] Cormen, et al (2001). "Section 26.2: The Ford-Fulkerson method".
 //       "Introduction to Algorithms (Second ed.)", pp. 651-664.
 //   [2] "Ford-Fulkerson algorithm", Wikipedia,
-//       'http://en.wikipedia.org/wiki/Ford%E2%80%93Fulkerson_algorithm'
+//       'https://en.wikipedia.org/wiki/Ford%E2%80%93Fulkerson_algorithm'
 class MaxBipartiteMatchState {
  public:
   explicit MaxBipartiteMatchState(const MatchMatrix& graph)

--- a/googletest/README.md
+++ b/googletest/README.md
@@ -53,7 +53,7 @@ Google Test comes with a CMake build script (
 [CMakeLists.txt](https://github.com/google/googletest/blob/master/CMakeLists.txt))
 that can be used on a wide range of platforms ("C" stands for cross-platform.).
 If you don't have CMake installed already, you can download it for free from
-<http://www.cmake.org/>.
+<https://cmake.org/>.
 
 CMake works by generating native makefiles or build projects that can be used in
 the compiler environment of your choice. You can either build Google Test as a
@@ -172,7 +172,7 @@ Existing build's `CMakeLists.txt`:
 
 Note that this approach requires CMake 2.8.2 or later due to its use of the
 `ExternalProject_Add()` command. The above technique is discussed in more detail
-in [this separate article](http://crascit.com/2015/07/25/cmake-gtest/) which
+in [this separate article](https://crascit.com/2015/07/25/cmake-gtest/) which
 also contains a link to a fully generalized implementation of the technique.
 
 ##### Visual Studio Dynamic vs Static Runtimes
@@ -228,7 +228,7 @@ need to either:
     MacOS X.
 *   Install an SDK for an earlier version. This doesn't appear to be supported
     by Apple, but has been reported to work
-    (http://stackoverflow.com/questions/5378518).
+    (https://stackoverflow.com/questions/5378518).
 
 ### Tweaking Google Test
 
@@ -312,7 +312,7 @@ to the compiler flags.
 Note: while the above steps aren't technically necessary today when using some
 compilers (e.g. GCC), they may become necessary in the future, if we decide to
 improve the speed of loading the library (see
-<http://gcc.gnu.org/wiki/Visibility> for details). Therefore you are recommended
+<https://gcc.gnu.org/wiki/Visibility> for details). Therefore you are recommended
 to always add the above flags when using Google Test as a shared library.
 Otherwise a future release of Google Test may break your build script.
 

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -84,7 +84,7 @@ macro(config_compiler_and_linker)
     endif()
     if (NOT (MSVC_VERSION LESS 1700))  # 1700 is Visual Studio 2012.
       # Suppress "unreachable code" warning on VS 2012 and later.
-      # http://stackoverflow.com/questions/3232669 explains the issue.
+      # https://stackoverflow.com/questions/3232669 explains the issue.
       set(cxx_base_flags "${cxx_base_flags} -wd4702")
     endif()
 

--- a/googletest/docs/advanced.md
+++ b/googletest/docs/advanced.md
@@ -449,7 +449,7 @@ using ::testing::MatchesRegex;
 
 If the string contains a well-formed HTML or XML document, you can check whether
 its DOM tree matches an [XPath
-expression](http://www.w3.org/TR/xpath/#contents):
+expression](https://www.w3.org/TR/xpath/all/#contents):
 
 ```c++
 // Currently still in //template/prototemplate/testing:xpath_matcher
@@ -789,7 +789,7 @@ TEST_F(FooDeathTest, DoesThat) {
 On POSIX systems (e.g. Linux, Cygwin, and Mac), googletest uses the
 [POSIX extended regular expression](http://www.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap09.html#tag_09_04)
 syntax. To learn about this syntax, you may want to read this
-[Wikipedia entry](http://en.wikipedia.org/wiki/Regular_expression#POSIX_Extended_Regular_Expressions).
+[Wikipedia entry](https://en.wikipedia.org/wiki/Regular_expression#POSIX_Extended_Regular_Expressions).
 
 On Windows, googletest uses its own simple regular expression implementation. It
 lacks many features. For example, we don't support union (`"x|y"`), grouping

--- a/googletest/docs/primer.md
+++ b/googletest/docs/primer.md
@@ -53,12 +53,12 @@ of misunderstanding these.
 
 Historically, googletest started to use the term _Test Case_ for grouping
 related tests, whereas current publications including the International Software
-Testing Qualifications Board ([ISTQB](http://www.istqb.org/)) and various
+Testing Qualifications Board ([ISTQB](https://www.istqb.org/)) and various
 textbooks on Software Quality use the term _[Test
-Suite](http://glossary.istqb.org/search/test%20suite)_ for this.
+Suite](https://glossary.istqb.org/search/test%20suite)_ for this.
 
 The related term _Test_, as it is used in the googletest, is corresponding to
-the term _[Test Case](http://glossary.istqb.org/search/test%20case)_ of ISTQB
+the term _[Test Case](https://glossary.istqb.org/search/test%20case)_ of ISTQB
 and others.
 
 The term _Test_ is commonly of broad enough sense, including ISTQB's
@@ -72,10 +72,10 @@ part of the public API at various places.
 So for the time being, please be aware of the different definitions of
 the terms:
 
-Meaning                                                                              | googletest Term                                                                                            | [ISTQB](http://www.istqb.org/) Term
+Meaning                                                                              | googletest Term                                                                                            | [ISTQB](https://www.istqb.org/) Term
 :----------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------- | :----------------------------------
-Exercise a particular program path with specific input values and verify the results | [TEST()](#simple-tests)                                                                                    | [Test Case](http://glossary.istqb.org/search/test%20case)
-A set of several tests related to one component                                      | [TestCase](#basic-concepts) | [TestSuite](http://glossary.istqb.org/search/test%20suite)
+Exercise a particular program path with specific input values and verify the results | [TEST()](#simple-tests)                                                                                    | [Test Case](https://glossary.istqb.org/search/test%20case)
+A set of several tests related to one component                                      | [TestCase](#basic-concepts) | [TestSuite](https://glossary.istqb.org/search/test%20suite)
 
 ## Basic Concepts
 

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -160,7 +160,7 @@ namespace edit_distance {
 // All edits cost the same, with replace having lower priority than
 // add/remove.
 // Simple implementation of the Wagner-Fischer algorithm.
-// See http://en.wikipedia.org/wiki/Wagner-Fischer_algorithm
+// See https://en.wikipedia.org/wiki/Wagner-Fischer_algorithm
 enum EditType { kMatch, kAdd, kRemove, kReplace };
 GTEST_API_ std::vector<EditType> CalculateOptimalEdits(
     const std::vector<size_t>& left, const std::vector<size_t>& right);
@@ -237,7 +237,7 @@ GTEST_API_ std::string GetBoolAssertionFailureMessage(
 //   For double, there are 11 exponent bits and 52 fraction bits.
 //
 //   More details can be found at
-//   http://en.wikipedia.org/wiki/IEEE_floating-point_standard.
+//   https://en.wikipedia.org/wiki/IEEE_floating-point_standard.
 //
 // Template parameter:
 //
@@ -282,7 +282,7 @@ class FloatingPoint {
   // bits.  Therefore, 4 should be enough for ordinary use.
   //
   // See the following article for more details on ULP:
-  // http://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
+  // https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
   static const size_t kMaxUlps = 4;
 
   // Constructs a FloatingPoint from a raw floating-point number.
@@ -368,7 +368,7 @@ class FloatingPoint {
   //   N - 1  (the biggest number representable using
   //          sign-and-magnitude) is represented by 2N - 1.
   //
-  // Read http://en.wikipedia.org/wiki/Signed_number_representations
+  // Read https://en.wikipedia.org/wiki/Signed_number_representations
   // for more details on signed number representations.
   static Bits SignAndMagnitudeToBiased(const Bits &sam) {
     if (kSignBitMask & sam) {

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -393,7 +393,7 @@
 #  endif
 # elif defined(__GLIBCXX__)
 // Inspired by boost/config/stdlib/libstdcpp3.hpp,
-// http://gcc.gnu.org/gcc-4.2/changes.html and
+// https://gcc.gnu.org/gcc-4.2/changes.html and
 // https://web.archive.org/web/20140227044429/gcc.gnu.org/onlinedocs/libstdc++/manual/bk01pt01ch01.html#manual.intro.status.standard.200x
 #  if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 2)
 #   undef GTEST_HAS_STD_TUPLE_
@@ -766,7 +766,7 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 // Determines whether clone(2) is supported.
 // Usually it will only be available on Linux, excluding
 // Linux on the Itanium architecture.
-// Also see http://linux.die.net/man/2/clone.
+// Also see https://linux.die.net/man/2/clone.
 #ifndef GTEST_HAS_CLONE
 // The user didn't tell us, so we need to figure it out.
 

--- a/googletest/scripts/release_docs.py
+++ b/googletest/scripts/release_docs.py
@@ -101,8 +101,8 @@ class WikiBrancher(object):
     # A link to Foo.wiki is in one of the following forms:
     #   [Foo words]
     #   [Foo#Anchor words]
-    #   [http://code.google.com/.../wiki/Foo words]
-    #   [http://code.google.com/.../wiki/Foo#Anchor words]
+    #   [https://code.google.com/.../wiki/Foo words]
+    #   [https://code.google.com/.../wiki/Foo#Anchor words]
     # We want to replace 'Foo' with 'V2_6_Foo' in the above cases.
     self.search_for_re = re.compile(
         # This regex matches either

--- a/googletest/src/gtest-death-test.cc
+++ b/googletest/src/gtest-death-test.cc
@@ -751,7 +751,7 @@ DeathTest::TestRole WindowsDeathTest::AssumeRole() {
       StreamableToString(static_cast<unsigned int>(::GetCurrentProcessId())) +
       // size_t has the same width as pointers on both 32-bit and 64-bit
       // Windows platforms.
-      // See http://msdn.microsoft.com/en-us/library/tcxf1dw6.aspx.
+      // See https://msdn.microsoft.com/en-us/library/tcxf1dw6.aspx.
       "|" + StreamableToString(reinterpret_cast<size_t>(write_handle)) +
       "|" + StreamableToString(reinterpret_cast<size_t>(event_handle_.Get()));
 

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -316,7 +316,7 @@ void ShuffleRange(internal::Random* random, int begin, int end,
       << begin << ", " << size << "].";
 
   // Fisher-Yates shuffle, from
-  // http://en.wikipedia.org/wiki/Fisher-Yates_shuffle
+  // https://en.wikipedia.org/wiki/Fisher-Yates_shuffle
   for (int range_width = end - begin; range_width >= 2; range_width--) {
     const int last_in_range = begin + range_width - 1;
     const int selected = begin + random->Generate(range_width);

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -570,7 +570,7 @@ int UnitTestOptions::GTestShouldProcessSEH(DWORD exception_code) {
   //      apparently).
   //
   // SEH exception code for C++ exceptions.
-  // (see http://support.microsoft.com/kb/185294 for more information).
+  // (see https://support.microsoft.com/kb/185294 for more information).
   const DWORD kCxxExceptionCode = 0xe06d7363;
 
   bool should_handle = true;
@@ -834,7 +834,7 @@ std::string UnitTestImpl::CurrentOsStackTraceExceptTop(int skip_count) {
 TimeInMillis GetTimeInMillis() {
 #if GTEST_OS_WINDOWS_MOBILE || defined(__BORLANDC__)
   // Difference between 1970-01-01 and 1601-01-01 in milliseconds.
-  // http://analogous.blogspot.com/2005/04/epoch.html
+  // https://analogous.blogspot.com/2005/04/epoch.html
   const TimeInMillis kJavaEpochToWinFileTimeDelta =
     static_cast<TimeInMillis>(116444736UL) * 100000UL;
   const DWORD kTenthMicrosInMilliSecond = 10000;

--- a/googletest/xcode/Config/General.xcconfig
+++ b/googletest/xcode/Config/General.xcconfig
@@ -20,7 +20,7 @@ PREBINDING = NO
 WARNING_CFLAGS = -Wall -Werror -Wendif-labels -Wnewline-eof -Wno-sign-compare -Wshadow
 
 // Work around Xcode bugs by using external strip. See:
-// http://lists.apple.com/archives/Xcode-users/2006/Feb/msg00050.html
+// https://lists.apple.com/archives/Xcode-users/2006/Feb/msg00050.html
 SEPARATE_STRIP = YES
 
 // Force C99 dialect

--- a/googletest/xcode/Resources/Info.plist
+++ b/googletest/xcode/Resources/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/googletest/xcode/Samples/FrameworkSample/Info.plist
+++ b/googletest/xcode/Samples/FrameworkSample/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>


### PR DESCRIPTION
Runned `grep -rnw . -e 'http:/'` in the repo directory and changed all occurrences of "http://" to "https://" if the page was accessible via HTTPS.

Checked all URLs manually. Tried both with and without "www". Skipped licences. Didn't change URLs when only HTTP version was working.