### PR TITLE
Add C++11 standard in the root CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ endif (POLICY CMP0048)
 
 project(googletest-distribution)
 set(GOOGLETEST_VERSION 1.9.0)
+set(CMAKE_CXX_STANDARD 11)
 
 enable_testing()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ endif (POLICY CMP0048)
 
 project(googletest-distribution)
 set(GOOGLETEST_VERSION 1.9.0)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 11 CACHE STRING "Set the C++ standard to be used for compiling")
 
 enable_testing()
 


### PR DESCRIPTION
This pull request should fix a build issue that was mentioned in issue [#1865](https://github.com/google/googletest/issues/1865). I added C++11 as a standard to the root CMakeLists.txt file. As a result, the build not longer fails and succeeds.