### PR TITLE
Fix GCC Compiler Warning (same as #1712)

### DIFF
--- a/googletest/src/gtest-death-test.cc
+++ b/googletest/src/gtest-death-test.cc
@@ -237,7 +237,7 @@ static std::string DeathTestThreadWarning(size_t thread_count) {
     msg << "couldn't detect the number of threads.";
   else
     msg << "detected " << thread_count << " threads.";
-    msg << " See https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#death-tests-and-threads"
+  msg << " See https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#death-tests-and-threads"
       << " for more explanation and suggested solutions, especially if"
       << " this is the last message you see before your test times out.";
   return msg.GetString();


### PR DESCRIPTION
There was a pull request #1712 from @Mister-Meeseeks. Don't know why Travis CI failed.
Error message: 
```
E: Unable to locate package g++-4.9
E: Couldn't find any package by glob 'g++-4.9'
E: Couldn't find any package by regex 'g++-4.9'
The command "sudo -E apt-get -yq --no-install-suggests --no-install-recommends $TRAVIS_APT_OPTS install g++-4.9 clang-3.7" failed and exited with 100 during .
```
Trying to pull again. #1711