### PR TITLE
Added special catch for std::exception in GTEST_TEST_NO_THROW_

### DIFF
--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1189,6 +1189,19 @@ class NativeArray {
   GTEST_DISALLOW_ASSIGN_(NativeArray);
 };
 
+class AdditionalMessage
+{
+public:
+  AdditionalMessage(const char* message) : value(message) {}
+  void set(const std::string& message) { value = message; }
+  operator bool() const { return true; }
+
+  const std::string& get() const { return value; }
+
+private:
+  std::string value;
+};
+
 }  // namespace internal
 }  // namespace testing
 
@@ -1216,43 +1229,56 @@ class NativeArray {
 
 #define GTEST_TEST_THROW_(statement, expected_exception, fail) \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
-  if (::testing::internal::ConstCharPtr gtest_msg = "") { \
+  if (::testing::internal::AdditionalMessage message = "") { \
     bool gtest_caught_expected = false; \
     try { \
-      GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement); \
+      try { \
+        GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement); \
+      } \
+      catch (expected_exception const&) { \
+        gtest_caught_expected = true; \
+        throw; \
+      } \
     } \
-    catch (expected_exception const&) { \
-      gtest_caught_expected = true; \
+    catch (const std::exception& e) { \
+      if (!gtest_caught_expected) { \
+        message.set("it throws a different type " \
+            "with message: " + std::string(e.what())); \
+        goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
+      } \
     } \
     catch (...) { \
-      gtest_msg.value = \
-          "Expected: " #statement " throws an exception of type " \
-          #expected_exception ".\n  Actual: it throws a different type."; \
-      goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
+      if (!gtest_caught_expected) { \
+        message.set("it throws a different type."); \
+        goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
+      } \
     } \
     if (!gtest_caught_expected) { \
-      gtest_msg.value = \
-          "Expected: " #statement " throws an exception of type " \
-          #expected_exception ".\n  Actual: it throws nothing."; \
+      message.set("it throws nothing."); \
       goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
     } \
   } else \
     GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__): \
-      fail(gtest_msg.value)
+      fail(("Expected: " #statement " throws an exception of type " \
+            #expected_exception ".\n  Actual: " + message.get()).c_str())
 
 #define GTEST_TEST_NO_THROW_(statement, fail) \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
-  if (::testing::internal::AlwaysTrue()) { \
+  if (::testing::internal::AdditionalMessage message = ".") { \
     try { \
       GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement); \
+    } \
+    catch (const std::exception& e) { \
+      message.set(std::string(": ") + e.what()); \
+      goto GTEST_CONCAT_TOKEN_(gtest_label_testnothrow_, __LINE__); \
     } \
     catch (...) { \
       goto GTEST_CONCAT_TOKEN_(gtest_label_testnothrow_, __LINE__); \
     } \
   } else \
     GTEST_CONCAT_TOKEN_(gtest_label_testnothrow_, __LINE__): \
-      fail("Expected: " #statement " doesn't throw an exception.\n" \
-           "  Actual: it throws.")
+      fail(("Expected: " #statement " doesn't throw an exception.\n" \
+           "  Actual: it throws" + message.get()).c_str())
 
 #define GTEST_TEST_ANY_THROW_(statement, fail) \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_ \

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1192,14 +1192,14 @@ class NativeArray {
 class AdditionalMessage
 {
 public:
-  AdditionalMessage(const char* message) : value(message) {}
-  void set(const std::string& message) { value = message; }
+  AdditionalMessage(const char* message) : msg(message) {}
+  void set(const std::string& message) { msg = message; }
   operator bool() const { return true; }
 
-  const std::string& get() const { return value; }
+  const std::string& get() const { return msg; }
 
 private:
-  std::string value;
+  std::string msg;
 };
 
 }  // namespace internal

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -6858,7 +6858,7 @@ TEST(ColoredOutputTest, UsesColorsWhenStdoutIsTty) {
 TEST(ColoredOutputTest, UsesColorsWhenTermSupportsColors) {
   GTEST_FLAG(color) = "auto";
 
-#if GTEST_OS_WINDOWS
+#if GTEST_OS_WINDOWS && !GTEST_OS_WINDOWS_MINGW
   // On Windows, we ignore the TERM variable as it's usually not set.
 
   SetEnv("TERM", "dumb");

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -3821,9 +3821,9 @@ TEST(AssertionTest, ASSERT_THROW) {
       "  Actual: it throws nothing.");
 
   EXPECT_FATAL_FAILURE(
-      ASSERT_THROW(ThrowAnException("buuh"), bool),
-      "Expected: ThrowAnException(\"buuh\") throws an exception of type bool.\n"
-      "  Actual: it throws a different type with message: buuh");
+      ASSERT_THROW(ThrowAnException("b"), bool),
+      "Expected: ThrowAnException(\"b\") throws an exception of type bool.\n"
+      "  Actual: it throws a different type with message: b");
 }
 
 // Tests ASSERT_NO_THROW.
@@ -3833,8 +3833,8 @@ TEST(AssertionTest, ASSERT_NO_THROW) {
                        "Expected: ThrowAnInteger() doesn't throw an exception."
                        "\n  Actual: it throws.");
   EXPECT_FATAL_FAILURE(ASSERT_NO_THROW(ThrowAnException("blablubb")),
-                       "Expected: ThrowAnException(\"blablubb\") doesn't throw an exception."
-                       "\n  Actual: it throws: blablubb");
+                       "Expected: ThrowAnException(\"blablubb\") doesn't throw"
+                       "an exception.\n  Actual: it throws: blablubb");
 }
 
 // Tests ASSERT_ANY_THROW.
