### PR TITLE
Fix MSVC warning C5046 in gmock-matchers.h

### DIFF
--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -145,6 +145,9 @@ class MatcherDescriberInterface {
 template <typename T>
 class MatcherInterface : public MatcherDescriberInterface {
  public:
+  // https://developercommunity.visualstudio.com/content/problem/288509/view.html
+  virtual ~MatcherInterface() {};
+
   // Returns true iff the matcher matches x; also explains the match
   // result to 'listener' if necessary (see the next paragraph), in
   // the form of a non-restrictive relative clause ("which ...",


### PR DESCRIPTION
C5046: Symbol involving type with internal linkage not defined

This warning appeared in VS2017 15.8, and is (so far) undocumented.

The workaround described in the following link should be harmless:

https://developercommunity.visualstudio.com/content/problem/288509/view.html

Signed-off-by: Dakota Hawkins <dakotahawkins@gmail.com>