### PR TITLE
Only build with warnings-as-errors on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ matrix:
       dist: trusty
       sudo: required
       group: deprecated-2017Q3
-      before_install: chmod -R +x ./ci/*platformio.sh 
+      before_install: chmod -R +x ./ci/*platformio.sh
       install: ./ci/install-platformio.sh
-      script: ./ci/build-platformio.sh      
+      script: ./ci/build-platformio.sh
     - os: linux
       compiler: gcc
       sudo : true
@@ -36,19 +36,19 @@ matrix:
     - os: linux
       group: deprecated-2017Q4
       compiler: gcc
-      env: BUILD_TYPE=Debug VERBOSE=1 CXX_FLAGS=-std=c++11
+      env: BUILD_TYPE=Debug VERBOSE=1 CXX_FLAGS="-std=c++11 -Werror"
     - os: linux
       group: deprecated-2017Q4
       compiler: clang
-      env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11
+      env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS="-std=c++11 -Werror"
     - os: linux
       compiler: clang
-      env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11 NO_EXCEPTION=ON NO_RTTI=ON COMPILER_IS_GNUCXX=ON
+      env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS="-std=c++11 -Werror" NO_EXCEPTION=ON NO_RTTI=ON COMPILER_IS_GNUCXX=ON
     - os: osx
       compiler: gcc
-      env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11
+      env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS="-std=c++11 -Werror"
     - os: osx
-      env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11
+      env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS="-std=c++11 -Werror"
       if: type != pull_request
 
 # These are the install and build (script) phases for the most common entries in the matrix.  They could be included

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -76,7 +76,7 @@ macro(config_compiler_and_linker)
     # http://stackoverflow.com/questions/3232669 explains the issue.
     set(cxx_base_flags "${cxx_base_flags} -wd4702")
   elseif (CMAKE_COMPILER_IS_GNUCXX)
-    set(cxx_base_flags "-Wall -Wshadow -Werror")
+    set(cxx_base_flags "-Wall -Wshadow")
     if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0.0)
       set(cxx_base_flags "${cxx_base_flags} -Wno-error=dangling-else")
     endif()


### PR DESCRIPTION
This is so that -Werror doesn't break compilation for people on different platforms/newer compilers.