@@ -4563,14 +4563,15 @@ TEST(ExpectTest, EXPECT_THROW) {
   EXPECT_THROW(ThrowAnInteger(), int);
   EXPECT_THROW(ThrowAnException(""), std::exception);
   EXPECT_NONFATAL_FAILURE(EXPECT_THROW(ThrowAnInteger(), bool),
-                          "Expected: ThrowAnInteger() throws an exception of type bool.\n"
-                          "  Actual: it throws a different type.");
+                          "Expected: ThrowAnInteger() throws an exception of "
+                          "type bool.\n  Actual: it throws a different type.");
   EXPECT_NONFATAL_FAILURE(EXPECT_THROW(ThrowNothing(), bool),
-                         "Expected: ThrowNothing() throws an exception of type bool.\n"
-                          "  Actual: it throws nothing.");
+                         "Expected: ThrowNothing() throws an exception of "
+                          "type bool.\n  Actual: it throws nothing.");
   EXPECT_NONFATAL_FAILURE(EXPECT_THROW(ThrowAnException("buuh"), bool),
-                         "Expected: ThrowAnException(\"buuh\") throws an exception of type bool.\n"
-                          "  Actual: it throws a different type with message: buuh");
+                         "Expected: ThrowAnException(\"buuh\") throws an "
+                          "exception of type bool.\n  Actual: "
+                          "it throws a different type with message: buuh");
 }
 
 // Tests EXPECT_NO_THROW.
