### PR TITLE
Fix Compile error, and warning in Visual Studio 2013

### DIFF
--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -56,11 +56,17 @@
 # include <initializer_list>  // NOLINT -- must be after gtest.h
 #endif
 
+#if _MSC_VER >= 1900
 GTEST_DISABLE_MSC_WARNINGS_PUSH_(
     4251 5046 /* class A needs to have dll-interface to be used by clients of
                  class B */
     /* Symbol involving type with internal linkage not defined */)
-
+#else //Pragma 5046 doesn't exist in version of MSC prior to 1900
+GTEST_DISABLE_MSC_WARNINGS_PUSH_(
+    4251 /* class A needs to have dll-interface to be used by clients of
+                 class B */
+    /* Symbol involving type with internal linkage not defined */)
+#endif
 namespace testing {
 
 // To implement a matcher Foo for type T, define:

--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -983,7 +983,7 @@ struct TuplePolicy {
 
   template <size_t I>
   static typename AddReference<const typename ::std::tr1::tuple_element<
-      static_cast<int>(I), Tuple>::type>::type
+      I, Tuple>::type>::type
   get(const Tuple& tuple) {
     return ::std::tr1::get<I>(tuple);
   }


### PR DESCRIPTION
The commit [b50b2f7](https://github.com/google/googletest/commit/b50b2f775ed0268af9c83a96b285e296778d0743) causes the project build to fail in Visual Studio 2013. This PR fixes this, by reverting the breaking change for older versions of VS. 
Also, VisualStudio 2013 doesn't support pragma warning 5046 and gives a warning/error when run on the current version of GooglewMock. This PR also fixes this issue.