### PR TITLE
Fix INSTANTIATE_TEST_CASE_P with zero variadic arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
       env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11
     - os: linux
       compiler: clang
-      env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11 NO_EXCEPTION=ON NO_RTTI=ON COMPILER_IS_GNUCXX=ON
+      env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS="-std=c++11 -Wgnu-zero-variadic-macro-arguments" NO_EXCEPTION=ON NO_RTTI=ON COMPILER_IS_GNUCXX=ON
     - os: osx
       compiler: gcc
       env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11 HOMEBREW_LOGS=~/homebrew-logs HOMEBREW_TEMP=~/homebrew-temp

--- a/googletest/include/gtest/gtest-param-test.h
+++ b/googletest/include/gtest/gtest-param-test.h
@@ -556,15 +556,20 @@ internal::CartesianProductHolder10<Generator1, Generator2, Generator3,
 // alphanumeric characters or underscore. Because PrintToString adds quotes
 // to std::string and C strings, it won't work for these types.
 
+#define GTEST_GET_FIRST_(first, ...) first
+#define GTEST_GET_SECOND_(first, second, ...) second
+
 #define INSTANTIATE_TEST_SUITE_P(prefix, test_suite_name, ...)                \
   static ::testing::internal::ParamGenerator<test_suite_name::ParamType>      \
       gtest_##prefix##test_suite_name##_EvalGenerator_() {                    \
-    return VA_GETFIRST(__VA_ARGS__);                                          \
+    return GTEST_GET_FIRST_(__VA_ARGS__, DUMMY_PARAM_);                       \
   }                                                                           \
   static ::std::string gtest_##prefix##test_suite_name##_EvalGenerateName_(   \
       const ::testing::TestParamInfo<test_suite_name::ParamType>& info) {     \
-    return ::testing::internal::CreateParamGenerator<                         \
-        test_suite_name::ParamType>(VA_GETREST(__VA_ARGS__, 0))(info);        \
+    return GTEST_GET_SECOND_(                                                 \
+        __VA_ARGS__,                                                          \
+        ::testing::internal::DefaultParamName<test_suite_name::ParamType>,    \
+        DUMMY_PARAM_)(info);                                                  \
   }                                                                           \
   static int gtest_##prefix##test_suite_name##_dummy_                         \
       GTEST_ATTRIBUTE_UNUSED_ =                                               \

--- a/googletest/include/gtest/gtest-param-test.h
+++ b/googletest/include/gtest/gtest-param-test.h
@@ -557,20 +557,20 @@ internal::CartesianProductHolder10<Generator1, Generator2, Generator3,
 // to std::string and C strings, it won't work for these types.
 
 #define GTEST_EXPAND_(arg) arg
-#define GTEST_GET_FIRST_(first, ...) GTEST_EXPAND_(first)
-#define GTEST_GET_SECOND_(first, second, ...) GTEST_EXPAND_(second)
+#define GTEST_GET_FIRST_(first, ...) first
+#define GTEST_GET_SECOND_(first, second, ...) second
 
 #define INSTANTIATE_TEST_SUITE_P(prefix, test_suite_name, ...)                \
   static ::testing::internal::ParamGenerator<test_suite_name::ParamType>      \
       gtest_##prefix##test_suite_name##_EvalGenerator_() {                    \
-    return GTEST_GET_FIRST_(__VA_ARGS__, DUMMY_PARAM_);                       \
+    return GTEST_EXPAND_(GTEST_GET_FIRST_(__VA_ARGS__, DUMMY_PARAM_));        \
   }                                                                           \
   static ::std::string gtest_##prefix##test_suite_name##_EvalGenerateName_(   \
       const ::testing::TestParamInfo<test_suite_name::ParamType>& info) {     \
-    return GTEST_GET_SECOND_(                                                 \
+    return GTEST_EXPAND_(GTEST_GET_SECOND_(                                   \
         __VA_ARGS__,                                                          \
         ::testing::internal::DefaultParamName<test_suite_name::ParamType>,    \
-        DUMMY_PARAM_)(info);                                                  \
+        DUMMY_PARAM_))(info);                                                  \
   }                                                                           \
   static int gtest_##prefix##test_suite_name##_dummy_                         \
       GTEST_ATTRIBUTE_UNUSED_ =                                               \

