### PR TITLE
Revert "Add C++11 standard in the root CMakeLists.txt"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ endif (POLICY CMP0048)
 
 project(googletest-distribution)
 set(GOOGLETEST_VERSION 1.9.0)
-set(CMAKE_CXX_STANDARD 11 CACHE STRING "Set the C++ standard to be used for compiling")
 
 enable_testing()
 


### PR DESCRIPTION
Reverts google/googletest#1872, broke some users