### PR TITLE
Fix #1764 Remove cmake code that leads to a configuration error

### DIFF
--- a/googlemock/README.md
+++ b/googlemock/README.md
@@ -144,27 +144,6 @@ to
     target_link_libraries(example gmock_main)
 
 This works because `gmock_main` library is compiled with Google Test.
-However, it does not automatically add Google Test includes.
-Therefore you will also have to change
-
-    if (CMAKE_VERSION VERSION_LESS 2.8.11)
-      include_directories("${gtest_SOURCE_DIR}/include")
-    endif()
-
-to
-
-    if (CMAKE_VERSION VERSION_LESS 2.8.11)
-      include_directories(BEFORE SYSTEM
-        "${gtest_SOURCE_DIR}/include" "${gmock_SOURCE_DIR}/include")
-    else()
-      target_include_directories(gmock_main SYSTEM BEFORE INTERFACE
-        "${gtest_SOURCE_DIR}/include" "${gmock_SOURCE_DIR}/include")
-    endif()
-
-This will addtionally mark Google Mock includes as system, which will
-silence compiler warnings when compiling your tests using clang with
-`-Wpedantic -Wall -Wextra -Wconversion`.
-
 
 #### Preparing to Build (Unix only) ####
 


### PR DESCRIPTION
This step is no longer necessary and causes configuration errors. The configuration given in the googletest README.md is sufficient to bring in all the googlemock headers.