--- a/googletest/include/gtest/gtest-param-test.h
+++ b/googletest/include/gtest/gtest-param-test.h
@@ -544,9 +544,9 @@ internal::CartesianProductHolder10<Generator1, Generator2, Generator3,
       GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)::AddToRegistry();     \
   void GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)::TestBody()
 
-// The optional last argument to INSTANTIATE_TEST_SUITE_P allows the user
-// to specify a function or functor that generates custom test name suffixes
-// based on the test parameters. The function should accept one argument of
+// The last argument to INSTANTIATE_TEST_SUITE_P allows the user to specify generator
+// and an optional function or functor that generates custom test name suffixes
+// based on the test parameters. Such a function or functor should accept one argument of
 // type testing::TestParamInfo<class ParamType>, and return std::string.
 //
 // testing::PrintToStringParamName is a builtin test suffix generator that
@@ -556,15 +556,15 @@ internal::CartesianProductHolder10<Generator1, Generator2, Generator3,
 // alphanumeric characters or underscore. Because PrintToString adds quotes
 // to std::string and C strings, it won't work for these types.
 
-#define INSTANTIATE_TEST_SUITE_P(prefix, test_suite_name, generator, ...)     \
+#define INSTANTIATE_TEST_SUITE_P(prefix, test_suite_name, ...)                \
   static ::testing::internal::ParamGenerator<test_suite_name::ParamType>      \
       gtest_##prefix##test_suite_name##_EvalGenerator_() {                    \
-    return generator;                                                         \
+    return VA_GETFIRST(__VA_ARGS__);                                          \
   }                                                                           \
   static ::std::string gtest_##prefix##test_suite_name##_EvalGenerateName_(   \
       const ::testing::TestParamInfo<test_suite_name::ParamType>& info) {     \
-    return ::testing::internal::GetParamNameGen<test_suite_name::ParamType>(  \
-        __VA_ARGS__)(info);                                                   \
+    return ::testing::internal::CreateParamGenerator<                         \
+        test_suite_name::ParamType>(VA_GETREST(__VA_ARGS__, 0))(info);        \
   }                                                                           \
   static int gtest_##prefix##test_suite_name##_dummy_                         \
       GTEST_ATTRIBUTE_UNUSED_ =                                               \

--- a/googletest/include/gtest/gtest-param-test.h
+++ b/googletest/include/gtest/gtest-param-test.h
@@ -556,8 +556,9 @@ internal::CartesianProductHolder10<Generator1, Generator2, Generator3,
 // alphanumeric characters or underscore. Because PrintToString adds quotes
 // to std::string and C strings, it won't work for these types.
 
-#define GTEST_GET_FIRST_(first, ...) first
-#define GTEST_GET_SECOND_(first, second, ...) second
+#define GTEST_EXPAND_(arg) arg
+#define GTEST_GET_FIRST_(first, ...) GTEST_EXPAND_(first)
+#define GTEST_GET_SECOND_(first, second, ...) GTEST_EXPAND_(second)
 
 #define INSTANTIATE_TEST_SUITE_P(prefix, test_suite_name, ...)                \
   static ::testing::internal::ParamGenerator<test_suite_name::ParamType>      \

--- a/googletest/include/gtest/internal/gtest-param-util.h
+++ b/googletest/include/gtest/internal/gtest-param-util.h
@@ -41,6 +41,7 @@
 #include <memory>
 #include <set>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -394,6 +395,30 @@ struct ParamNameGenFunc {
 template <class ParamType>
 typename ParamNameGenFunc<ParamType>::Type *GetParamNameGen() {
   return DefaultParamName;
+}
+
+// INTERNAL IMPLEMENTATION - DO NOT USE IN USER CODE.
+//
+// Macroses allow to address an issue with zero element variadic macro
+
+#define EXPAND(X) X
+#define VA__GETFIRST(X, ...) X
+#define VA_GETFIRST(...) EXPAND(VA__GETFIRST(__VA_ARGS__, 0))
+#define VA_GETREST(X, ...) __VA_ARGS__
+
+// INTERNAL IMPLEMENTATION - DO NOT USE IN USER CODE.
+//
+// Function is intended to swallow 0 as last argument and call GetParamNameGen
+
+template <class ParamType>
+auto CreateParamGenerator(int) -> decltype(GetParamNameGen<ParamType>()) {
+  return GetParamNameGen<ParamType>();
+}
+
+template <class ParamType, class Arg>
+auto CreateParamGenerator(Arg&& arg, int) -> decltype(
+    GetParamNameGen<ParamType>(std::forward<Arg>(arg))) {
+  return GetParamNameGen<ParamType>(std::forward<Arg>(arg));
 }
 
 // INTERNAL IMPLEMENTATION - DO NOT USE IN USER CODE.

