### PR TITLE
FunctionMockerBase calls virtual function in its destructor

### DIFF
--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -1559,7 +1559,7 @@ class FunctionMockerBase : public UntypedFunctionMockerBase {
   // Implements UntypedFunctionMockerBase::ClearDefaultActionsLocked():
   // clears the ON_CALL()s set on this mock function.
   virtual void ClearDefaultActionsLocked()
-      GTEST_EXCLUSIVE_LOCK_REQUIRED_(g_gmock_mutex) {
+      GTEST_EXCLUSIVE_LOCK_REQUIRED_(g_gmock_mutex) final {
     g_gmock_mutex.AssertHeld();
 
     // Deleting our default actions may trigger other mock objects to be


### PR DESCRIPTION
FunctionMockerBase calls ClearDefaultActionsLocked within its
destructor. While this destructor is implemented here, it is not marked
final. This means any clas inheriting FunctionMockerbase "could" call
override which causes undifined behaviour. Mark
ClearDefaultActionsLocked as final so it cannot be overridden.

Error was pointed out by Clang Tidy 7.0.0-RC3