### PR TITLE
Correct library.json syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ bazel-testlogs
 *.pyc
 
 # Visual Studio files
+.vs
 *.sdf
 *.opensdf
 *.VC.opendb

--- a/library.json
+++ b/library.json
@@ -30,7 +30,7 @@
     "googletest/xcode",
     "googletest/CMakeLists.txt",
     "googletest/Makefile.am",
-    "googletest/configure.ac",
+    "googletest/configure.ac"
   ],
   "frameworks": "arduino",
   "platforms": [


### PR DESCRIPTION
There was a trailing comma in the library.json file that was causing it to be malformed.
 
I also added .vs directory to .gitignore to ignore Visual Studio working files.