### PR TITLE
Issue #1854: remove support for i386 for XCode 10

### DIFF
--- a/googletest/xcode/Config/General.xcconfig
+++ b/googletest/xcode/Config/General.xcconfig
@@ -7,8 +7,8 @@
 //  https://github.com/google/google-toolbox-for-mac
 // 
 
-// Build for PPC and Intel, 32- and 64-bit
-ARCHS = i386 x86_64 ppc ppc64
+// Build for PPC and Intel 64-bit
+ARCHS = x86_64 ppc ppc64
 
 // Zerolink prevents link warnings so turn it off
 ZERO_LINK = NO


### PR DESCRIPTION
In support of issue: https://github.com/google/googletest/issues/1854

Tested in: Xcode 10 (10A255) - September 17, 2018