@@ -4579,9 +4580,9 @@ TEST(ExpectTest, EXPECT_NO_THROW) {
   EXPECT_NONFATAL_FAILURE(EXPECT_NO_THROW(ThrowAnInteger()),
                           "Expected: ThrowAnInteger() doesn't throw an "
                           "exception.\n  Actual: it throws.");
-  EXPECT_NONFATAL_FAILURE(EXPECT_NO_THROW(ThrowAnException("blablubb")),
-                          "Expected: ThrowAnException(\"blablubb\") doesn't throw an "
-                          "exception.\n  Actual: it throws: blablubb");
+  EXPECT_NONFATAL_FAILURE(EXPECT_NO_THROW(ThrowAnException("blah")),
+                          "Expected: ThrowAnException(\"blah\") doesn't "
+                          "throw an exception.\n  Actual: it throws: blah");
 }
 
 // Tests EXPECT_ANY_THROW.

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -3328,6 +3328,9 @@ TEST_F(SingleEvaluationTest, OtherCases) {
 void ThrowAnInteger() {
   throw 1;
 }
+void ThrowAnException(const char* what) {
+  throw std::runtime_error(what);
+}
 
 // Tests that assertion arguments are evaluated exactly once.
 TEST_F(SingleEvaluationTest, ExceptionTests) {
@@ -3370,6 +3373,20 @@ TEST_F(SingleEvaluationTest, ExceptionTests) {
   // failed EXPECT_ANY_THROW
   EXPECT_NONFATAL_FAILURE(EXPECT_ANY_THROW(a_++), "it doesn't");
   EXPECT_EQ(7, a_);
+
+  // failed EXPECT_THROW std::exception, throws different
+  EXPECT_NONFATAL_FAILURE(EXPECT_THROW({  // NOLINT
+    a_++;
+    ThrowAnInteger();
+  }, std::exception), "throws a different type");
+  EXPECT_EQ(8, a_);
+
+  // failed EXPECT_THROW, throws std::exception
+  EXPECT_NONFATAL_FAILURE(EXPECT_THROW({  // NOLINT
+    a_++;
+    ThrowAnException("blablubb");
+  }, bool), "throws a different type with message: blablubb");
+  EXPECT_EQ(9, a_);
 }
 
 #endif  // GTEST_HAS_EXCEPTIONS
@@ -3802,6 +3819,11 @@ TEST(AssertionTest, ASSERT_THROW) {
       ASSERT_THROW(ThrowNothing(), bool),
       "Expected: ThrowNothing() throws an exception of type bool.\n"
       "  Actual: it throws nothing.");
+
+  EXPECT_FATAL_FAILURE(
+      ASSERT_THROW(ThrowAnException("buuh"), bool),
+      "Expected: ThrowAnException(\"buuh\") throws an exception of type bool.\n"
+      "  Actual: it throws a different type with message: buuh");
 }
 
 // Tests ASSERT_NO_THROW.
@@ -3810,6 +3832,9 @@ TEST(AssertionTest, ASSERT_NO_THROW) {
   EXPECT_FATAL_FAILURE(ASSERT_NO_THROW(ThrowAnInteger()),
                        "Expected: ThrowAnInteger() doesn't throw an exception."
                        "\n  Actual: it throws.");
+  EXPECT_FATAL_FAILURE(ASSERT_NO_THROW(ThrowAnException("blablubb")),
+                       "Expected: ThrowAnException(\"blablubb\") doesn't throw an exception."
+                       "\n  Actual: it throws: blablubb");
 }
 
 // Tests ASSERT_ANY_THROW.
@@ -4536,13 +4561,16 @@ TEST(ExpectTest, EXPECT_GT) {
 // Tests EXPECT_THROW.
 TEST(ExpectTest, EXPECT_THROW) {
   EXPECT_THROW(ThrowAnInteger(), int);
+  EXPECT_THROW(ThrowAnException(""), std::exception);
   EXPECT_NONFATAL_FAILURE(EXPECT_THROW(ThrowAnInteger(), bool),
-                          "Expected: ThrowAnInteger() throws an exception of "
-                          "type bool.\n  Actual: it throws a different type.");
-  EXPECT_NONFATAL_FAILURE(
-      EXPECT_THROW(ThrowNothing(), bool),
-      "Expected: ThrowNothing() throws an exception of type bool.\n"
-      "  Actual: it throws nothing.");
+                          "Expected: ThrowAnInteger() throws an exception of type bool.\n"
+                          "  Actual: it throws a different type.");
+  EXPECT_NONFATAL_FAILURE(EXPECT_THROW(ThrowNothing(), bool),
+                         "Expected: ThrowNothing() throws an exception of type bool.\n"
+                          "  Actual: it throws nothing.");
+  EXPECT_NONFATAL_FAILURE(EXPECT_THROW(ThrowAnException("buuh"), bool),
+                         "Expected: ThrowAnException(\"buuh\") throws an exception of type bool.\n"
+                          "  Actual: it throws a different type with message: buuh");
 }
 
 // Tests EXPECT_NO_THROW.
@@ -4551,6 +4579,9 @@ TEST(ExpectTest, EXPECT_NO_THROW) {
   EXPECT_NONFATAL_FAILURE(EXPECT_NO_THROW(ThrowAnInteger()),
                           "Expected: ThrowAnInteger() doesn't throw an "
                           "exception.\n  Actual: it throws.");
+  EXPECT_NONFATAL_FAILURE(EXPECT_NO_THROW(ThrowAnException("blablubb")),
+                          "Expected: ThrowAnException(\"blablubb\") doesn't throw an "
+                          "exception.\n  Actual: it throws: blablubb");
 }
 
 // Tests EXPECT_ANY_THROW.
@@ -6826,7 +6857,7 @@ TEST(ColoredOutputTest, UsesColorsWhenStdoutIsTty) {
 TEST(ColoredOutputTest, UsesColorsWhenTermSupportsColors) {
   GTEST_FLAG(color) = "auto";
 
-#if GTEST_OS_WINDOWS && !GTEST_OS_WINDOWS_MINGW
+#if GTEST_OS_WINDOWS
   // On Windows, we ignore the TERM variable as it's usually not set.
 
   SetEnv("TERM", "dumb");


### PR DESCRIPTION
Identical PR to #1832.
Is used the code from master when the PR was merged, shortened some lines and renamed the value member (I have to add that I think value is a pretty good name for the member of this class ;) )