### PR TITLE
Added special catch for std::exception in GTEST_TEST_NO_THROW_

### DIFF
--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1199,6 +1199,7 @@ public:
   const std::string& get() const { return value; }
 
 private:
+  AdditionalMessage& operator=(AdditionalMessage&&);
   std::string value;
 };
 

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1192,7 +1192,7 @@ class NativeArray {
 class AdditionalMessage
 {
 public:
-  AdditionalMessage(const std::string& message) : value(message) {}
+  AdditionalMessage(const char* message) : value(message) {}
   AdditionalMessage& operator=(const std::string& message) { value = message; return *this; }
   operator bool() const { return ::testing::internal::AlwaysTrue(); }
 

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1242,22 +1242,19 @@ private:
     } \
     catch (const std::exception& e) { \
       if (!gtest_caught_expected) { \
-        message.set( \
-            "it throws a different type " \
+        message.set("it throws a different type " \
             "with message: " + std::string(e.what())); \
         goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
       } \
     } \
     catch (...) { \
       if (!gtest_caught_expected) { \
-        message.set( \
-            "it throws a different type."); \
+        message.set("it throws a different type."); \
         goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
       } \
     } \
     if (!gtest_caught_expected) { \
-      message.set( \
-          "it throws nothing."); \
+      message.set("it throws nothing."); \
       goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
     } \
   } else \

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1199,7 +1199,6 @@ public:
   const std::string& get() const { return value; }
 
 private:
-  AdditionalMessage& operator=(AdditionalMessage&&);
   std::string value;
 };
 

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1193,7 +1193,7 @@ class AdditionalMessage
 {
 public:
   AdditionalMessage(const char* message) : value(message) {}
-  AdditionalMessage& operator=(const std::string& message) { value = message; return *this; }
+  void set(const std::string& message) { value = message; }
   operator bool() const { return true; }
 
   const std::string& get() const { return value; }
@@ -1242,22 +1242,22 @@ private:
     } \
     catch (const std::exception& e) { \
       if (!gtest_caught_expected) { \
-        message = \
+        message.set( \
             "it throws a different type " \
-            "with message: " + std::string(e.what()); \
+            "with message: " + std::string(e.what())); \
         goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
       } \
     } \
     catch (...) { \
       if (!gtest_caught_expected) { \
-        message = \
-            "it throws a different type."; \
+        message.set( \
+            "it throws a different type."); \
         goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
       } \
     } \
     if (!gtest_caught_expected) { \
-      message = \
-          "it throws nothing."; \
+      message.set( \
+          "it throws nothing."); \
       goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
     } \
   } else \
@@ -1272,7 +1272,7 @@ private:
       GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement); \
     } \
     catch (const std::exception& e) { \
-      message = std::string(": ") + e.what(); \
+      message.set(std::string(": ") + e.what()); \
       goto GTEST_CONCAT_TOKEN_(gtest_label_testnothrow_, __LINE__); \
     } \
     catch (...) { \

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -3373,6 +3373,20 @@ TEST_F(SingleEvaluationTest, ExceptionTests) {
   // failed EXPECT_ANY_THROW
   EXPECT_NONFATAL_FAILURE(EXPECT_ANY_THROW(a_++), "it doesn't");
   EXPECT_EQ(7, a_);
+
+  // failed EXPECT_THROW std::exception, throws different
+  EXPECT_NONFATAL_FAILURE(EXPECT_THROW({  // NOLINT
+    a_++;
+    ThrowAnInteger();
+  }, std::exception), "throws a different type");
+  EXPECT_EQ(8, a_);
+
+  // failed EXPECT_THROW, throws std::exception
+  EXPECT_NONFATAL_FAILURE(EXPECT_THROW({  // NOLINT
+    a_++;
+    ThrowAnException("blablubb");
+  }, bool), "throws a different type with message: blablubb");
+  EXPECT_EQ(9, a_);
 }
 
 #endif  // GTEST_HAS_EXCEPTIONS
@@ -3805,6 +3819,11 @@ TEST(AssertionTest, ASSERT_THROW) {
       ASSERT_THROW(ThrowNothing(), bool),
       "Expected: ThrowNothing() throws an exception of type bool.\n"
       "  Actual: it throws nothing.");
+
+  EXPECT_FATAL_FAILURE(
+      ASSERT_THROW(ThrowAnException("buuh"), bool),
+      "Expected: ThrowAnException(\"buuh\") throws an exception of type bool.\n"
+      "  Actual: it throws a different type with message: buuh");
 }
 
 // Tests ASSERT_NO_THROW.
