### PR TITLE
Add clang format check to one of the builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,9 @@ matrix:
     - os: linux
       compiler: clang
       sudo : true
+      env: TEST_CLANG_FORMAT="yes"
       install: ./ci/install-linux.sh && ./ci/log-config.sh
-      script: ./ci/build-linux-bazel.sh
+      script: ./ci/test_format.sh && ./ci/build-linux-bazel.sh
     - os: linux
       group: deprecated-2017Q4
       compiler: gcc
@@ -65,6 +66,7 @@ addons:
     packages:
     - g++-4.9
     - clang-3.9
+    - clang-format-3.9
 
 notifications:
   email: false

--- a/ci/test-format.sh
+++ b/ci/test-format.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+echo "clang-format - checking Code Formatting..."
+
+if [[ "${TRAVIS_OS_NAME}" == "linux" ]] && \
+   [[ "${TEST_CLANG_FORMAT}" == "yes" ]]; then
+
+    RETURN=0
+    CLANG_FORMAT="clang-format-3.9"
+
+    which clang-format-3.9
+
+    if [ ! -f ".clang-format" ]; then
+        echo ".clang-format file not found!"
+        exit 1
+    fi
+
+    FILES=`git diff master --name-only | grep -E "\.(cc|cpp|h)$"`
+
+    for FILE in $FILES; do
+
+        $CLANG_FORMAT $FILE | cmp  $FILE >/dev/null
+
+        if [ $? -ne 0 ]; then
+            echo "[!] Clang-Format Found INCORRECT FORMATTING. Please re-format and re-submit.  The following file failed: $FILE" >&2
+            RETURN=1
+        fi
+
+    done
+
+    exit $RETURN
+fi
+
+exit 0


### PR DESCRIPTION
Along with .clang-format file this will provide indication and fail the build if formatting is incorrect