### PR TITLE
Silence use-after-free warning from clang-tidy

### DIFF
--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -1282,7 +1282,7 @@ class MockSpec {
     const std::string source_text(std::string("EXPECT_CALL(") + obj + ", " +
                                   call + ")");
     LogWithLocation(internal::kInfo, file, line, source_text + " invoked");
-    return function_mocker_->AddNewExpectation(
+    return function_mocker_->AddNewExpectation( // NOLINT
         file, line, source_text, matchers_);
   }
 


### PR DESCRIPTION
Inside the AddNewExpectation() function, the expectation object owner is
pushed in a vector effectively incrementing the owner count. This prevents
the next destructor call (the closing bracket) from deleting the object.