### PR TITLE
Fix FreeBSD -Werror compilation issues

### DIFF
--- a/googlemock/test/gmock-actions_test.cc
+++ b/googlemock/test/gmock-actions_test.cc
@@ -902,7 +902,7 @@ class NullaryFunctor {
   int operator()() { return 2; }
 };
 
-bool g_done = false;
+static bool g_done = false;
 void VoidNullary() { g_done = true; }
 
 class VoidNullaryFunctor {

--- a/googlemock/test/gmock-generated-actions_test.cc
+++ b/googlemock/test/gmock-generated-actions_test.cc
@@ -65,8 +65,6 @@ inline char Char(char ch) { return ch; }
 // Sample functions and functors for testing various actions.
 int Nullary() { return 1; }
 
-bool g_done = false;
-
 bool ByConstRef(const std::string& s) { return s == "Hi"; }
 
 const double g_double = 0;

--- a/googlemock/test/gmock-generated-matchers_test.cc
+++ b/googlemock/test/gmock-generated-matchers_test.cc
@@ -1259,10 +1259,14 @@ namespace adl_test {
 
 // The matcher must be in the same namespace as AllOf/AnyOf to make argument
 // dependent lookup find those.
-MATCHER(M, "") { return true; }
+MATCHER(M, "") {
+  // -Wunused: fake use of `arg`.
+  (void)arg;
+  return true;
+}
 
 template <typename T1, typename T2>
-bool AllOf(const T1& t1, const T2& t2) { return true; }
+bool AllOf(const T1& /*t1*/, const T2& /*t2*/) { return true; }
 
 TEST(AllOfTest, DoesNotCallAllOfUnqualified) {
   EXPECT_THAT(42, testing::AllOf(
@@ -1270,7 +1274,7 @@ TEST(AllOfTest, DoesNotCallAllOfUnqualified) {
 }
 
 template <typename T1, typename T2> bool
-AnyOf(const T1& t1, const T2& t2) { return true; }
+AnyOf(const T1& /*t1*/, const T2& /*t2*/) { return true; }
 
 TEST(AnyOfTest, DoesNotCallAnyOfUnqualified) {
   EXPECT_THAT(42, testing::AnyOf(

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -968,6 +968,8 @@ class Unprintable {
   Unprintable() : c_('a') {}
 
   bool operator==(const Unprintable& /* rhs */) const { return true; }
+  // -Wunused: dummy accessor for `c_`.
+  char dummy_c() { return c_; }
  private:
   char c_;
 };
@@ -6927,7 +6929,7 @@ TEST(ArgsTest, ExplainsMatchResultWithoutInnerExplanation) {
 // For testing Args<>'s explanation.
 class LessThanMatcher : public MatcherInterface<std::tuple<char, int> > {
  public:
-  virtual void DescribeTo(::std::ostream* os) const {}
+  void DescribeTo(::std::ostream* /*os*/) const override {}
 
   virtual bool MatchAndExplain(std::tuple<char, int> value,
                                MatchResultListener* listener) const {

--- a/googlemock/test/gmock-more-actions_test.cc
+++ b/googlemock/test/gmock-more-actions_test.cc
@@ -74,7 +74,7 @@ class NullaryFunctor {
   int operator()() { return 2; }
 };
 
-bool g_done = false;
+static bool g_done = false;
 void VoidNullary() { g_done = true; }
 
 class VoidNullaryFunctor {

--- a/googletest/test/googletest-listener-test.cc
+++ b/googletest/test/googletest-listener-test.cc
@@ -47,7 +47,7 @@ using ::testing::TestPartResult;
 using ::testing::UnitTest;
 
 // Used by tests to register their events.
-std::vector<std::string>* g_events = nullptr;
+static std::vector<std::string>* g_events = nullptr;
 
 namespace testing {
 namespace internal {

--- a/googletest/test/googletest-output-test_.cc
+++ b/googletest/test/googletest-output-test_.cc
@@ -39,6 +39,8 @@
 
 #include <stdlib.h>
 
+namespace {
+
 #if _MSC_VER
 GTEST_DISABLE_MSC_WARNINGS_PUSH_(4127 /* conditional expression is constant */)
 #endif  //  _MSC_VER
@@ -465,12 +467,6 @@ TEST(AddFailureAtTest, MessageContainsSpecifiedFileAndLineNumber) {
 }
 
 #if GTEST_IS_THREADSAFE
-
-// A unary function that may die.
-void DieIf(bool should_die) {
-  GTEST_CHECK_(!should_die) << " - death inside DieIf().";
-}
-
 // Tests running death tests in a multi-threaded context.
 
 // Used for coordination between the main and the spawn thread.
@@ -1043,7 +1039,7 @@ class DynamicTest : public DynamicFixture {
   void TestBody() override { EXPECT_TRUE(Pass); }
 };
 
-auto dynamic_test = (
+static auto dynamic_test = (
     // Register two tests with the same fixture correctly.
     testing::RegisterTest(
         "DynamicFixture", "DynamicTestPass", nullptr, nullptr, __FILE__,
@@ -1096,6 +1092,15 @@ class BarEnvironment : public testing::Environment {
     ADD_FAILURE() << "Expected non-fatal failure.";
   }
 };
+
+}
+
+#if GTEST_IS_THREADSAFE
+// A unary function that may die.
+void DieIf(bool should_die) {
+  GTEST_CHECK_(!should_die) << " - death inside DieIf().";
+}
+#endif  // GTEST_IS_THREADSAFE
 
 // The main function.
 //

--- a/googletest/test/googletest-param-test-test.cc
+++ b/googletest/test/googletest-param-test-test.cc
@@ -965,6 +965,9 @@ class Unstreamable {
  public:
   explicit Unstreamable(int value) : value_(value) {}
 
+  // -Wunused: dummy accessor for `value_`.
+  const int& dummy_value() const { return value_; }
+
  private:
   int value_;
 };

--- a/googletest/test/googletest-param-test2-test.cc
+++ b/googletest/test/googletest-param-test2-test.cc
@@ -37,6 +37,8 @@
 using ::testing::Values;
 using ::testing::internal::ParamGenerator;
 
+extern ParamGenerator<int> extern_gen;
+
 // Tests that generators defined in a different translation unit
 // are functional. The test using extern_gen is defined
 // in googletest-param-test-test.cc.

--- a/googletest/test/googletest-test2_test.cc
+++ b/googletest/test/googletest-test2_test.cc
@@ -40,7 +40,7 @@ using ::testing::internal::ParamGenerator;
 // Tests that generators defined in a different translation unit
 // are functional. The test using extern_gen_2 is defined
 // in googletest-param-test-test.cc.
-ParamGenerator<int> extern_gen_2 = Values(33);
+static ParamGenerator<int> extern_gen_2 = Values(33);
 
 // Tests that a parameterized test case can be defined in one translation unit
 // and instantiated in another. The test is defined in

--- a/googletest/test/gtest-typed-test_test.cc
+++ b/googletest/test/gtest-typed-test_test.cc
@@ -377,10 +377,12 @@ TYPED_TEST_P(TypedTestP2, A) {}
 
 REGISTER_TYPED_TEST_SUITE_P(TypedTestP2, A);
 
-// Verifies that the code between TYPED_TEST_SUITE_P() and
-// REGISTER_TYPED_TEST_SUITE_P() is not enclosed in a namespace.
-IntAfterTypedTestSuiteP after = 0;
-IntBeforeRegisterTypedTestSuiteP before = 0;
+// Verifies that the code between TYPED_TEST_CASE_P() and
+// REGISTER_TYPED_TEST_CASE_P() is not enclosed in a namespace.
+namespace {
+IntAfterTypedTestSuiteP after GTEST_ATTRIBUTE_UNUSED_ = 0;
+IntBeforeRegisterTypedTestSuiteP before GTEST_ATTRIBUTE_UNUSED_ = 0;
+}
 
 // Verifies that the last argument of INSTANTIATE_TYPED_TEST_SUITE_P()
 // can be either a single type or a Types<...> type list.

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -7576,9 +7576,11 @@ class DynamicTest : public DynamicUnitTestFixture {
   void TestBody() override { EXPECT_TRUE(true); }
 };
 
+namespace {
 auto* dynamic_test = testing::RegisterTest(
     "DynamicUnitTestFixture", "DynamicTest", "TYPE", "VALUE", __FILE__,
     __LINE__, []() -> DynamicUnitTestFixture* { return new DynamicTest; });
+}
 
 TEST(RegisterTest, WasRegistered) {
   auto* unittest = testing::UnitTest::GetInstance();


### PR DESCRIPTION
The attached pull request fixes 2 trivial issues when compiling the googletest tests on FreeBSD with WARNS >= 1, i.e., -Werror on, with clang.

This issue was seen when trying to integrate googletest 1.8.1 into the FreeBSD base system on my GitHub project branch.

This PR requires #2100.