### PR TITLE
Return GTEST_ATTRIBUTE_UNUSED_ on record_property_env

### DIFF
--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -2117,7 +2117,7 @@ class UnitTestRecordPropertyTestEnvironment : public Environment {
 };
 
 // This will test property recording outside of any test or test case.
-static Environment* record_property_env =
+static Environment* record_property_env GTEST_ATTRIBUTE_UNUSED_ =
     AddGlobalTestEnvironment(new UnitTestRecordPropertyTestEnvironment);
 
 // This group of tests is for predicate assertions (ASSERT_PRED*, etc)


### PR DESCRIPTION
The unused attribute was removed with commit 3299a23 on 2018-02-23, but it currently breaks build of 1.8.1, because of -Werror GCC parameter as reported in issue #1825.