### PR TITLE
Issue #1659: Add Support for PlatformIO and Arduino

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       dist: trusty
       sudo: required
       group: deprecated-2017Q3
+      before_install: chmod -R +x ./ci/*platformio.sh 
       install: ./ci/install-platformio.sh
       script: ./ci/build-platformio.sh      
     - os: linux
@@ -49,9 +50,6 @@ matrix:
     - os: osx
       env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11
       if: type != pull_request
-
-before_install:
-    - chmod -R +x ./ci/*.sh 
 
 # These are the install and build (script) phases for the most common entries in the matrix.  They could be included
 # in each entry in the matrix, but that is just repetitive.

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ language: cpp
 matrix:
   include:
     - os: linux
+      dist: trusty
+      sudo: required
+      group: deprecated-2017Q3
+      install: ./ci/install-platformio.sh
+      script: ./ci/build-platformio.sh      
+    - os: linux
       compiler: gcc
       sudo : true
       install: ./ci/install-linux.sh && ./ci/log-config.sh
@@ -43,6 +49,9 @@ matrix:
     - os: osx
       env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11
       if: type != pull_request
+
+before_install:
+    - chmod -R +x ./ci/*.sh 
 
 # These are the install and build (script) phases for the most common entries in the matrix.  They could be included
 # in each entry in the matrix, but that is just repetitive.

--- a/ci/build-platformio.sh
+++ b/ci/build-platformio.sh
@@ -1,0 +1,2 @@
+# run PlatformIO builds
+platformio run

--- a/ci/install-platformio.sh
+++ b/ci/install-platformio.sh
@@ -1,0 +1,5 @@
+# install PlatformIO
+sudo pip install -U platformio
+
+# update PlatformIO
+platformio update

--- a/googlemock/src/gmock_main.cc
+++ b/googlemock/src/gmock_main.cc
@@ -34,8 +34,12 @@
 
 #ifdef ARDUINO
 void setup() {
-  int argc = 0;
-  char** argv = nullptr;
+  // Since Arduino doesn't have a command line, fake out the argc/argv arguments
+  int argc = 1;
+  const auto arg0 = "PlatformIO";
+  char* argv0 = const_cast<char*>(arg0);
+  char** argv = &argv0;
+  
    // Since Google Mock depends on Google Test, InitGoogleMock() is
   // also responsible for initializing Google Test.  Therefore there's
   // no need for calling testing::InitGoogleTest() separately.

--- a/googlemock/src/gmock_main.cc
+++ b/googlemock/src/gmock_main.cc
@@ -32,6 +32,20 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#ifdef ARDUINO
+void setup() {
+  int argc = 0;
+  char** argv = nullptr;
+   // Since Google Mock depends on Google Test, InitGoogleMock() is
+  // also responsible for initializing Google Test.  Therefore there's
+  // no need for calling testing::InitGoogleTest() separately.
+  testing::InitGoogleMock(&argc, argv);
+}
+void loop() {
+  RUN_ALL_TESTS();
+}
+#else
+
 // MS C++ compiler/linker has a bug on Windows (not on Windows CE), which
 // causes a link error when _tmain is defined in a static library and UNICODE
 // is enabled. For this reason instead of _tmain, main function is used on
@@ -52,3 +66,5 @@ GTEST_API_ int main(int argc, char** argv) {
   testing::InitGoogleMock(&argc, argv);
   return RUN_ALL_TESTS();
 }
+#endif
+  

--- a/googletest/src/gtest_main.cc
+++ b/googletest/src/gtest_main.cc
@@ -32,8 +32,12 @@
 
 #ifdef ARDUINO
 void setup() {
-  int argc = 0;
-  char** argv = nullptr;
+  // Since Arduino doesn't have a command line, fake out the argc/argv arguments
+  int argc = 1;
+  const auto arg0 = "PlatformIO";
+  char* argv0 = const_cast<char*>(arg0);
+  char** argv = &argv0;
+  
   testing::InitGoogleTest(&argc, argv);
 }
 

--- a/googletest/src/gtest_main.cc
+++ b/googletest/src/gtest_main.cc
@@ -30,8 +30,22 @@
 #include <stdio.h>
 #include "gtest/gtest.h"
 
+#ifdef ARDUINO
+void setup() {
+  int argc = 0;
+  char** argv = nullptr;
+  testing::InitGoogleTest(&argc, argv);
+}
+
+void loop() {
+  RUN_ALL_TESTS();
+}
+
+#else
+
 GTEST_API_ int main(int argc, char **argv) {
   printf("Running main() from %s\n", __FILE__);
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
+#endif

--- a/library.json
+++ b/library.json
@@ -1,0 +1,51 @@
+{
+  "name": "googletest",
+  "keywords": "unittest, unit, test, gtest, gmock",
+  "description": "googletest is a testing framework developed by the Testing Technology team with Google's specific requirements and constraints in mind. No matter whether you work on Linux, Windows, or a Mac, if you write C++ code, googletest can help you. And it supports any kind of tests, not just unit tests.",
+   "license": "BSD-3-Clause",
+  "homepage": "https://github.com/abseil/googletest/blob/master/README.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/abseil/googletest.git"
+  },
+  "version": "0.0.1",
+  "exclude": [
+    "ci",
+    "googlemock/build-aux",
+    "googlemock/cmake",
+    "googlemock/make",
+    "googlemock/msvc",
+    "googlemock/scripts",
+    "googlemock/test",
+    "googlemock/CMakeLists.txt",
+    "googlemock/Makefile.am",
+    "googlemock/configure.ac",
+    "googletest/cmake",
+    "googletest/codegear",
+    "googletest/m4",
+    "googletest/make",
+    "googletest/msvc",
+    "googletest/scripts",
+    "googletest/test",
+    "googletest/xcode",
+    "googletest/CMakeLists.txt",
+    "googletest/Makefile.am",
+    "googletest/configure.ac",
+  ],
+  "frameworks": "arduino",
+  "platforms": [
+        "espressif32"
+    ],
+    "export": {
+        "include": [
+            "googlemock/include/*",
+            "googletest/include/*"
+        ]
+    },
+    "build": {
+        "flags": [
+            "-I googlemock/include",
+            "-I googletest/include"
+        ]
+    }
+}

--- a/library.json
+++ b/library.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/abseil/googletest.git"
   },
-  "version": "0.0.1",
+  "version": "1.8.1",
   "exclude": [
     "ci",
     "googlemock/build-aux",

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,31 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+
+[platformio]
+#src_dir = ./googlemock
+#src_dir = ./googletest
+src_dir = .
+
+[env:googletest_esp32]
+platform = espressif32
+board = esp32dev
+framework = arduino
+build_flags = -I./googletest/include -I./googletest
+src_filter = +<*> -<.git/> -<googlemock> -<googletest/codegear/> -<googletest/samples> -<googletest/test/> -<googletest/xcode> -<googletest/src> +<googletest/src/gtest-all.cc> +<googletest/src/gtest_main.cc>
+upload_speed = 921600
+
+[env:googlemock_esp32]
+platform = espressif32
+board = esp32dev
+framework = arduino
+build_flags = -I./googlemock/include -I./googletest/include -I./googletest -I./googlemock
+src_filter = +<*> -<.git/> -<googletest> -<googlemock/test/> -<googlemock/src> +<googlemock/src/gmock-all.cc> +<googlemock/src/gmock_main.cc> +<googletest/src/gtest-all.cc>
+upload_speed = 921600


### PR DESCRIPTION
This is an initial effort to add PlatformIO/Arduino support to GTest and GMock.

This PR is not meant to be a final version, just the starting point to the discussion to gain feedback.

Is this general approach sound and what changes would you like to see?

I would like to target ESP8266 and ESP32 boards initially.

This would ultimately also be registered in the PIO Library Manager.

Fixes #1659 

Thank you.