### PR TITLE
Update internal_utils.cmake

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -121,8 +121,7 @@ macro(config_compiler_and_linker)
 
   # For building gtest's own tests and samples.
   set(cxx_exception "${cxx_base_flags} ${cxx_exception_flags}")
-  set(cxx_no_exception
-    "${CMAKE_CXX_FLAGS} ${cxx_base_flags} ${cxx_no_exception_flags}")
+  set(cxx_no_exception "${cxx_base_flags} ${cxx_no_exception_flags}")
   set(cxx_default "${cxx_exception}")
   set(cxx_no_rtti "${cxx_default} ${cxx_no_rtti_flags}")
 


### PR DESCRIPTION
If CMAKE_CXX_FLAGS are part of cxx_no_exception, the compiler flags are doubled, because CMake adds the CMAKE_CXX_FLAGS to the compiler call by itself, so if cxx_no_exception also contains the CMAKE_CXX_FLAGS and is then added to the compiler flags by function 'cxx_library_with_type' (defined in the same file) , they are two times in the compiler call.

This is OK for most use cases, but not if you are using compiler flags that may only be set once.

See discussion in https://github.com/google/googletest/issues/1637