### PR TITLE
Updating Sample Makefile to Specify C++11

### DIFF
--- a/googletest/make/Makefile
+++ b/googletest/make/Makefile
@@ -25,7 +25,7 @@ USER_DIR = ../samples
 CPPFLAGS += -isystem $(GTEST_DIR)/include
 
 # Flags passed to the C++ compiler.
-CXXFLAGS += -g -Wall -Wextra -pthread
+CXXFLAGS += -g -Wall -Wextra -pthread -std=c++11
 
 # All tests produced by this Makefile.  Remember to add new tests you
 # created to the list.


### PR DESCRIPTION
Added a line to the sample Makefile in googletest/googletest/make to specify the use of C++11 in CXXFLAGS as required by googletest. This flag is required on some systems to make sure C++11 is used and it should be automatically included in the sample Makefile in order for it to run out of the box.