### PR TITLE
Work around Oracle Developer Studio 12.6 compiler bug

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -5648,7 +5648,7 @@ bool ParseInt32Flag(const char* str, const char* flag, Int32* value) {
 // On success, stores the value of the flag in *value, and returns
 // true.  On failure, returns false without changing *value.
 template <typename String>
-static bool ParseStringFlag(const char* str, const char* flag, String* value) {
+bool ParseStringFlag(const char* str, const char* flag, String* value) {
   // Gets the value of the flag as a string.
   const char* const value_str = ParseFlagValue(str, flag, false);
 


### PR DESCRIPTION
Compiling `googletest/src/gtest.cc` with the free version of Oracle Developer Studio 12.6 triggers a compiler assertion:

    <root>/googletest/src $ CC -c -std=c++11 -mt -I.. -I../include gtest.cc
     >> Assertion:   (../lnk/symdescr.cc, line 96)
        while processing gtest.cc at line 0.

This is apparently a [known bug in the compiler](https://community.oracle.com/thread/4106985) when instantiating a static function template inside a namespace. Adding `-verbose=template` to the command line revealed that `testing::internal::ParseStringFlag()` was the last static function template to be instantiated before the crash.

Remove the `static` qualifier from the function template to work around the compiler bug.

NOTE: I discovered the problem while building Google Test from within the IDE after [setting up a project file](https://github.com/tanzislam/cryptopals/wiki/Importing-into-Oracle-Developer-Studio-12.6#prepare-the-google-test-projects). I'm running it on Solaris 11.3 x86 in a Hyper-V VM (guest: 2 vCPU + 3.5 GB RAM).