### PR TITLE
Revert "[mingw] enable the unittests for gmock and gtest again"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,8 +64,8 @@ build_script:
 
     $conf = if ($env:generator -eq "MinGW Makefiles") {"-DCMAKE_BUILD_TYPE=$env:configuration"} else {"-DCMAKE_CONFIGURATION_TYPES=Debug;Release"}
     # Disable test for MinGW (gtest tests fail, gmock tests can not build)
-    $gtest_build_tests = "-Dgtest_build_tests=ON"
-    $gmock_build_tests = "-Dgmock_build_tests=ON"
+    $gtest_build_tests = if ($env:generator -eq "MinGW Makefiles") {"-Dgtest_build_tests=OFF"} else {"-Dgtest_build_tests=ON"}
+    $gmock_build_tests = if ($env:generator -eq "MinGW Makefiles") {"-Dgmock_build_tests=OFF"} else {"-Dgmock_build_tests=ON"}
     & cmake -G "$env:generator" $conf -Dgtest_build_samples=ON $gtest_build_tests $gmock_build_tests ..
     if ($LastExitCode -ne 0) {
         throw "Exec: $ErrorMessage"


### PR DESCRIPTION
Reverts google/googletest#1853
This causes errors 

cmake.exe : C:/mingw-w64/i686-6.3.0-posix-dwarf-rt_v5-rev1/mingw32/bin/../lib/gcc/i686-w64-mingw32/6.3.0/../../../../i686-w64-mingw32/bin/as.exe: CMakeFiles\gmock-matchers_test.dir\test\gmock-matchers_test.cc.obj: too many 
sections (54707)
At line:17 char:1
+ & cmake --build . --config $env:configuration -- $cmake_parallel
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (C:/mingw-w64/i6...ections (54707):String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
 
C:\Users\appveyor\AppData\Local\Temp\1\ccIA2Doy.s: Assembler messages:
C:\Users\appveyor\AppData\Local\Temp\1\ccIA2Doy.s: Fatal error: can't write 220 bytes to section .text of CMakeFiles\gmock-matchers_test.dir\test\gmock-matchers_test.cc.obj because: 'File too big'
C:/mingw-w64/i686-6.3.0-posix-dwarf-rt_v5-rev1/mingw32/bin/../lib/gcc/i686-w64-mingw32/6.3.0/../../../../i686-w64-mingw32/bin/as.exe: CMakeFiles\gmock-matchers_test.dir\test\gmock-matchers_test.cc.obj: too many sections (54707)
C:\Users\appveyor\AppData\Local\Temp\1\ccIA2Doy.s: Fatal error: can't close CMakeFiles\gmock-matchers_test.dir\test\gmock-matchers_test.cc.obj: File too