### PR TITLE
make WithParamInterface<T>::GetParam static

### DIFF
--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1798,11 +1798,8 @@ class WithParamInterface {
   virtual ~WithParamInterface() {}
 
   // The current parameter value. Is also available in the test fixture's
-  // constructor. This member function is non-static, even though it only
-  // references static data, to reduce the opportunity for incorrect uses
-  // like writing 'WithParamInterface<bool>::GetParam()' for a test that
-  // uses a fixture whose parameter type is int.
-  const ParamType& GetParam() const {
+  // constructor.
+  static const ParamType& GetParam() {
     GTEST_CHECK_(parameter_ != NULL)
         << "GetParam() can only be called inside a value-parameterized test "
         << "-- did you intend to write TEST_P instead of TEST_F?";


### PR DESCRIPTION
The decision for GetParam to be non-static can lead to order dependencies in multiple inheritance cases for otherwise normal usage.

As an example from libvpx we have

#define GET_PARAM(k) std::tr1::get< k >(GetParam())
template<class T1, class T2>
class CodecTestWith2Params : public ::testing::TestWithParam<
    std::tr1::tuple< const libvpx_test::CodecFactory*, T1, T2 > > {
};
...
class ActiveMapTest
    : public ::libvpx_test::EncoderTest,
      public ::libvpx_test::CodecTestWith2Params<libvpx_test::TestMode, int> {
...
  ActiveMapTest() : EncoderTest(GET_PARAM(0)) {}

here GetParam is called before the TestWithParam subobject has begun construction. This is, of course, undefined behaviour (and the address-sanitizer will complain). The problem can be avoided by changing the order of inheritance. But this seems to be a rather artificial restriction which does not necessarily weigh less than the desire to avoid mistakes that were meant to be prevented by making GetParam non-static.