### PR TITLE
Add ASSERT_THROW_MATCH to examine the thrown exception

### DIFF
--- a/googlemock/include/gmock/gmock-gtest-fusion.h
+++ b/googlemock/include/gmock/gmock-gtest-fusion.h
@@ -1,0 +1,89 @@
+// Copyright 2007, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Google Mock - a framework for writing C++ mock classes.
+//
+// This file implements some things that extend gtest but require gmock
+
+// GOOGLETEST_CM0002 DO NOT DELETE
+
+#ifndef GMOCK_INCLUDE_GMOCK_GMOCK_GTEST_FUSION_H_
+#define GMOCK_INCLUDE_GMOCK_GMOCK_GTEST_FUSION_H_
+
+#include "gmock/gmock-matchers.h"
+#include "gtest/gtest.h"
+#include <sstream>
+
+#define GTEST_TEST_THROW_MATCH_(statement, expected_exception, matcher, fail) \
+  GTEST_AMBIGUOUS_ELSE_BLOCKER_                                               \
+  if (::testing::internal::AdditionalMessage gtest_msg = "") {                \
+    bool gtest_caught_expected = false;                                       \
+    try {                                                                     \
+      GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement);              \
+    } catch (expected_exception const& e) {                                   \
+      const auto matcherImpl = SafeMatcherCast<expected_exception>(matcher);  \
+      ::testing::StringMatchResultListener listener;                          \
+      std::stringstream b;                                                    \
+      matcherImpl.DescribeTo(&b);                                             \
+      if (!matcherImpl.MatchAndExplain(e, &listener)) {                       \
+        gtest_msg.set(                                                        \
+            "Expected: " #statement " throws an exception of "                \
+            "type " #expected_exception " which " +                           \
+            b.str() + ".\n  Actual: it throws " #expected_exception);         \
+        if (!listener.str().empty())                                          \
+          gtest_msg.append(" " + listener.str());                             \
+        gtest_msg.append(".");                                                \
+        goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__);           \
+      }                                                                       \
+      gtest_caught_expected = true;                                           \
+    } catch (...) {                                                           \
+      gtest_msg.set("Expected: " #statement                                   \
+                    " throws an exception of type " #expected_exception       \
+                    ".\n  Actual: it throws a different type.");              \
+      goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__);             \
+    }                                                                         \
+    if (!gtest_caught_expected) {                                             \
+      gtest_msg.set("Expected: " #statement                                   \
+                    " throws an exception of type " #expected_exception       \
+                    ".\n  Actual: it throws nothing.");                       \
+      goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__);             \
+    }                                                                         \
+  } else                                                                      \
+    GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__)                     \
+        : fail(gtest_msg.get().c_str())
+
+#define EXPECT_THROW_MATCH(statement, expected_exception, matcher) \
+  GTEST_TEST_THROW_MATCH_(statement, expected_exception, matcher,  \
+                          GTEST_NONFATAL_FAILURE_)
+#define ASSERT_THROW_MATCH(statement, expected_exception, matcher) \
+  GTEST_TEST_THROW_MATCH_(statement, expected_exception, matcher,  \
+                          GTEST_FATAL_FAILURE_)
+
+
+#endif  // GMOCK_INCLUDE_GMOCK_GMOCK_GTEST_FUSION_H_

--- a/googlemock/include/gmock/gmock.h
+++ b/googlemock/include/gmock/gmock.h
@@ -66,6 +66,7 @@
 #include "gmock/gmock-more-actions.h"
 #include "gmock/gmock-more-matchers.h"
 #include "gmock/internal/gmock-internal-utils.h"
