### PR TITLE
Relocatable pkgconfig fix

### DIFF
--- a/googlemock/cmake/gmock.pc.in
+++ b/googlemock/cmake/gmock.pc.in
@@ -1,5 +1,6 @@
-libdir=@CMAKE_INSTALL_FULL_LIBDIR@
-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+prefix=${pcfiledir}/../..
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: gmock
 Description: GoogleMock (without main() function)

--- a/googlemock/cmake/gmock_main.pc.in
+++ b/googlemock/cmake/gmock_main.pc.in
@@ -1,5 +1,6 @@
-libdir=@CMAKE_INSTALL_FULL_LIBDIR@
-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+prefix=${pcfiledir}/../..
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: gmock_main
 Description: GoogleMock (with main() function)

--- a/googletest/cmake/gtest.pc.in
+++ b/googletest/cmake/gtest.pc.in
@@ -1,5 +1,6 @@
-libdir=@CMAKE_INSTALL_FULL_LIBDIR@
-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+prefix=${pcfiledir}/../..
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: gtest
 Description: GoogleTest (without main() function)

--- a/googletest/cmake/gtest_main.pc.in
+++ b/googletest/cmake/gtest_main.pc.in
@@ -1,5 +1,6 @@
-libdir=@CMAKE_INSTALL_FULL_LIBDIR@
-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+prefix=${pcfiledir}/../..
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: gtest_main
 Description: GoogleTest (with main() function)


### PR DESCRIPTION
Using absolute paths in the pkg-config file makes it not relocatable and
leads to problems, when trying to use it with precompiled cross
toolchains. Setting prefix to relative path based on pcfiledir makes it
more reliable for such cases.