### PR TITLE
Fixes human readable print for last google protobuf

### DIFF
--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -82,6 +82,7 @@
 
 class ProtocolMessage;
 namespace proto2 { class Message; }
+namespace google { namespace protobuf { class Message; }}
 
 namespace testing {
 
@@ -927,7 +928,8 @@ template <typename T>
 struct IsAProtocolMessage
     : public bool_constant<
   std::is_convertible<const T*, const ::ProtocolMessage*>::value ||
-  std::is_convertible<const T*, const ::proto2::Message*>::value> {
+  std::is_convertible<const T*, const ::proto2::Message*>::value ||
+  std::is_convertible<const T*, const ::google::protobuf::Message*>::value> {
 };
 
 // When the compiler sees expression IsContainerTest<C>(0), if C is an

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -7121,6 +7121,7 @@ TEST(IsAProtocolMessageTest, ValueIsCompileTimeConstant) {
 // proto2::Message or a sub-class of it.
 TEST(IsAProtocolMessageTest, ValueIsTrueWhenTypeIsAProtocolMessage) {
   EXPECT_TRUE(IsAProtocolMessage< ::proto2::Message>::value);
+  EXPECT_TRUE(IsAProtocolMessage< ::google::protobuf::Message>::value);
   EXPECT_TRUE(IsAProtocolMessage<ProtocolMessage>::value);
 }
 


### PR DESCRIPTION
Google seems changed namespace ages ago for protobuf. Strange that nobody fixed it yet.