### PR TITLE
Use std::forward instead of std::move for MockFunction

### DIFF
--- a/googlemock/include/gmock/gmock-generated-function-mockers.h
+++ b/googlemock/include/gmock/gmock-generated-function-mockers.h
@@ -418,534 +418,478 @@ using internal::FunctionMocker;
     GTEST_CONCAT_TOKEN_(gmock##constness##arity##_##Method##_, __LINE__)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD0_(tn, constness, ct, Method, ...)                       \
-  GMOCK_RESULT_(tn, __VA_ARGS__) ct Method() constness {                     \
-    GTEST_COMPILE_ASSERT_(                                                   \
-        (::testing::tuple_size<tn ::testing::internal::Function<             \
-             __VA_ARGS__>::ArgumentTuple>::value == 0),                      \
-        this_method_does_not_take_0_arguments);                              \
-    GMOCK_MOCKER_(0, constness, Method).SetOwnerAndName(this, #Method);      \
-    return GMOCK_MOCKER_(0, constness, Method).Invoke();                     \
-  }                                                                          \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method() constness {              \
-    GMOCK_MOCKER_(0, constness, Method).RegisterOwner(this);                 \
-    return GMOCK_MOCKER_(0, constness, Method).With();                       \
-  }                                                                          \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                           \
-      const ::testing::internal::WithoutMatchers&,                           \
-      constness ::testing::internal::Function<__VA_ARGS__>*) const {         \
-    return ::testing::internal::AdjustConstness_##constness(this)            \
-        ->gmock_##Method();                                                  \
-  }                                                                          \
+#define GMOCK_METHOD0_(tn, constness, ct, Method, ...) \
+  GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
+      ) constness { \
+    GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
+        tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
+            == 0), \
+        this_method_does_not_take_0_arguments); \
+    GMOCK_MOCKER_(0, constness, Method).SetOwnerAndName(this, #Method); \
+    return GMOCK_MOCKER_(0, constness, Method).Invoke(); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> \
+      gmock_##Method() constness { \
+    GMOCK_MOCKER_(0, constness, Method).RegisterOwner(this); \
+    return GMOCK_MOCKER_(0, constness, Method).With(); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> gmock_##Method( \
+      const ::testing::internal::WithoutMatchers&, \
+      constness ::testing::internal::Function<__VA_ARGS__>* ) const { \
+        return ::testing::internal::AdjustConstness_##constness(this)-> \
+            gmock_##Method(); \
+      } \
   mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(0, constness, \
-                                                               Method)
+      Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD1_(tn, constness, ct, Method, ...)                        \
-  GMOCK_RESULT_(tn, __VA_ARGS__)                                              \
-  ct Method(GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1) constness {              \
-    GTEST_COMPILE_ASSERT_(                                                    \
-        (::testing::tuple_size<tn ::testing::internal::Function<              \
-             __VA_ARGS__>::ArgumentTuple>::value == 1),                       \
-        this_method_does_not_take_1_argument);                                \
-    GMOCK_MOCKER_(1, constness, Method).SetOwnerAndName(this, #Method);       \
-    return GMOCK_MOCKER_(1, constness, Method)                                \
-        .Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, __VA_ARGS__)>( \
-            gmock_a1));                                                       \
-  }                                                                           \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                            \
-      GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1) constness {                \
-    GMOCK_MOCKER_(1, constness, Method).RegisterOwner(this);                  \
-    return GMOCK_MOCKER_(1, constness, Method).With(gmock_a1);                \
-  }                                                                           \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                            \
-      const ::testing::internal::WithoutMatchers&,                            \
-      constness ::testing::internal::Function<__VA_ARGS__>*) const {          \
-    return ::testing::internal::AdjustConstness_##constness(this)             \
-        ->gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>());     \
-  }                                                                           \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(1, constness,  \
-                                                               Method)
+#define GMOCK_METHOD1_(tn, constness, ct, Method, ...) \
+  GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
+      GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1) constness { \
+    GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
+        tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
+            == 1), \
+        this_method_does_not_take_1_argument); \
+    GMOCK_MOCKER_(1, constness, Method).SetOwnerAndName(this, #Method); \
+    return GMOCK_MOCKER_(1, constness, \
+        Method).Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, \
+        __VA_ARGS__)>(gmock_a1)); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> \
+      gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1) constness { \
+    GMOCK_MOCKER_(1, constness, Method).RegisterOwner(this); \
+    return GMOCK_MOCKER_(1, constness, Method).With(gmock_a1); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> gmock_##Method( \
+      const ::testing::internal::WithoutMatchers&, \
+      constness ::testing::internal::Function<__VA_ARGS__>* ) const { \
+        return ::testing::internal::AdjustConstness_##constness(this)-> \
+            gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>()); \
+      } \
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(1, constness, \
+      Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD2_(tn, constness, ct, Method, ...)                        \
-  GMOCK_RESULT_(tn, __VA_ARGS__)                                              \
-  ct Method(GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1,                          \
-            GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2) constness {              \
-    GTEST_COMPILE_ASSERT_(                                                    \
-        (::testing::tuple_size<tn ::testing::internal::Function<              \
-             __VA_ARGS__>::ArgumentTuple>::value == 2),                       \
-        this_method_does_not_take_2_arguments);                               \
-    GMOCK_MOCKER_(2, constness, Method).SetOwnerAndName(this, #Method);       \
-    return GMOCK_MOCKER_(2, constness, Method)                                \
-        .Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, __VA_ARGS__)>( \
-                    gmock_a1),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 2, __VA_ARGS__)>( \
-                    gmock_a2));                                               \
-  }                                                                           \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                            \
-      GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1,                            \
-      GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2) constness {                \
-    GMOCK_MOCKER_(2, constness, Method).RegisterOwner(this);                  \
-    return GMOCK_MOCKER_(2, constness, Method).With(gmock_a1, gmock_a2);      \
-  }                                                                           \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                            \
-      const ::testing::internal::WithoutMatchers&,                            \
-      constness ::testing::internal::Function<__VA_ARGS__>*) const {          \
-    return ::testing::internal::AdjustConstness_##constness(this)             \
-        ->gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 2, __VA_ARGS__)>());     \
-  }                                                                           \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(2, constness,  \
-                                                               Method)
+#define GMOCK_METHOD2_(tn, constness, ct, Method, ...) \
+  GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
+      GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, GMOCK_ARG_(tn, 2, \
+          __VA_ARGS__) gmock_a2) constness { \
+    GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
+        tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
+            == 2), \
+        this_method_does_not_take_2_arguments); \
+    GMOCK_MOCKER_(2, constness, Method).SetOwnerAndName(this, #Method); \
+    return GMOCK_MOCKER_(2, constness, \
+        Method).Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, \
+        __VA_ARGS__)>(gmock_a1), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(gmock_a2)); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> \
+      gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
+                     GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2) constness { \
+    GMOCK_MOCKER_(2, constness, Method).RegisterOwner(this); \
+    return GMOCK_MOCKER_(2, constness, Method).With(gmock_a1, gmock_a2); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> gmock_##Method( \
+      const ::testing::internal::WithoutMatchers&, \
+      constness ::testing::internal::Function<__VA_ARGS__>* ) const { \
+        return ::testing::internal::AdjustConstness_##constness(this)-> \
+            gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 2, __VA_ARGS__)>()); \
+      } \
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(2, constness, \
+      Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD3_(tn, constness, ct, Method, ...)                        \
-  GMOCK_RESULT_(tn, __VA_ARGS__)                                              \
-  ct Method(GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1,                          \
-            GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2,                          \
-            GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3) constness {              \
-    GTEST_COMPILE_ASSERT_(                                                    \
-        (::testing::tuple_size<tn ::testing::internal::Function<              \
-             __VA_ARGS__>::ArgumentTuple>::value == 3),                       \
-        this_method_does_not_take_3_arguments);                               \
-    GMOCK_MOCKER_(3, constness, Method).SetOwnerAndName(this, #Method);       \
-    return GMOCK_MOCKER_(3, constness, Method)                                \
-        .Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, __VA_ARGS__)>( \
-                    gmock_a1),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 2, __VA_ARGS__)>( \
-                    gmock_a2),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 3, __VA_ARGS__)>( \
-                    gmock_a3));                                               \
-  }                                                                           \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                            \
-      GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1,                            \
-      GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2,                            \
-      GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3) constness {                \
-    GMOCK_MOCKER_(3, constness, Method).RegisterOwner(this);                  \
-    return GMOCK_MOCKER_(3, constness, Method)                                \
-        .With(gmock_a1, gmock_a2, gmock_a3);                                  \
-  }                                                                           \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                            \
-      const ::testing::internal::WithoutMatchers&,                            \
-      constness ::testing::internal::Function<__VA_ARGS__>*) const {          \
-    return ::testing::internal::AdjustConstness_##constness(this)             \
-        ->gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 3, __VA_ARGS__)>());     \
-  }                                                                           \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(3, constness,  \
-                                                               Method)
+#define GMOCK_METHOD3_(tn, constness, ct, Method, ...) \
+  GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
+      GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, GMOCK_ARG_(tn, 2, \
+          __VA_ARGS__) gmock_a2, GMOCK_ARG_(tn, 3, \
+          __VA_ARGS__) gmock_a3) constness { \
+    GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
+        tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
+            == 3), \
+        this_method_does_not_take_3_arguments); \
+    GMOCK_MOCKER_(3, constness, Method).SetOwnerAndName(this, #Method); \
+    return GMOCK_MOCKER_(3, constness, \
+        Method).Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, \
+        __VA_ARGS__)>(gmock_a1), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(gmock_a2), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(gmock_a3)); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> \
+      gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
+                     GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2, \
+                     GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3) constness { \
+    GMOCK_MOCKER_(3, constness, Method).RegisterOwner(this); \
+    return GMOCK_MOCKER_(3, constness, Method).With(gmock_a1, gmock_a2, \
+        gmock_a3); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> gmock_##Method( \
+      const ::testing::internal::WithoutMatchers&, \
+      constness ::testing::internal::Function<__VA_ARGS__>* ) const { \
+        return ::testing::internal::AdjustConstness_##constness(this)-> \
+            gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 3, __VA_ARGS__)>()); \
+      } \
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(3, constness, \
+      Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD4_(tn, constness, ct, Method, ...)                        \
-  GMOCK_RESULT_(tn, __VA_ARGS__)                                              \
-  ct Method(GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1,                          \
-            GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2,                          \
-            GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3,                          \
-            GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4) constness {              \
-    GTEST_COMPILE_ASSERT_(                                                    \
-        (::testing::tuple_size<tn ::testing::internal::Function<              \
-             __VA_ARGS__>::ArgumentTuple>::value == 4),                       \
-        this_method_does_not_take_4_arguments);                               \
-    GMOCK_MOCKER_(4, constness, Method).SetOwnerAndName(this, #Method);       \
-    return GMOCK_MOCKER_(4, constness, Method)                                \
-        .Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, __VA_ARGS__)>( \
-                    gmock_a1),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 2, __VA_ARGS__)>( \
-                    gmock_a2),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 3, __VA_ARGS__)>( \
-                    gmock_a3),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 4, __VA_ARGS__)>( \
-                    gmock_a4));                                               \
-  }                                                                           \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                            \
-      GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1,                            \
-      GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2,                            \
-      GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3,                            \
-      GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4) constness {                \
-    GMOCK_MOCKER_(4, constness, Method).RegisterOwner(this);                  \
-    return GMOCK_MOCKER_(4, constness, Method)                                \
-        .With(gmock_a1, gmock_a2, gmock_a3, gmock_a4);                        \
-  }                                                                           \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                            \
-      const ::testing::internal::WithoutMatchers&,                            \
-      constness ::testing::internal::Function<__VA_ARGS__>*) const {          \
-    return ::testing::internal::AdjustConstness_##constness(this)             \
-        ->gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 4, __VA_ARGS__)>());     \
-  }                                                                           \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(4, constness,  \
-                                                               Method)
+#define GMOCK_METHOD4_(tn, constness, ct, Method, ...) \
+  GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
+      GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, GMOCK_ARG_(tn, 2, \
+          __VA_ARGS__) gmock_a2, GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
+          GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4) constness { \
+    GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
+        tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
+            == 4), \
+        this_method_does_not_take_4_arguments); \
+    GMOCK_MOCKER_(4, constness, Method).SetOwnerAndName(this, #Method); \
+    return GMOCK_MOCKER_(4, constness, \
+        Method).Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, \
+        __VA_ARGS__)>(gmock_a1), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(gmock_a2), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(gmock_a3), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(gmock_a4)); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> \
+      gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
+                     GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2, \
+                     GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3, \
+                     GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4) constness { \
+    GMOCK_MOCKER_(4, constness, Method).RegisterOwner(this); \
+    return GMOCK_MOCKER_(4, constness, Method).With(gmock_a1, gmock_a2, \
+        gmock_a3, gmock_a4); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> gmock_##Method( \
+      const ::testing::internal::WithoutMatchers&, \
+      constness ::testing::internal::Function<__VA_ARGS__>* ) const { \
+        return ::testing::internal::AdjustConstness_##constness(this)-> \
+            gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 4, __VA_ARGS__)>()); \
+      } \
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(4, constness, \
+      Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD5_(tn, constness, ct, Method, ...)                        \
-  GMOCK_RESULT_(tn, __VA_ARGS__)                                              \
-  ct Method(GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1,                          \
-            GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2,                          \
-            GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3,                          \
-            GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4,                          \
-            GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5) constness {              \
-    GTEST_COMPILE_ASSERT_(                                                    \
-        (::testing::tuple_size<tn ::testing::internal::Function<              \
-             __VA_ARGS__>::ArgumentTuple>::value == 5),                       \
-        this_method_does_not_take_5_arguments);                               \
-    GMOCK_MOCKER_(5, constness, Method).SetOwnerAndName(this, #Method);       \
-    return GMOCK_MOCKER_(5, constness, Method)                                \
-        .Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, __VA_ARGS__)>( \
-                    gmock_a1),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 2, __VA_ARGS__)>( \
-                    gmock_a2),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 3, __VA_ARGS__)>( \
-                    gmock_a3),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 4, __VA_ARGS__)>( \
-                    gmock_a4),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 5, __VA_ARGS__)>( \
-                    gmock_a5));                                               \
-  }                                                                           \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                            \
-      GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1,                            \
-      GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2,                            \
-      GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3,                            \
-      GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4,                            \
-      GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5) constness {                \
-    GMOCK_MOCKER_(5, constness, Method).RegisterOwner(this);                  \
-    return GMOCK_MOCKER_(5, constness, Method)                                \
-        .With(gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5);              \
-  }                                                                           \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                            \
-      const ::testing::internal::WithoutMatchers&,                            \
-      constness ::testing::internal::Function<__VA_ARGS__>*) const {          \
-    return ::testing::internal::AdjustConstness_##constness(this)             \
-        ->gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 5, __VA_ARGS__)>());     \
-  }                                                                           \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(5, constness,  \
-                                                               Method)
+#define GMOCK_METHOD5_(tn, constness, ct, Method, ...) \
+  GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
+      GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, GMOCK_ARG_(tn, 2, \
+          __VA_ARGS__) gmock_a2, GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
+          GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, GMOCK_ARG_(tn, 5, \
+          __VA_ARGS__) gmock_a5) constness { \
+    GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
+        tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
+            == 5), \
+        this_method_does_not_take_5_arguments); \
+    GMOCK_MOCKER_(5, constness, Method).SetOwnerAndName(this, #Method); \
+    return GMOCK_MOCKER_(5, constness, \
+        Method).Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, \
+        __VA_ARGS__)>(gmock_a1), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(gmock_a2), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(gmock_a3), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(gmock_a4), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 5, __VA_ARGS__)>(gmock_a5)); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> \
+      gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
+                     GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2, \
+                     GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3, \
+                     GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4, \
+                     GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5) constness { \
+    GMOCK_MOCKER_(5, constness, Method).RegisterOwner(this); \
+    return GMOCK_MOCKER_(5, constness, Method).With(gmock_a1, gmock_a2, \
+        gmock_a3, gmock_a4, gmock_a5); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> gmock_##Method( \
+      const ::testing::internal::WithoutMatchers&, \
+      constness ::testing::internal::Function<__VA_ARGS__>* ) const { \
+        return ::testing::internal::AdjustConstness_##constness(this)-> \
+            gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 5, __VA_ARGS__)>()); \
+      } \
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(5, constness, \
+      Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD6_(tn, constness, ct, Method, ...)                        \
-  GMOCK_RESULT_(tn, __VA_ARGS__)                                              \
-  ct Method(GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1,                          \
-            GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2,                          \
-            GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3,                          \
-            GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4,                          \
-            GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5,                          \
-            GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6) constness {              \
-    GTEST_COMPILE_ASSERT_(                                                    \
-        (::testing::tuple_size<tn ::testing::internal::Function<              \
-             __VA_ARGS__>::ArgumentTuple>::value == 6),                       \
-        this_method_does_not_take_6_arguments);                               \
-    GMOCK_MOCKER_(6, constness, Method).SetOwnerAndName(this, #Method);       \
-    return GMOCK_MOCKER_(6, constness, Method)                                \
-        .Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, __VA_ARGS__)>( \
-                    gmock_a1),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 2, __VA_ARGS__)>( \
-                    gmock_a2),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 3, __VA_ARGS__)>( \
-                    gmock_a3),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 4, __VA_ARGS__)>( \
-                    gmock_a4),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 5, __VA_ARGS__)>( \
-                    gmock_a5),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 6, __VA_ARGS__)>( \
-                    gmock_a6));                                               \
-  }                                                                           \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                            \
-      GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1,                            \
-      GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2,                            \
-      GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3,                            \
-      GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4,                            \
-      GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5,                            \
-      GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6) constness {                \
-    GMOCK_MOCKER_(6, constness, Method).RegisterOwner(this);                  \
-    return GMOCK_MOCKER_(6, constness, Method)                                \
-        .With(gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6);    \
-  }                                                                           \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                            \
-      const ::testing::internal::WithoutMatchers&,                            \
-      constness ::testing::internal::Function<__VA_ARGS__>*) const {          \
-    return ::testing::internal::AdjustConstness_##constness(this)             \
-        ->gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 5, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 6, __VA_ARGS__)>());     \
-  }                                                                           \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(6, constness,  \
-                                                               Method)
+#define GMOCK_METHOD6_(tn, constness, ct, Method, ...) \
+  GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
+      GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, GMOCK_ARG_(tn, 2, \
+          __VA_ARGS__) gmock_a2, GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
+          GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, GMOCK_ARG_(tn, 5, \
+          __VA_ARGS__) gmock_a5, GMOCK_ARG_(tn, 6, \
+          __VA_ARGS__) gmock_a6) constness { \
+    GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
+        tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
+            == 6), \
+        this_method_does_not_take_6_arguments); \
+    GMOCK_MOCKER_(6, constness, Method).SetOwnerAndName(this, #Method); \
+    return GMOCK_MOCKER_(6, constness, \
+        Method).Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, \
+        __VA_ARGS__)>(gmock_a1), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(gmock_a2), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(gmock_a3), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(gmock_a4), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 5, __VA_ARGS__)>(gmock_a5), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 6, __VA_ARGS__)>(gmock_a6)); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> \
+      gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
+                     GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2, \
+                     GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3, \
+                     GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4, \
+                     GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5, \
+                     GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6) constness { \
+    GMOCK_MOCKER_(6, constness, Method).RegisterOwner(this); \
+    return GMOCK_MOCKER_(6, constness, Method).With(gmock_a1, gmock_a2, \
+        gmock_a3, gmock_a4, gmock_a5, gmock_a6); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> gmock_##Method( \
+      const ::testing::internal::WithoutMatchers&, \
+      constness ::testing::internal::Function<__VA_ARGS__>* ) const { \
+        return ::testing::internal::AdjustConstness_##constness(this)-> \
+            gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 5, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 6, __VA_ARGS__)>()); \
+      } \
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(6, constness, \
+      Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD7_(tn, constness, ct, Method, ...)                        \
-  GMOCK_RESULT_(tn, __VA_ARGS__)                                              \
-  ct Method(GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1,                          \
-            GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2,                          \
-            GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3,                          \
-            GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4,                          \
-            GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5,                          \
-            GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6,                          \
-            GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7) constness {              \
-    GTEST_COMPILE_ASSERT_(                                                    \
-        (::testing::tuple_size<tn ::testing::internal::Function<              \
-             __VA_ARGS__>::ArgumentTuple>::value == 7),                       \
-        this_method_does_not_take_7_arguments);                               \
-    GMOCK_MOCKER_(7, constness, Method).SetOwnerAndName(this, #Method);       \
-    return GMOCK_MOCKER_(7, constness, Method)                                \
-        .Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, __VA_ARGS__)>( \
-                    gmock_a1),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 2, __VA_ARGS__)>( \
-                    gmock_a2),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 3, __VA_ARGS__)>( \
-                    gmock_a3),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 4, __VA_ARGS__)>( \
-                    gmock_a4),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 5, __VA_ARGS__)>( \
-                    gmock_a5),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 6, __VA_ARGS__)>( \
-                    gmock_a6),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 7, __VA_ARGS__)>( \
-                    gmock_a7));                                               \
-  }                                                                           \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                            \
-      GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1,                            \
-      GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2,                            \
-      GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3,                            \
-      GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4,                            \
-      GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5,                            \
-      GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6,                            \
-      GMOCK_MATCHER_(tn, 7, __VA_ARGS__) gmock_a7) constness {                \
-    GMOCK_MOCKER_(7, constness, Method).RegisterOwner(this);                  \
-    return GMOCK_MOCKER_(7, constness, Method)                                \
-        .With(gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6,     \
-              gmock_a7);                                                      \
-  }                                                                           \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                            \
-      const ::testing::internal::WithoutMatchers&,                            \
-      constness ::testing::internal::Function<__VA_ARGS__>*) const {          \
-    return ::testing::internal::AdjustConstness_##constness(this)             \
-        ->gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 5, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 6, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 7, __VA_ARGS__)>());     \
-  }                                                                           \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(7, constness,  \
-                                                               Method)
+#define GMOCK_METHOD7_(tn, constness, ct, Method, ...) \
+  GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
+      GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, GMOCK_ARG_(tn, 2, \
+          __VA_ARGS__) gmock_a2, GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
+          GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, GMOCK_ARG_(tn, 5, \
+          __VA_ARGS__) gmock_a5, GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
+          GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7) constness { \
+    GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
+        tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
+            == 7), \
+        this_method_does_not_take_7_arguments); \
+    GMOCK_MOCKER_(7, constness, Method).SetOwnerAndName(this, #Method); \
+    return GMOCK_MOCKER_(7, constness, \
+        Method).Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, \
+        __VA_ARGS__)>(gmock_a1), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(gmock_a2), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(gmock_a3), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(gmock_a4), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 5, __VA_ARGS__)>(gmock_a5), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 6, __VA_ARGS__)>(gmock_a6), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 7, __VA_ARGS__)>(gmock_a7)); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> \
+      gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
+                     GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2, \
+                     GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3, \
+                     GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4, \
+                     GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5, \
+                     GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6, \
+                     GMOCK_MATCHER_(tn, 7, __VA_ARGS__) gmock_a7) constness { \
+    GMOCK_MOCKER_(7, constness, Method).RegisterOwner(this); \
+    return GMOCK_MOCKER_(7, constness, Method).With(gmock_a1, gmock_a2, \
+        gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> gmock_##Method( \
+      const ::testing::internal::WithoutMatchers&, \
+      constness ::testing::internal::Function<__VA_ARGS__>* ) const { \
+        return ::testing::internal::AdjustConstness_##constness(this)-> \
+            gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 5, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 6, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 7, __VA_ARGS__)>()); \
+      } \
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(7, constness, \
+      Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD8_(tn, constness, ct, Method, ...)                        \
-  GMOCK_RESULT_(tn, __VA_ARGS__)                                              \
-  ct Method(GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1,                          \
-            GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2,                          \
-            GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3,                          \
-            GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4,                          \
-            GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5,                          \
-            GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6,                          \
-            GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7,                          \
-            GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8) constness {              \
-    GTEST_COMPILE_ASSERT_(                                                    \
-        (::testing::tuple_size<tn ::testing::internal::Function<              \
-             __VA_ARGS__>::ArgumentTuple>::value == 8),                       \
-        this_method_does_not_take_8_arguments);                               \
-    GMOCK_MOCKER_(8, constness, Method).SetOwnerAndName(this, #Method);       \
-    return GMOCK_MOCKER_(8, constness, Method)                                \
-        .Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, __VA_ARGS__)>( \
-                    gmock_a1),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 2, __VA_ARGS__)>( \
-                    gmock_a2),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 3, __VA_ARGS__)>( \
-                    gmock_a3),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 4, __VA_ARGS__)>( \
-                    gmock_a4),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 5, __VA_ARGS__)>( \
-                    gmock_a5),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 6, __VA_ARGS__)>( \
-                    gmock_a6),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 7, __VA_ARGS__)>( \
-                    gmock_a7),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 8, __VA_ARGS__)>( \
-                    gmock_a8));                                               \
-  }                                                                           \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                            \
-      GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1,                            \
-      GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2,                            \
-      GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3,                            \
-      GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4,                            \
-      GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5,                            \
-      GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6,                            \
-      GMOCK_MATCHER_(tn, 7, __VA_ARGS__) gmock_a7,                            \
-      GMOCK_MATCHER_(tn, 8, __VA_ARGS__) gmock_a8) constness {                \
-    GMOCK_MOCKER_(8, constness, Method).RegisterOwner(this);                  \
-    return GMOCK_MOCKER_(8, constness, Method)                                \
-        .With(gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6,     \
-              gmock_a7, gmock_a8);                                            \
-  }                                                                           \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                            \
-      const ::testing::internal::WithoutMatchers&,                            \
-      constness ::testing::internal::Function<__VA_ARGS__>*) const {          \
-    return ::testing::internal::AdjustConstness_##constness(this)             \
-        ->gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 5, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 6, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 7, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 8, __VA_ARGS__)>());     \
-  }                                                                           \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(8, constness,  \
-                                                               Method)
+#define GMOCK_METHOD8_(tn, constness, ct, Method, ...) \
+  GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
+      GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, GMOCK_ARG_(tn, 2, \
+          __VA_ARGS__) gmock_a2, GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
+          GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, GMOCK_ARG_(tn, 5, \
+          __VA_ARGS__) gmock_a5, GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
+          GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7, GMOCK_ARG_(tn, 8, \
+          __VA_ARGS__) gmock_a8) constness { \
+    GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
+        tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
+            == 8), \
+        this_method_does_not_take_8_arguments); \
+    GMOCK_MOCKER_(8, constness, Method).SetOwnerAndName(this, #Method); \
+    return GMOCK_MOCKER_(8, constness, \
+        Method).Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, \
+        __VA_ARGS__)>(gmock_a1), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(gmock_a2), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(gmock_a3), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(gmock_a4), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 5, __VA_ARGS__)>(gmock_a5), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 6, __VA_ARGS__)>(gmock_a6), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 7, __VA_ARGS__)>(gmock_a7), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 8, __VA_ARGS__)>(gmock_a8)); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> \
+      gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
+                     GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2, \
+                     GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3, \
+                     GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4, \
+                     GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5, \
+                     GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6, \
+                     GMOCK_MATCHER_(tn, 7, __VA_ARGS__) gmock_a7, \
+                     GMOCK_MATCHER_(tn, 8, __VA_ARGS__) gmock_a8) constness { \
+    GMOCK_MOCKER_(8, constness, Method).RegisterOwner(this); \
+    return GMOCK_MOCKER_(8, constness, Method).With(gmock_a1, gmock_a2, \
+        gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> gmock_##Method( \
+      const ::testing::internal::WithoutMatchers&, \
+      constness ::testing::internal::Function<__VA_ARGS__>* ) const { \
+        return ::testing::internal::AdjustConstness_##constness(this)-> \
+            gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 5, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 6, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 7, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 8, __VA_ARGS__)>()); \
+      } \
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(8, constness, \
+      Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD9_(tn, constness, ct, Method, ...)                        \
-  GMOCK_RESULT_(tn, __VA_ARGS__)                                              \
-  ct Method(GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1,                          \
-            GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2,                          \
-            GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3,                          \
-            GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4,                          \
-            GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5,                          \
-            GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6,                          \
-            GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7,                          \
-            GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8,                          \
-            GMOCK_ARG_(tn, 9, __VA_ARGS__) gmock_a9) constness {              \
-    GTEST_COMPILE_ASSERT_(                                                    \
-        (::testing::tuple_size<tn ::testing::internal::Function<              \
-             __VA_ARGS__>::ArgumentTuple>::value == 9),                       \
-        this_method_does_not_take_9_arguments);                               \
-    GMOCK_MOCKER_(9, constness, Method).SetOwnerAndName(this, #Method);       \
-    return GMOCK_MOCKER_(9, constness, Method)                                \
-        .Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, __VA_ARGS__)>( \
-                    gmock_a1),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 2, __VA_ARGS__)>( \
-                    gmock_a2),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 3, __VA_ARGS__)>( \
-                    gmock_a3),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 4, __VA_ARGS__)>( \
-                    gmock_a4),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 5, __VA_ARGS__)>( \
-                    gmock_a5),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 6, __VA_ARGS__)>( \
-                    gmock_a6),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 7, __VA_ARGS__)>( \
-                    gmock_a7),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 8, __VA_ARGS__)>( \
-                    gmock_a8),                                                \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 9, __VA_ARGS__)>( \
-                    gmock_a9));                                               \
-  }                                                                           \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                            \
-      GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1,                            \
-      GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2,                            \
-      GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3,                            \
-      GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4,                            \
-      GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5,                            \
-      GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6,                            \
-      GMOCK_MATCHER_(tn, 7, __VA_ARGS__) gmock_a7,                            \
-      GMOCK_MATCHER_(tn, 8, __VA_ARGS__) gmock_a8,                            \
-      GMOCK_MATCHER_(tn, 9, __VA_ARGS__) gmock_a9) constness {                \
-    GMOCK_MOCKER_(9, constness, Method).RegisterOwner(this);                  \
-    return GMOCK_MOCKER_(9, constness, Method)                                \
-        .With(gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6,     \
-              gmock_a7, gmock_a8, gmock_a9);                                  \
-  }                                                                           \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                            \
-      const ::testing::internal::WithoutMatchers&,                            \
-      constness ::testing::internal::Function<__VA_ARGS__>*) const {          \
-    return ::testing::internal::AdjustConstness_##constness(this)             \
-        ->gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 5, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 6, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 7, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 8, __VA_ARGS__)>(),      \
-                         ::testing::A<GMOCK_ARG_(tn, 9, __VA_ARGS__)>());     \
-  }                                                                           \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(9, constness,  \
-                                                               Method)
+#define GMOCK_METHOD9_(tn, constness, ct, Method, ...) \
+  GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
+      GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, GMOCK_ARG_(tn, 2, \
+          __VA_ARGS__) gmock_a2, GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
+          GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, GMOCK_ARG_(tn, 5, \
+          __VA_ARGS__) gmock_a5, GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
+          GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7, GMOCK_ARG_(tn, 8, \
+          __VA_ARGS__) gmock_a8, GMOCK_ARG_(tn, 9, \
+          __VA_ARGS__) gmock_a9) constness { \
+    GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
+        tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
+            == 9), \
+        this_method_does_not_take_9_arguments); \
+    GMOCK_MOCKER_(9, constness, Method).SetOwnerAndName(this, #Method); \
+    return GMOCK_MOCKER_(9, constness, \
+        Method).Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, \
+        __VA_ARGS__)>(gmock_a1), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(gmock_a2), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(gmock_a3), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(gmock_a4), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 5, __VA_ARGS__)>(gmock_a5), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 6, __VA_ARGS__)>(gmock_a6), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 7, __VA_ARGS__)>(gmock_a7), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 8, __VA_ARGS__)>(gmock_a8), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 9, __VA_ARGS__)>(gmock_a9)); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> \
+      gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
+                     GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2, \
+                     GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3, \
+                     GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4, \
+                     GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5, \
+                     GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6, \
+                     GMOCK_MATCHER_(tn, 7, __VA_ARGS__) gmock_a7, \
+                     GMOCK_MATCHER_(tn, 8, __VA_ARGS__) gmock_a8, \
+                     GMOCK_MATCHER_(tn, 9, __VA_ARGS__) gmock_a9) constness { \
+    GMOCK_MOCKER_(9, constness, Method).RegisterOwner(this); \
+    return GMOCK_MOCKER_(9, constness, Method).With(gmock_a1, gmock_a2, \
+        gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, \
+        gmock_a9); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> gmock_##Method( \
+      const ::testing::internal::WithoutMatchers&, \
+      constness ::testing::internal::Function<__VA_ARGS__>* ) const { \
+        return ::testing::internal::AdjustConstness_##constness(this)-> \
+            gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 5, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 6, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 7, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 8, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 9, __VA_ARGS__)>()); \
+      } \
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(9, constness, \
+      Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD10_(tn, constness, ct, Method, ...)                        \
-  GMOCK_RESULT_(tn, __VA_ARGS__)                                               \
-  ct Method(GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1,                           \
-            GMOCK_ARG_(tn, 2, __VA_ARGS__) gmock_a2,                           \
-            GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3,                           \
-            GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4,                           \
-            GMOCK_ARG_(tn, 5, __VA_ARGS__) gmock_a5,                           \
-            GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6,                           \
-            GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7,                           \
-            GMOCK_ARG_(tn, 8, __VA_ARGS__) gmock_a8,                           \
-            GMOCK_ARG_(tn, 9, __VA_ARGS__) gmock_a9,                           \
-            GMOCK_ARG_(tn, 10, __VA_ARGS__) gmock_a10) constness {             \
-    GTEST_COMPILE_ASSERT_(                                                     \
-        (::testing::tuple_size<tn ::testing::internal::Function<               \
-             __VA_ARGS__>::ArgumentTuple>::value == 10),                       \
-        this_method_does_not_take_10_arguments);                               \
-    GMOCK_MOCKER_(10, constness, Method).SetOwnerAndName(this, #Method);       \
-    return GMOCK_MOCKER_(10, constness, Method)                                \
-        .Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, __VA_ARGS__)>(  \
-                    gmock_a1),                                                 \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(  \
-                    gmock_a2),                                                 \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(  \
-                    gmock_a3),                                                 \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(  \
-                    gmock_a4),                                                 \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 5, __VA_ARGS__)>(  \
-                    gmock_a5),                                                 \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 6, __VA_ARGS__)>(  \
-                    gmock_a6),                                                 \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 7, __VA_ARGS__)>(  \
-                    gmock_a7),                                                 \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 8, __VA_ARGS__)>(  \
-                    gmock_a8),                                                 \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 9, __VA_ARGS__)>(  \
-                    gmock_a9),                                                 \
-                ::testing::internal::forward<GMOCK_ARG_(tn, 10, __VA_ARGS__)>( \
-                    gmock_a10));                                               \
-  }                                                                            \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                             \
-      GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1,                             \
-      GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2,                             \
-      GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3,                             \
-      GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4,                             \
-      GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5,                             \
-      GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6,                             \
-      GMOCK_MATCHER_(tn, 7, __VA_ARGS__) gmock_a7,                             \
-      GMOCK_MATCHER_(tn, 8, __VA_ARGS__) gmock_a8,                             \
-      GMOCK_MATCHER_(tn, 9, __VA_ARGS__) gmock_a9,                             \
-      GMOCK_MATCHER_(tn, 10, __VA_ARGS__) gmock_a10) constness {               \
-    GMOCK_MOCKER_(10, constness, Method).RegisterOwner(this);                  \
-    return GMOCK_MOCKER_(10, constness, Method)                                \
-        .With(gmock_a1, gmock_a2, gmock_a3, gmock_a4, gmock_a5, gmock_a6,      \
-              gmock_a7, gmock_a8, gmock_a9, gmock_a10);                        \
-  }                                                                            \
-  ::testing::MockSpec<__VA_ARGS__> gmock_##Method(                             \
-      const ::testing::internal::WithoutMatchers&,                             \
-      constness ::testing::internal::Function<__VA_ARGS__>*) const {           \
-    return ::testing::internal::AdjustConstness_##constness(this)              \
-        ->gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>(),       \
-                         ::testing::A<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(),       \
-                         ::testing::A<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(),       \
-                         ::testing::A<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(),       \
-                         ::testing::A<GMOCK_ARG_(tn, 5, __VA_ARGS__)>(),       \
-                         ::testing::A<GMOCK_ARG_(tn, 6, __VA_ARGS__)>(),       \
-                         ::testing::A<GMOCK_ARG_(tn, 7, __VA_ARGS__)>(),       \
-                         ::testing::A<GMOCK_ARG_(tn, 8, __VA_ARGS__)>(),       \
-                         ::testing::A<GMOCK_ARG_(tn, 9, __VA_ARGS__)>(),       \
-                         ::testing::A<GMOCK_ARG_(tn, 10, __VA_ARGS__)>());     \
-  }                                                                            \
-  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(10, constness,  \
-                                                               Method)
+#define GMOCK_METHOD10_(tn, constness, ct, Method, ...) \
+  GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
+      GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, GMOCK_ARG_(tn, 2, \
+          __VA_ARGS__) gmock_a2, GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
+          GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, GMOCK_ARG_(tn, 5, \
+          __VA_ARGS__) gmock_a5, GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
+          GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7, GMOCK_ARG_(tn, 8, \
+          __VA_ARGS__) gmock_a8, GMOCK_ARG_(tn, 9, __VA_ARGS__) gmock_a9, \
+          GMOCK_ARG_(tn, 10, __VA_ARGS__) gmock_a10) constness { \
+    GTEST_COMPILE_ASSERT_((::testing::tuple_size<                          \
+        tn ::testing::internal::Function<__VA_ARGS__>::ArgumentTuple>::value \
+            == 10), \
+        this_method_does_not_take_10_arguments); \
+    GMOCK_MOCKER_(10, constness, Method).SetOwnerAndName(this, #Method); \
+    return GMOCK_MOCKER_(10, constness, \
+        Method).Invoke(::testing::internal::forward<GMOCK_ARG_(tn, 1, \
+        __VA_ARGS__)>(gmock_a1), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(gmock_a2), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(gmock_a3), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(gmock_a4), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 5, __VA_ARGS__)>(gmock_a5), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 6, __VA_ARGS__)>(gmock_a6), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 7, __VA_ARGS__)>(gmock_a7), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 8, __VA_ARGS__)>(gmock_a8), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 9, __VA_ARGS__)>(gmock_a9), \
+  ::testing::internal::forward<GMOCK_ARG_(tn, 10, __VA_ARGS__)>(gmock_a10)); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> \
+      gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
+                     GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2, \
+                     GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3, \
+                     GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4, \
+                     GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5, \
+                     GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6, \
+                     GMOCK_MATCHER_(tn, 7, __VA_ARGS__) gmock_a7, \
+                     GMOCK_MATCHER_(tn, 8, __VA_ARGS__) gmock_a8, \
+                     GMOCK_MATCHER_(tn, 9, __VA_ARGS__) gmock_a9, \
+                     GMOCK_MATCHER_(tn, 10, \
+                         __VA_ARGS__) gmock_a10) constness { \
+    GMOCK_MOCKER_(10, constness, Method).RegisterOwner(this); \
+    return GMOCK_MOCKER_(10, constness, Method).With(gmock_a1, gmock_a2, \
+        gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, \
+        gmock_a10); \
+  } \
+  ::testing::MockSpec<__VA_ARGS__> gmock_##Method( \
+      const ::testing::internal::WithoutMatchers&, \
+      constness ::testing::internal::Function<__VA_ARGS__>* ) const { \
+        return ::testing::internal::AdjustConstness_##constness(this)-> \
+            gmock_##Method(::testing::A<GMOCK_ARG_(tn, 1, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 2, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 3, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 4, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 5, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 6, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 7, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 8, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 9, __VA_ARGS__)>(), \
+                     ::testing::A<GMOCK_ARG_(tn, 10, __VA_ARGS__)>()); \
+      } \
+  mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(10, constness, \
+      Method)
 
 #define MOCK_METHOD0(m, ...) GMOCK_METHOD0_(, , , m, __VA_ARGS__)
 #define MOCK_METHOD1(m, ...) GMOCK_METHOD1_(, , , m, __VA_ARGS__)
