### PR TITLE
Disable C4702: unreachable code in GTEST_SKIP test

### DIFF
--- a/googletest/test/gtest_skip_test.cc
+++ b/googletest/test/gtest_skip_test.cc
@@ -34,6 +34,13 @@
 
 using ::testing::Test;
 
+// This entire test is based on making code unreachable, so disabling
+// C4702: unreachable code is fine here.
+#ifdef _MSC_VER
+# pragma warning(push)
+# pragma warning(disable:4702)
+#endif
+
 TEST(SkipTest, DoesSkip) {
   GTEST_SKIP();
   EXPECT_EQ(0, 1);
@@ -53,3 +60,7 @@ TEST_F(Fixture, SkipsOneTest) {
 TEST_F(Fixture, SkipsAnotherTest) {
   EXPECT_EQ(99, 100);
 }
+
+#ifdef _MSC_VER
+# pragma warning(pop)
+#endif


### PR DESCRIPTION
EDIT: Never mind. I accidentally removed a warning suppression in the other PR. I didn't realise that you had globally suppressed the unreachable code warning.

~~When opening #1959 I noticed that the AppVeyor CI system fails with the following output even without my changes:~~

```
Build FAILED.
       "C:\projects\googletest\_build\ALL_BUILD.vcxproj" (default target) (1) ->
       "C:\projects\googletest\_build\googlemock\gtest\gtest_dll_test_.vcxproj" (default target) (55) ->
       (ClCompile target) -> 
         c:\projects\googletest\googletest\test\gtest_skip_test.cc(39): warning C4702: unreachable code [C:\projects\googletest\_build\googlemock\gtest\gtest_dll_test_.vcxproj]
       "C:\projects\googletest\_build\ALL_BUILD.vcxproj" (default target) (1) ->
       "C:\projects\googletest\_build\googlemock\gtest\gtest_skip_test.vcxproj" (default target) (66) ->
         c:\projects\googletest\googletest\test\gtest_skip_test.cc(39): warning C4702: unreachable code [C:\projects\googletest\_build\googlemock\gtest\gtest_skip_test.vcxproj]
       "C:\projects\googletest\_build\ALL_BUILD.vcxproj" (default target) (1) ->
       "C:\projects\googletest\_build\googlemock\gtest\gtest_dll_test_.vcxproj" (default target) (55) ->
       (ClCompile target) -> 
         c:\projects\googletest\googletest\test\gtest_skip_test.cc(39): error C2220: warning treated as error - no 'object' file generated [C:\projects\googletest\_build\googlemock\gtest\gtest_dll_test_.vcxproj]
       "C:\projects\googletest\_build\ALL_BUILD.vcxproj" (default target) (1) ->
       "C:\projects\googletest\_build\googlemock\gtest\gtest_skip_test.vcxproj" (default target) (66) ->
         c:\projects\googletest\googletest\test\gtest_skip_test.cc(39): error C2220: warning treated as error - no 'object' file generated [C:\projects\googletest\_build\googlemock\gtest\gtest_skip_test.vcxproj]
    2 Warning(s)
    2 Error(s)
```
~~For the full output, see e.g. https://ci.appveyor.com/project/GoogleTestAppVeyor/googletest/builds/20196951/job/4tm45pusbkjk7qvw and https://ci.appveyor.com/project/GoogleTestAppVeyor/googletest/builds/20196951/job/eo7v6wn3rv8g70pd~~

~~The GTEST_SKIP macro and the test with the warning were both added in #1544.~~

~~This PR should hopefully have your CI system passing by default again so it's nice and easy to see if a PR breaks things.~~