### PR TITLE
Fix GCC Compiler Warning

### DIFF
--- a/googletest/src/gtest-death-test.cc
+++ b/googletest/src/gtest-death-test.cc
@@ -237,7 +237,7 @@ static std::string DeathTestThreadWarning(size_t thread_count) {
     msg << "couldn't detect the number of threads.";
   else
     msg << "detected " << thread_count << " threads.";
-    msg << " See https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#death-tests-and-threads"
+  msg << " See https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#death-tests-and-threads"
       << " for more explanation and suggested solutions, especially if"
       << " this is the last message you see before your test times out.";
   return msg.GetString();


### PR DESCRIPTION
GCC was puking due to a misleading indent warning. Patch corrects the indent without making any changes to functionality.