### PR TITLE
Use `$<INSTALL_PREFIX>` in `target_include_directories`

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -118,10 +118,10 @@ endif()
 if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
   target_include_directories(gmock SYSTEM INTERFACE
     "$<BUILD_INTERFACE:${gmock_build_include_dirs}>"
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
   target_include_directories(gmock_main SYSTEM INTERFACE
     "$<BUILD_INTERFACE:${gmock_build_include_dirs}>"
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
 endif()
 
 ########################################################################

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -138,10 +138,10 @@ cxx_library(gtest_main "${cxx_strict}" src/gtest_main.cc)
 if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
   target_include_directories(gtest SYSTEM INTERFACE
     "$<BUILD_INTERFACE:${gtest_build_include_dirs}>"
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
   target_include_directories(gtest_main SYSTEM INTERFACE
     "$<BUILD_INTERFACE:${gtest_build_include_dirs}>"
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
 endif()
 target_link_libraries(gtest_main PUBLIC gtest)
 


### PR DESCRIPTION
To make sure packages are relocatable, use `$<INSTALL_PREFIX>` in `$<INSTALL_INTERFACE:...>` `target_include_directories`.

`$<INSTALL_PREFIX>` was introduced in CMake 2.8.11, which is already being checked for locally.

References:

- https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#id19
- https://github.com/robotology/how-to-export-cpp-library/blob/claudio/headeronly/src/LibTemplateCMake/CMakeLists.txt#L42

Signed-off-by: Dakota Hawkins <dakotahawkins@gmail.com>