### PR TITLE
no dllimport on main (remove macro GTEST_API_ from before main)

### DIFF
--- a/googlemock/src/gmock_main.cc
+++ b/googlemock/src/gmock_main.cc
@@ -57,9 +57,9 @@ void loop() { RUN_ALL_TESTS(); }
 #if GTEST_OS_WINDOWS_MOBILE
 # include <tchar.h>  // NOLINT
 
-GTEST_API_ int _tmain(int argc, TCHAR** argv) {
+int _tmain(int argc, TCHAR** argv) {
 #else
-GTEST_API_ int main(int argc, char** argv) {
+int main(int argc, char** argv) {
 #endif  // GTEST_OS_WINDOWS_MOBILE
   std::cout << "Running main() from gmock_main.cc\n";
   // Since Google Mock depends on Google Test, InitGoogleMock() is


### PR DESCRIPTION
When compiling for shared libs via 

```cmake
option(BUILD_SHARED_LIBS "build shared (dll) libs" ON)
if (BUILD_SHARED_LIBS)
  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
else()
  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS OFF)
endif()

set(CMAKE_CXX_STANDARD    14 CACHE STRING "c++ standard")
set(CMAKE_CXX_EXTENSIONS OFF CACHE BOOL   "c++ extensions")

set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

option(gtest_force_shared_crt "" ON)
option(gtest_hide_internal_symbols "" ON)
target_compile_definitions(gtest      PRIVATE   GTEST_CREATE_SHARED_LIBRARY=1)
target_compile_definitions(gtest      INTERFACE GTEST_LINKED_AS_SHARED_LIBRARY=1)
```

I get the following error from Visual Studio:

**'main': definition of dllimport function not allowed**

```
ClCompile:
  C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.16.27023\bin\HostX86\x86\CL.exe /c /IE:\gt\googletest\googletest\include /IE:\gt\googletest\googletest /Zi /nologo /W4 /WX /diagnostics:classic /Od /Ob0 /Oy- /D WIN32 /D _WINDOWS /D _UNICODE /D UNICODE /D _WIN32 /D STRICT /D WIN32_LEAN_AND_MEAN /D GTEST_HAS_PTHREAD=0 /D _HAS_EXCEPTIONS=1 /D GTEST_CREATE_SHARED_LIBRARY=1 /D GTEST_LINKED_AS_SHARED_LIBRARY=1 /D "CMAKE_INTDIR=\"Debug\"" /D gtest_main_EXPORTS /D _WINDLL /D _UNICODE /D UNICODE /Gm- /EHsc /RTC1 /MDd /GS /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /GR /Fo"gtest_main.dir\Debug\\" /Fd"E:\gt\build\bin\Debug\gtest_maind.pdb" /Gd /TP /wd4251 /wd4275 /wd4702 /analyze- /errorReport:queue  -J E:\gt\googletest\googletest\src\gtest_main.cc gtest_main.cc
E:\gt\googletest\googletest\src\gtest_main.cc(48): error C2491: 'main': definition of dllimport function not allowed [E:\gt\build\googletest\googlemock\gtest\gtest_main.vcxproj]
```

So my question is: can that macro be removed as suggested in this pull-request?
And if not, how would you go about using cmake to allow shared libraries, without getting that error?

Thanks