### PR TITLE
pkgconfig: Unconditionally depend on GTest when using GMock

### DIFF
--- a/googlemock/cmake/gmock.pc.in
+++ b/googlemock/cmake/gmock.pc.in
@@ -5,5 +5,6 @@ Name: gmock
 Description: GoogleMock (without main() function)
 Version: @PROJECT_VERSION@
 URL: https://github.com/google/googletest
+Requires: gtest
 Libs: -L${libdir} -lgmock @CMAKE_THREAD_LIBS_INIT@
 Cflags: -I${includedir} @GTEST_HAS_PTHREAD_MACRO@ @CMAKE_THREAD_LIBS_INIT@

--- a/googlemock/cmake/gmock_main.pc.in
+++ b/googlemock/cmake/gmock_main.pc.in
@@ -5,5 +5,6 @@ Name: gmock_main
 Description: GoogleMock (with main() function)
 Version: @PROJECT_VERSION@
 URL: https://github.com/google/googletest
+Requires: gmock
 Libs: -L${libdir} -lgmock_main @CMAKE_THREAD_LIBS_INIT@
 Cflags: -I${includedir} @GTEST_HAS_PTHREAD_MACRO@ @CMAKE_THREAD_LIBS_INIT@


### PR DESCRIPTION
* GTest is a required dependency for GMock, hence
  we always need to pull it in.

@gennadiycivil could we also get this into the `1.8.0` branch? Having the wrong pkg-config files there will set it in stone and make them quasi useless.