+#include "gmock/gmock-gtest-fusion.h"
 
 namespace testing {
 

--- a/googlemock/test/gmock-gtest-fusion_test.cc
+++ b/googlemock/test/gmock-gtest-fusion_test.cc
@@ -1,0 +1,101 @@
+// Copyright 2007, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Google Mock - a framework for writing C++ mock classes.
+//
+// This file tests the built-in actions.
+
+// Silence C4800 (C4800: 'int *const ': forcing value
+// to bool 'true' or 'false') for MSVC 14,15
+#ifdef _MSC_VER
+#if _MSC_VER <= 1900
+#pragma warning(push)
+#pragma warning(disable : 4800)
+#endif
+#endif
+
+#include "gmock/gmock-gtest-fusion.h"
+#include <stdexcept>
+#include "gtest/gtest.h"
+#include "gtest/gtest-spi.h"
+
+namespace {
+
+class CustomException
+{
+public:
+  int Member;
+  CustomException(int member) : Member(member) {}
+};
+void ThrowAnInteger() { throw 42; }
+void ThrowAChar() { throw 'h'; }
+void ThrowNothing() {}
+void ThrowException(int member) {
+  throw CustomException(member);
+}
+
+using namespace ::testing;
+
+// Tests ASSERT_THROW.
+TEST(AssertionTest, ASSERT_THROW_MATCH) {
+  ASSERT_THROW_MATCH(ThrowAnInteger(), int, Ge(0));
+
+  EXPECT_FATAL_FAILURE(
+      ASSERT_THROW_MATCH(ThrowAChar(), int, Ge(0)),
+      "Expected: ThrowAChar() throws an exception of type int.\n"
+      "  Actual: it throws a different type.");
+  
+  EXPECT_FATAL_FAILURE(
+      ASSERT_THROW_MATCH(ThrowNothing(), int, Ge(0)),
+      "Expected: ThrowNothing() throws an exception of type int.\n"
+      "  Actual: it throws nothing.");
+
+  EXPECT_FATAL_FAILURE(
+      ASSERT_THROW_MATCH(ThrowAnInteger(), int, Lt(20)),
+      "Expected: ThrowAnInteger() throws an exception"
+      " of type int which is < 20.\n"
+      "  Actual: it throws int.");
+
+  EXPECT_FATAL_FAILURE(
+      ASSERT_THROW_MATCH(ThrowException(1336), CustomException,
+          Field("Member", &CustomException::Member, Eq(1337))),
+      "Expected: ThrowException(1336) throws an exception of type "
+      "CustomException which is an object whose "
+      "field `Member` is equal to 1337.\n"
+      "  Actual: it throws CustomException whose "
+      "field `Member` is 1336 (of type int).");
+}
+
+}  // Unnamed namespace
+
+#ifdef _MSC_VER
+#if _MSC_VER == 1900
+#pragma warning(pop)
+#endif
+#endif

--- a/googlemock/test/gmock_all_test.cc
+++ b/googlemock/test/gmock_all_test.cc
@@ -47,4 +47,5 @@
 #include "test/gmock-nice-strict_test.cc"
 #include "test/gmock-port_test.cc"
 #include "test/gmock-spec-builders_test.cc"
+#include "test/gmock-gtest-fusion_test.cc"
 #include "test/gmock_test.cc"

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -779,6 +779,16 @@ struct GTEST_API_ ConstCharPtr {
   operator bool() const { return true; }
   const char* value;
 };
+class AdditionalMessage {
+ public:
+  AdditionalMessage(const char* message) : msg(message) {}
+  void set(const std::string& message) { msg = message; }
+  void append(const std::string& message) { msg += message; }
+  operator bool() const { return true; }
+  const std::string& get() const { return msg; }
+ private:
+  std::string msg;
+};
 
 // A simple Linear Congruential Generator for generating random
 // numbers with a uniform distribution.  Unlike rand() and srand(), it


### PR DESCRIPTION
The most tests I write are to check the error handling which usually involes throwing exceptions. All I currently can do with gtest is checking **whether** an exception of a specified type is thrown. But what I want to do is also testing whether this exception matches my criteria (message, member, ...).

Example:

    struct CustomException {
        int Member;
        CustomException(int member) : Member(member) {}
    };
    void ThrowException(int member) { throw CustomException(member); }
    
    ASSERT_THROW(ThrowException(1337), CustomException); // is the exception thrown? --> yes.
    // but does it also have the Member == 1337?

This is why I want to add an `ASSERT_THROW_MATCH` macro which applies the gmock matchers onto the catched exception to achieve this.

      ASSERT_THROW_MATCH(ThrowException(1337), CustomException,
          Field("Member", &CustomException::Member, Eq(1337))),

I don't like the naming but couldn't come up with something better. We can also move the code to other files, but I didn't what to put it into `gtest-matchers.h` like the ASSERT_THAT things (because it is no matcher). As soon as you say you like it I can also write something in the docs.