@@ -1176,7 +1120,7 @@ class MockFunction<R(A0)> {
 #if GTEST_HAS_STD_FUNCTION_
   ::std::function<R(A0)> AsStdFunction() {
     return [this](A0 a0) -> R {
-      return this->Call(::std::move(a0));
+      return this->Call(::std::forward<A0>(a0));
     };
   }
 #endif  // GTEST_HAS_STD_FUNCTION_
@@ -1195,7 +1139,7 @@ class MockFunction<R(A0, A1)> {
 #if GTEST_HAS_STD_FUNCTION_
   ::std::function<R(A0, A1)> AsStdFunction() {
     return [this](A0 a0, A1 a1) -> R {
-      return this->Call(::std::move(a0), ::std::move(a1));
+      return this->Call(::std::forward<A0>(a0), ::std::forward<A1>(a1));
     };
   }
 #endif  // GTEST_HAS_STD_FUNCTION_
@@ -1214,7 +1158,8 @@ class MockFunction<R(A0, A1, A2)> {
 #if GTEST_HAS_STD_FUNCTION_
   ::std::function<R(A0, A1, A2)> AsStdFunction() {
     return [this](A0 a0, A1 a1, A2 a2) -> R {
-      return this->Call(::std::move(a0), ::std::move(a1), ::std::move(a2));
+      return this->Call(::std::forward<A0>(a0), ::std::forward<A1>(a1),
+          ::std::forward<A2>(a2));
     };
   }
 #endif  // GTEST_HAS_STD_FUNCTION_
@@ -1233,8 +1178,8 @@ class MockFunction<R(A0, A1, A2, A3)> {
 #if GTEST_HAS_STD_FUNCTION_
   ::std::function<R(A0, A1, A2, A3)> AsStdFunction() {
     return [this](A0 a0, A1 a1, A2 a2, A3 a3) -> R {
-      return this->Call(::std::move(a0), ::std::move(a1), ::std::move(a2),
-          ::std::move(a3));
+      return this->Call(::std::forward<A0>(a0), ::std::forward<A1>(a1),
+          ::std::forward<A2>(a2), ::std::forward<A3>(a3));
     };
   }
 #endif  // GTEST_HAS_STD_FUNCTION_
@@ -1254,8 +1199,9 @@ class MockFunction<R(A0, A1, A2, A3, A4)> {
 #if GTEST_HAS_STD_FUNCTION_
   ::std::function<R(A0, A1, A2, A3, A4)> AsStdFunction() {
     return [this](A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) -> R {
-      return this->Call(::std::move(a0), ::std::move(a1), ::std::move(a2),
-          ::std::move(a3), ::std::move(a4));
+      return this->Call(::std::forward<A0>(a0), ::std::forward<A1>(a1),
+          ::std::forward<A2>(a2), ::std::forward<A3>(a3),
+          ::std::forward<A4>(a4));
     };
   }
 #endif  // GTEST_HAS_STD_FUNCTION_
@@ -1275,8 +1221,9 @@ class MockFunction<R(A0, A1, A2, A3, A4, A5)> {
 #if GTEST_HAS_STD_FUNCTION_
   ::std::function<R(A0, A1, A2, A3, A4, A5)> AsStdFunction() {
     return [this](A0 a0, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5) -> R {
-      return this->Call(::std::move(a0), ::std::move(a1), ::std::move(a2),
-          ::std::move(a3), ::std::move(a4), ::std::move(a5));
+      return this->Call(::std::forward<A0>(a0), ::std::forward<A1>(a1),
+          ::std::forward<A2>(a2), ::std::forward<A3>(a3),
+          ::std::forward<A4>(a4), ::std::forward<A5>(a5));
     };
   }
 #endif  // GTEST_HAS_STD_FUNCTION_
@@ -1296,8 +1243,10 @@ class MockFunction<R(A0, A1, A2, A3, A4, A5, A6)> {
 #if GTEST_HAS_STD_FUNCTION_
   ::std::function<R(A0, A1, A2, A3, A4, A5, A6)> AsStdFunction() {
     return [this](A0 a0, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6) -> R {
-      return this->Call(::std::move(a0), ::std::move(a1), ::std::move(a2),
-          ::std::move(a3), ::std::move(a4), ::std::move(a5), ::std::move(a6));
+      return this->Call(::std::forward<A0>(a0), ::std::forward<A1>(a1),
+          ::std::forward<A2>(a2), ::std::forward<A3>(a3),
+          ::std::forward<A4>(a4), ::std::forward<A5>(a5),
+          ::std::forward<A6>(a6));
     };
   }
 #endif  // GTEST_HAS_STD_FUNCTION_
@@ -1317,9 +1266,10 @@ class MockFunction<R(A0, A1, A2, A3, A4, A5, A6, A7)> {
 #if GTEST_HAS_STD_FUNCTION_
   ::std::function<R(A0, A1, A2, A3, A4, A5, A6, A7)> AsStdFunction() {
     return [this](A0 a0, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7) -> R {
-      return this->Call(::std::move(a0), ::std::move(a1), ::std::move(a2),
-          ::std::move(a3), ::std::move(a4), ::std::move(a5), ::std::move(a6),
-          ::std::move(a7));
+      return this->Call(::std::forward<A0>(a0), ::std::forward<A1>(a1),
+          ::std::forward<A2>(a2), ::std::forward<A3>(a3),
+          ::std::forward<A4>(a4), ::std::forward<A5>(a5),
+          ::std::forward<A6>(a6), ::std::forward<A7>(a7));
     };
   }
 #endif  // GTEST_HAS_STD_FUNCTION_
@@ -1340,9 +1290,11 @@ class MockFunction<R(A0, A1, A2, A3, A4, A5, A6, A7, A8)> {
   ::std::function<R(A0, A1, A2, A3, A4, A5, A6, A7, A8)> AsStdFunction() {
     return [this](A0 a0, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7,
         A8 a8) -> R {
-      return this->Call(::std::move(a0), ::std::move(a1), ::std::move(a2),
-          ::std::move(a3), ::std::move(a4), ::std::move(a5), ::std::move(a6),
-          ::std::move(a7), ::std::move(a8));
+      return this->Call(::std::forward<A0>(a0), ::std::forward<A1>(a1),
+          ::std::forward<A2>(a2), ::std::forward<A3>(a3),
+          ::std::forward<A4>(a4), ::std::forward<A5>(a5),
+          ::std::forward<A6>(a6), ::std::forward<A7>(a7),
+          ::std::forward<A8>(a8));
     };
   }
 #endif  // GTEST_HAS_STD_FUNCTION_
@@ -1364,9 +1316,11 @@ class MockFunction<R(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9)> {
   ::std::function<R(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9)> AsStdFunction() {
     return [this](A0 a0, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7,
         A8 a8, A9 a9) -> R {
-      return this->Call(::std::move(a0), ::std::move(a1), ::std::move(a2),
-          ::std::move(a3), ::std::move(a4), ::std::move(a5), ::std::move(a6),
-          ::std::move(a7), ::std::move(a8), ::std::move(a9));
+      return this->Call(::std::forward<A0>(a0), ::std::forward<A1>(a1),
+          ::std::forward<A2>(a2), ::std::forward<A3>(a3),
+          ::std::forward<A4>(a4), ::std::forward<A5>(a5),
+          ::std::forward<A6>(a6), ::std::forward<A7>(a7),
+          ::std::forward<A8>(a8), ::std::forward<A9>(a9));
     };
   }
 #endif  // GTEST_HAS_STD_FUNCTION_

--- a/googlemock/include/gmock/gmock-generated-function-mockers.h.pump
+++ b/googlemock/include/gmock/gmock-generated-function-mockers.h.pump
@@ -320,7 +320,7 @@ class MockFunction;
 $for i [[
 $range j 0..i-1
 $var ArgTypes = [[$for j, [[A$j]]]]
-$var ArgValues = [[$for j, [[::std::move(a$j)]]]]
+$var ArgValues = [[$for j, [[::std::forward<A$j>(a$j)]]]]
 $var ArgDecls = [[$for j, [[A$j a$j]]]]
 template <typename R$for j [[, typename A$j]]>
 class MockFunction<R($ArgTypes)> {

--- a/googlemock/test/gmock-generated-function-mockers_test.cc
+++ b/googlemock/test/gmock-generated-function-mockers_test.cc
@@ -608,6 +608,16 @@ TEST(MockFunctionTest, AsStdFunction) {
   EXPECT_EQ(-2, call(foo.AsStdFunction(), 2));
 }
 
+TEST(MockFunctionTest, AsStdFunctionWithReferenceParameter) {
+  MockFunction<int(int &)> foo;
+  auto call = [](const std::function<void(int)> &f, int &i) {
+    return f(i);
+  };
+  int i = 1;
+  EXPECT_CALL(foo, Call(i).WillOnce(Return(-1));
+  EXPECT_EQ(-1, call(foo.AsStdFunction(), i));
+}
+
 TEST(MockFunctionTest, AsStdFunctionReturnsReference) {
   MockFunction<int&()> foo;
   int value = 1;


### PR DESCRIPTION
If you use std::move you get an compile error for MockFunction<void(Foo&)>.