@@ -4542,13 +4561,16 @@ TEST(ExpectTest, EXPECT_GT) {
 // Tests EXPECT_THROW.
 TEST(ExpectTest, EXPECT_THROW) {
   EXPECT_THROW(ThrowAnInteger(), int);
+  EXPECT_THROW(ThrowAnException(""), std::exception);
   EXPECT_NONFATAL_FAILURE(EXPECT_THROW(ThrowAnInteger(), bool),
-                          "Expected: ThrowAnInteger() throws an exception of "
-                          "type bool.\n  Actual: it throws a different type.");
-  EXPECT_NONFATAL_FAILURE(
-      EXPECT_THROW(ThrowNothing(), bool),
-      "Expected: ThrowNothing() throws an exception of type bool.\n"
-      "  Actual: it throws nothing.");
+                          "Expected: ThrowAnInteger() throws an exception of type bool.\n"
+                          "  Actual: it throws a different type.");
+  EXPECT_NONFATAL_FAILURE(EXPECT_THROW(ThrowNothing(), bool),
+                         "Expected: ThrowNothing() throws an exception of type bool.\n"
+                          "  Actual: it throws nothing.");
+  EXPECT_NONFATAL_FAILURE(EXPECT_THROW(ThrowAnException("buuh"), bool),
+                         "Expected: ThrowAnException(\"buuh\") throws an exception of type bool.\n"
+                          "  Actual: it throws a different type with message: buuh");
 }
 
 // Tests EXPECT_NO_THROW.

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -3330,6 +3330,9 @@ TEST_F(SingleEvaluationTest, OtherCases) {
 void ThrowAnInteger() {
   throw 1;
 }
+void ThrowAnException(const char* what) {
+  throw std::runtime_error(what);
+}
 
 // Tests that assertion arguments are evaluated exactly once.
 TEST_F(SingleEvaluationTest, ExceptionTests) {
@@ -3812,6 +3815,9 @@ TEST(AssertionTest, ASSERT_NO_THROW) {
   EXPECT_FATAL_FAILURE(ASSERT_NO_THROW(ThrowAnInteger()),
                        "Expected: ThrowAnInteger() doesn't throw an exception."
                        "\n  Actual: it throws.");
+  EXPECT_FATAL_FAILURE(ASSERT_NO_THROW(ThrowAnException("blablubb")),
+                       "Expected: ThrowAnException(\"blablubb\") doesn't throw an exception."
+                       "\n  Actual: it throws: blablubb");
 }
 
 // Tests ASSERT_ANY_THROW.
@@ -4553,6 +4559,9 @@ TEST(ExpectTest, EXPECT_NO_THROW) {
   EXPECT_NONFATAL_FAILURE(EXPECT_NO_THROW(ThrowAnInteger()),
                           "Expected: ThrowAnInteger() doesn't throw an "
                           "exception.\n  Actual: it throws.");
+  EXPECT_NONFATAL_FAILURE(EXPECT_NO_THROW(ThrowAnException("blablubb")),
+                          "Expected: ThrowAnException(\"blablubb\") doesn't throw an "
+                          "exception.\n  Actual: it throws: blablubb");
 }
 
 // Tests EXPECT_ANY_THROW.

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -3748,6 +3748,19 @@ TEST(ExpectTest, ASSERT_EQ_0) {
                        "  0\n  5.6");
 }
 
+TEST(AssertionTest, AdditionalMessage) {
+  ::testing::internal::AdditionalMessage m = "servus";
+  EXPECT_EQ(m.get(), "servus");
+
+  const char* cc = "hello";
+  m = cc;
+  EXPECT_EQ(m.get(), cc);
+
+  std::string s = "hi";
+  m = s;
+  EXPECT_EQ(m.get(), s);
+}
+
 // Tests ASSERT_NE.
 TEST(AssertionTest, ASSERT_NE) {
   ASSERT_NE(6, 7);

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -3748,19 +3748,6 @@ TEST(ExpectTest, ASSERT_EQ_0) {
                        "  0\n  5.6");
 }
 
-TEST(AssertionTest, AdditionalMessage) {
-  ::testing::internal::AdditionalMessage m = "servus";
-  EXPECT_EQ(m.get(), "servus");
-
-  const char* cc = "hello";
-  m = cc;
-  EXPECT_EQ(m.get(), cc);
-
-  std::string s = "hi";
-  m = s;
-  EXPECT_EQ(m.get(), s);
-}
-
 // Tests ASSERT_NE.
 TEST(AssertionTest, ASSERT_NE) {
   ASSERT_NE(6, 7);


### PR DESCRIPTION
Just like #911 this PR aims to output the message of a std::exception in case of a failure.