### PR TITLE
Fix for: failed build on centos6 master #1587

### DIFF
--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -3033,7 +3033,7 @@ class PointwiseMatcher {
   operator Matcher<LhsContainer>() const {
     GTEST_COMPILE_ASSERT_(
         !IsHashTable<GTEST_REMOVE_REFERENCE_AND_CONST_(LhsContainer)>::value,
-        use_UnorderedPointwise_with_hash_tables);
+        use_UnorderedPointwise_with_hash_tables_);
 
     return MakeMatcher(new Impl<LhsContainer>(tuple_matcher_, rhs_));
   }


### PR DESCRIPTION
The issue still exists in 1.8.1 and NOT in master branch. It was introduced to 1.8.1 only by #1512.
This code
GTEST_COMPILE_ASSERT_(
!IsHashTable<GTEST_REMOVE_REFERENCE_AND_CONST_(LhsContainer)>::value,
use_UnorderedPointwise_with_hash_tables);

Creates 2nd variable use_UnorderedPointwise_with_hash_tables.