### PR TITLE
Enable building as a shared library (dll) on Windows with Bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -104,12 +104,20 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
+    features = select({
+        ":windows": ["windows_export_all_symbols"],
+        "//conditions:default": [],
+    })
 )
 
 cc_library(
     name = "gtest_main",
     srcs = ["googlemock/src/gmock_main.cc"],
     deps = [":gtest"],
+    features = select({
+        ":windows": ["windows_export_all_symbols"],
+        "//conditions:default": [],
+    })
 )
 
 # The following rules build samples of how to use gTest.

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -135,6 +135,10 @@ cc_library(
         "googletest/samples/sample3-inl.h",
         "googletest/samples/sample4.h",
     ],
+    features = select({
+        ":windows": ["windows_export_all_symbols"],
+        "//conditions:default": [],
+    })
 )
 
 cc_test(
@@ -157,6 +161,7 @@ cc_test(
         "gtest_sample_lib",
         ":gtest_main",
     ],
+    linkstatic = 0,
 )
 
 cc_test(

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,21 +6,31 @@ environment:
   matrix:
     - compiler: msvc-15-seh
       generator: "Visual Studio 15 2017"
+      build_system: cmake
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     - compiler: msvc-15-seh
       generator: "Visual Studio 15 2017 Win64"
+      build_system: cmake
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      enabled_on_pr: yes
+
+    - compiler: msvc-15-seh
+      build_system: bazel
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       enabled_on_pr: yes
 
     - compiler: msvc-14-seh
+      build_system: cmake
       generator: "Visual Studio 14 2015"
       enabled_on_pr: yes
 
     - compiler: msvc-14-seh
+      build_system: cmake
       generator: "Visual Studio 14 2015 Win64"
 
     - compiler: gcc-6.3.0-posix
+      build_system: cmake
       generator: "MinGW Makefiles"
       cxx_path: 'C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin'
       enabled_on_pr: yes
@@ -46,20 +56,44 @@ install:
       }
     }
 
-    # git bash conflicts with MinGW makefiles
-    if ($env:generator -eq "MinGW Makefiles") {
-        $env:path = $env:path.replace("C:\Program Files\Git\usr\bin;", "")
-        if ($env:cxx_path -ne "") {
-            $env:path += ";$env:cxx_path"
+    # install Bazel
+    if ($env:build_system -eq "bazel") {
+        appveyor DownloadFile https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel-0.21.0-windows-x86_64.exe -FileName bazel.exe
+    }
+
+    if ($env:build_system -eq "cmake") {
+        # git bash conflicts with MinGW makefiles
+        if ($env:generator -eq "MinGW Makefiles") {
+            $env:path = $env:path.replace("C:\Program Files\Git\usr\bin;", "")
+            if ($env:cxx_path -ne "") {
+                $env:path += ";$env:cxx_path"
+            }
         }
     }
+
+before_build:
+- ps: |
+     $env:root=$env:APPVEYOR_BUILD_FOLDER
+     Write-Output "env:root: $env:root"
 
 build_script:
 - ps: |
     # Only enable some builds for pull requests, the AppVeyor queue is too long.
     if ((Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER) -And (-not (Test-Path env:enabled_on_pr) -or $env:enabled_on_pr -ne "yes")) {
       return
+    } else {
+        # special case - build with Bazel
+        if ($env:build_system -eq "bazel") {
+            & $env:root\bazel.exe build -c opt //:gtest_samples
+            if ($LastExitCode -eq 0) { # bazel writes to StdErr and PowerShell interprets it as an error
+                $host.SetShouldExit(0)
+            } else { # a real error
+                throw "Exec: $ErrorMessage"
+            }
+            return
+        }
     }
+    # by default build with CMake
     md _build -Force | Out-Null
     cd _build
 
@@ -88,16 +122,33 @@ test_script:
     if ((Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER) -And (-not (Test-Path env:enabled_on_pr) -or $env:enabled_on_pr -ne "yes")) {
       return
     }
-    if ($env:generator -eq "MinGW Makefiles") {
-        return # No test available for MinGW
+    if ($env:build_system -eq "bazel") {
+        # special case - testing with Bazel
+        & $env:root\bazel.exe test //:gtest_samples
+        if ($LastExitCode -eq 0) { # bazel writes to StdErr and PowerShell interprets it as an error
+            $host.SetShouldExit(0)
+        } else { # a real error
+            throw "Exec: $ErrorMessage"
+        }
     }
-    & ctest -C $env:configuration --timeout 600 --output-on-failure
-    if ($LastExitCode -ne 0) {
-        throw "Exec: $ErrorMessage"
+    if ($env:build_system -eq "cmake") {
+        # built with CMake - test with CTest
+        if ($env:generator -eq "MinGW Makefiles") {
+            return # No test available for MinGW
+        }
+
+        & ctest -C $env:configuration --timeout 600 --output-on-failure
+        if ($LastExitCode -ne 0) {
+            throw "Exec: $ErrorMessage"
+        }
     }
 
 artifacts:
   - path: '_build/CMakeFiles/*.log'
     name: logs
   - path: '_build/Testing/**/*.xml'
+    name: test_results
+  - path: 'bazel-testlogs/**/test.log'
+    name: test_logs
+  - path: 'bazel-testlogs/**/test.xml'
     name: test_results


### PR DESCRIPTION
While the google test library is being built as a shared library using Bazel,
so that there is a rule like

cc_test(
     name = "iterator_traits_test",
     linkstatic = 0,
     deps = ["@gtest//:gtest_main"],
     ...
)

in a BUILD file, the following error appears on Windows:

INFO: Found 1 test target...
ERROR: C:/../external/gtest/BUILD.bazel:55:1: output 'external/gtest/gtest.if.lib' was not created
ERROR: C:/../external/gtest/BUILD.bazel:55:1: not all outputs were created or valid
Target //test:iterator_traits_test failed to build

The reason is a missing "win_def_file" attribute of the "gtest" and
"gtest_main" rules in the BUILD.bazel inside the google test library
package.

The "windows_export_all_symbols" feature is added to the rules, this
feature forces Bazel to export all symbols from the google test library
to linker. I believe exporting all symbols from a testing library makes
no problem for the application from a point of view on encapsulation.

Signed-off-by: Pavel Samolysov <samolisov@gmail.com>