--- a/googletest/include/gtest/internal/gtest-param-util.h
+++ b/googletest/include/gtest/internal/gtest-param-util.h
@@ -41,7 +41,6 @@
 #include <memory>
 #include <set>
 #include <tuple>
-#include <type_traits>
 #include <utility>
 #include <vector>
 

--- a/googletest/include/gtest/internal/gtest-param-util.h
+++ b/googletest/include/gtest/internal/gtest-param-util.h
@@ -379,50 +379,6 @@ std::string DefaultParamName(const TestParamInfo<ParamType>& info) {
 
 // INTERNAL IMPLEMENTATION - DO NOT USE IN USER CODE.
 //
-// Parameterized test name overload helpers, which help the
-// INSTANTIATE_TEST_SUITE_P macro choose between the default parameterized
-// test name generator and user param name generator.
-template <class ParamType, class ParamNameGenFunctor>
-ParamNameGenFunctor GetParamNameGen(ParamNameGenFunctor func) {
-  return func;
-}
-
-template <class ParamType>
-struct ParamNameGenFunc {
-  typedef std::string Type(const TestParamInfo<ParamType>&);
-};
-
-template <class ParamType>
-typename ParamNameGenFunc<ParamType>::Type *GetParamNameGen() {
-  return DefaultParamName;
-}
-
-// INTERNAL IMPLEMENTATION - DO NOT USE IN USER CODE.
-//
-// Macroses allow to address an issue with zero element variadic macro
-
-#define EXPAND(X) X
-#define VA__GETFIRST(X, ...) X
-#define VA_GETFIRST(...) EXPAND(VA__GETFIRST(__VA_ARGS__, 0))
-#define VA_GETREST(X, ...) __VA_ARGS__
-
-// INTERNAL IMPLEMENTATION - DO NOT USE IN USER CODE.
-//
-// Function is intended to swallow 0 as last argument and call GetParamNameGen
-
-template <class ParamType>
-auto CreateParamGenerator(int) -> decltype(GetParamNameGen<ParamType>()) {
-  return GetParamNameGen<ParamType>();
-}
-
-template <class ParamType, class Arg>
-auto CreateParamGenerator(Arg&& arg, int) -> decltype(
-    GetParamNameGen<ParamType>(std::forward<Arg>(arg))) {
-  return GetParamNameGen<ParamType>(std::forward<Arg>(arg));
-}
-
-// INTERNAL IMPLEMENTATION - DO NOT USE IN USER CODE.
-//
 // Stores a parameter value and later creates tests parameterized with that
 // value.
 template <class TestClass>
@@ -525,7 +481,7 @@ class ParameterizedTestSuiteInfo : public ParameterizedTestSuiteInfoBase {
   using ParamType = typename TestSuite::ParamType;
   // A function that returns an instance of appropriate generator type.
   typedef ParamGenerator<ParamType>(GeneratorCreationFunc)();
-  typedef typename ParamNameGenFunc<ParamType>::Type ParamNameGeneratorFunc;
+  typedef std::string ParamNameGeneratorFunc(const TestParamInfo<ParamType>&);
 
   explicit ParameterizedTestSuiteInfo(const char* name,
                                       CodeLocation code_location)


### PR DESCRIPTION
To fix: https://github.com/google/googletest/issues/1419
INSTANTIATE_TEST_CASE_P generates warnings with clang++ -Wpedantic #1419