### PR TITLE
Remove `-Werror` from the build flags if built as a dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,23 +25,23 @@ matrix:
       compiler: gcc
       install: ./ci/install-linux.sh && ./ci/log-config.sh
       script: ./ci/build-linux-autotools.sh
-      env: VERBOSE=1 CXXFLAGS=-std=c++11
+      env: VERBOSE=1 CXXFLAGS="-Werror -std=c++11"
     - os: linux
       group: deprecated-2017Q4
       compiler: gcc
-      env: BUILD_TYPE=Debug VERBOSE=1 CXX_FLAGS=-std=c++11
+      env: BUILD_TYPE=Debug VERBOSE=1 CXXFLAGS="-Werror -std=c++11"
     - os: linux
       group: deprecated-2017Q4
       compiler: clang
-      env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11
+      env: BUILD_TYPE=Release VERBOSE=1 CXXFLAGS="-Werror -std=c++11"
     - os: linux
       compiler: clang
-      env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11 NO_EXCEPTION=ON NO_RTTI=ON COMPILER_IS_GNUCXX=ON
+      env: BUILD_TYPE=Release VERBOSE=1 CXXFLAGS="-Werror -std=c++11" NO_EXCEPTION=ON NO_RTTI=ON COMPILER_IS_GNUCXX=ON
     - os: osx
       compiler: gcc
-      env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11
+      env: BUILD_TYPE=Release VERBOSE=1 CXXFLAGS="-Werror -std=c++11"
     - os: osx
-      env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11
+      env: BUILD_TYPE=Release VERBOSE=1 CXXFLAGS="-Werror -std=c++11"
       if: type != pull_request
 
 # These are the install and build (script) phases for the most common entries in the matrix.  They could be included

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -37,7 +37,6 @@ cmake -Dgtest_build_samples=ON \
       -Dcxx_no_exception=$NO_EXCEPTION \
       -Dcxx_no_rtti=$NO_RTTI \
       -DCMAKE_COMPILER_IS_GNUCXX=$COMPILER_IS_GNUCXX \
-      -DCMAKE_CXX_FLAGS=$CXX_FLAGS \
       -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
       ..
 make

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -67,7 +67,7 @@ macro(config_compiler_and_linker)
   if (MSVC)
     # Newlines inside flags variables break CMake's NMake generator.
     # TODO(vladl@google.com): Add -RTCs and -RTCu to debug builds.
-    set(cxx_base_flags "-GS -W4 -WX -wd4251 -wd4275 -nologo -J -Zi")
+    set(cxx_base_flags "-GS -W4 -wd4251 -wd4275 -nologo -J -Zi")
     if (MSVC_VERSION LESS 1400)  # 1400 is Visual Studio 2005
       # Suppress spurious warnings MSVC 7.1 sometimes issues.
       # Forcing value to bool.
@@ -99,7 +99,7 @@ macro(config_compiler_and_linker)
     set(cxx_no_exception_flags "-EHs-c- -D_HAS_EXCEPTIONS=0")
     set(cxx_no_rtti_flags "-GR-")
   elseif (CMAKE_COMPILER_IS_GNUCXX)
-    set(cxx_base_flags "-Wall -Wshadow -Werror")
+    set(cxx_base_flags "-Wall -Wshadow")
     if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0.0)
       set(cxx_base_flags "${cxx_base_flags} -Wno-error=dangling-else")
     endif()


### PR DESCRIPTION
This makes GoogleTest more future-proof against new compilers that might
introduce new warnings, causing dependent projects to fail their build.

Fixes #1943.