### PR TITLE
add documentation of manual c++11 specification

### DIFF
--- a/googletest/README.md
+++ b/googletest/README.md
@@ -192,6 +192,15 @@ Google Test already has a CMake option for this: `gtest_force_shared_crt`
 Enabling this option will make gtest link the runtimes dynamically too, and
 match the project in which it is included.
 
+#### C++ Standard Version
+
+An environment that supports C++11 is required in order to successfully build
+Google Test. One way to ensure this is to specify the standard in the top-level
+project, for example by using the `set(CMAKE_CXX_STANDARD 11)` command. If this
+is not feasible, for example in a C project using Google Test for validation,
+then it can be specified by adding it to the options for cmake via the
+`DCMAKE_CXX_FLAGS` option.
+
 ### Legacy Build Scripts
 
 Before settling on CMake, we have been providing hand-maintained build


### PR DESCRIPTION
Per #1883, builds of Google Test may fail if the version C++ is not manually
set to C++11 during the build process.