### PR TITLE
Issue #1614: Fix IsRecursiveContainer implementation to avoid infinite recursion

### DIFF
--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -983,7 +983,9 @@ struct IsRecursiveContainerImpl<C, true> {
   typedef decltype(*std::declval<typename C::const_iterator>())
       value_type;
   typedef is_same<
-    typename remove_constref<value_type>::type,
+    typename std::remove_const<
+      typename std::remove_reference<value_type>::type
+    >::type,
     C
   > type;
 };

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -2127,6 +2127,32 @@ struct IteratorTraits<const T*> {
   typedef T value_type;
 };
 
+// remove const and reference qualifier
+template <typename T>
+struct remove_constref {
+  typedef T type;
+};
+template <typename T>
+struct remove_constref<T&> {
+  typedef T type;
+};
+template <typename T>
+struct remove_constref<T&&> {
+  typedef T type;
+};
+template <typename T>
+struct remove_constref<const T> {
+  typedef T type;
+};
+template <typename T>
+struct remove_constref<const T&> {
+  typedef T type;
+};
+template <typename T>
+struct remove_constref<const T&&> {
+  typedef T type;
+};
+
 #if GTEST_OS_WINDOWS
 # define GTEST_PATH_SEP_ "\\"
 # define GTEST_HAS_ALT_PATH_SEP_ 1

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -2127,32 +2127,6 @@ struct IteratorTraits<const T*> {
   typedef T value_type;
 };
 
-// remove const and reference qualifier
-template <typename T>
-struct remove_constref {
-  typedef T type;
-};
-template <typename T>
-struct remove_constref<T&> {
-  typedef T type;
-};
-template <typename T>
-struct remove_constref<T&&> {
-  typedef T type;
-};
-template <typename T>
-struct remove_constref<const T> {
-  typedef T type;
-};
-template <typename T>
-struct remove_constref<const T&> {
-  typedef T type;
-};
-template <typename T>
-struct remove_constref<const T&&> {
-  typedef T type;
-};
-
 #if GTEST_OS_WINDOWS
 # define GTEST_PATH_SEP_ "\\"
 # define GTEST_HAS_ALT_PATH_SEP_ 1

--- a/googletest/test/googletest-printers-test.cc
+++ b/googletest/test/googletest-printers-test.cc
@@ -192,7 +192,13 @@ class PathLike {
  public:
   struct iterator {
     typedef PathLike value_type;
+
+    iterator& operator++();
+    PathLike& operator*();
   };
+
+  typedef char value_type;
+  typedef iterator const_iterator;
 
   PathLike() {}
 


### PR DESCRIPTION
Bug fix of #1614

[As ixSci mentioned](https://github.com/abseil/googletest/issues/1614#issuecomment-395414407), `HasValueType::value` will be always false and does not make any sense. Also the condition when `IsRecursiveContainer::value` will be true does not exactly match the condition when infinite recursion will be caused. infinite loop is still caused when the `const_iterator` object does not have `value_type` type or `value_type` is cv-qualified (because the result of is_same will be false).

Here is the exact condition when the infinite loop will be caused.

```cpp
// C: template argument of IsRecursiveContainer

is_same_v<remove_const_t<remove_reference_t<*(C::const_iterator())>>, C> == true
```

I changed the `IsRecursiveContainer` implementation so that infinite recursion will not be caused along `PrintTo` function. Also I updated the test to simulate `std::filesystem::path` and `boost::filesystem::path` object more accurately.

This fix eliminated the segfault on gcc 8.2.0 and Clang 6.0.1 (libstdc++) on Ubuntu 18.10.