### PR TITLE
added general floating point near comparison

### DIFF
--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1784,11 +1784,9 @@ AssertionResult CmpHelperFloatingPointEQ(const char* lhs_expression,
 //
 // INTERNAL IMPLEMENTATION - DO NOT USE IN A USER PROGRAM.
 template <class R1, class R2, class T>
-GTEST_API_ AssertionResult FPNearPredFormat(const char* expr1,
-                                            const char* expr2,
-                                            const char* abs_error_expr,
-                                            const R1& val1, const R2& val2,
-                                            const T& abs_error) {
+AssertionResult FPNearPredFormat(const char* expr1, const char* expr2,
+                                 const char* abs_error_expr, const R1& val1,
+                                 const R2& val2, const T& abs_error) {
   using namespace std;
   auto diff = fabs(val1 - val2);
   if (diff <= abs_error) {

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -52,7 +52,6 @@
 #ifndef GTEST_INCLUDE_GTEST_GTEST_H_
 #define GTEST_INCLUDE_GTEST_GTEST_H_
 
-#include <cmath>
 #include <iomanip>
 #include <limits>
 #include <memory>
@@ -1787,8 +1786,7 @@ template <class R1, class R2, class T>
 AssertionResult FPNearPredFormat(const char* expr1, const char* expr2,
                                  const char* abs_error_expr, const R1& val1,
                                  const R2& val2, const T& abs_error) {
-  using std::fabs;
-  auto diff = fabs(val1 - val2);
+  auto diff = val1 > val2 ? val1 - val2 : val2 - val1;
   if (diff <= abs_error) {
     return AssertionSuccess();
   }

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -52,7 +52,6 @@
 #ifndef GTEST_INCLUDE_GTEST_GTEST_H_
 #define GTEST_INCLUDE_GTEST_GTEST_H_
 
-#include <iomanip>
 #include <limits>
 #include <memory>
 #include <ostream>

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -52,12 +52,12 @@
 #ifndef GTEST_INCLUDE_GTEST_GTEST_H_
 #define GTEST_INCLUDE_GTEST_GTEST_H_
 
+#include <cmath>
+#include <iomanip>
 #include <limits>
 #include <memory>
 #include <ostream>
 #include <vector>
-#include <iomanip>
-#include <cmath>
 
 #include "gtest/internal/gtest-internal.h"
 #include "gtest/internal/gtest-string.h"
@@ -1787,14 +1787,15 @@ template <class R1, class R2, class T>
 AssertionResult FPNearPredFormat(const char* expr1, const char* expr2,
                                  const char* abs_error_expr, const R1& val1,
                                  const R2& val2, const T& abs_error) {
-  using namespace std;
+  using std::fabs;
   auto diff = fabs(val1 - val2);
   if (diff <= abs_error) {
     return AssertionSuccess();
   }
   return AssertionFailure()
-         << std::setprecision(
-                std::numeric_limits<typename std::decay<R1>::type>::max_digits10)
+         << std::setprecision(std::numeric_limits<
+                                  typename std::decay<R1>::type>::max_digits10 +
+                              2)
          << "The difference between " << expr1 << " and " << expr2 << " is "
          << diff << ", which exceeds " << abs_error_expr << ", where\n"
          << expr1 << " evaluates to " << val1 << ",\n"

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -1380,25 +1380,6 @@ std::string GetBoolAssertionFailureMessage(
   return msg.GetString();
 }
 
-// Helper function for implementing ASSERT_NEAR.
-AssertionResult DoubleNearPredFormat(const char* expr1,
-                                     const char* expr2,
-                                     const char* abs_error_expr,
-                                     double val1,
-                                     double val2,
-                                     double abs_error) {
-  const double diff = fabs(val1 - val2);
-  if (diff <= abs_error) return AssertionSuccess();
-
-  return AssertionFailure()
-      << "The difference between " << expr1 << " and " << expr2
-      << " is " << diff << ", which exceeds " << abs_error_expr << ", where\n"
-      << expr1 << " evaluates to " << val1 << ",\n"
-      << expr2 << " evaluates to " << val2 << ", and\n"
-      << abs_error_expr << " evaluates to " << abs_error << ".";
-}
-
-
 // Helper template for implementing FloatLE() and DoubleLE().
 template <typename RawType>
 AssertionResult FloatingPointLE(const char* expr1,

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -3160,9 +3160,9 @@ class custom_real {
   friend std::ostream& operator<<(std::ostream& out, const custom_real& v);
 };
 
-static custom_real fabs(const custom_real& v) { return std::fabs(v.value_); }
+custom_real fabs(const custom_real& v) { return std::fabs(v.value_); }
 
-static std::ostream& operator<<(std::ostream& out, const custom_real& v) {
+std::ostream& operator<<(std::ostream& out, const custom_real& v) {
   out << v.value_;
   return out;
 }

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -3147,23 +3147,11 @@ class custom_real {
   friend custom_real operator-(custom_real l, custom_real r) {
     return custom_real(l.value_ - r.value_);
   }
-  friend bool operator<(custom_real l, custom_real r) {
-    return l.value_ < r.value_;
-  }
   friend bool operator>(custom_real l, custom_real r) {
     return l.value_ > r.value_;
   }
   friend bool operator<=(custom_real l, custom_real r) {
     return l.value_ <= r.value_;
-  }
-  friend bool operator>=(custom_real l, custom_real r) {
-    return l.value_ >= r.value_;
-  }
-  friend bool operator==(custom_real l, custom_real r) {
-    return l.value_ == r.value_;
-  }
-  friend bool operator!=(custom_real l, custom_real r) {
-    return l.value_ != r.value_;
   }
   friend std::ostream& operator<<(std::ostream& out, custom_real v) {
     out << v.value_;

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -3134,6 +3134,7 @@ TEST(LongDoubleTest, ASSERT_NEAR) {
   }
 }
 
+namespace {
 // a custom floating-point like type which implements the minimal interface
 // required to test EXPECT_NEAR on a custom type
 class custom_real {
@@ -3197,6 +3198,7 @@ TEST(CustomRealTest, ASSERT_NEAR) {
                          "evaluates to -1.5, and\n0.25 evaluates to 0.25.");
   }
 }
+}  // namespace
 
 // Verifies that a test or test case whose name starts with DISABLED_ is
 // not run.


### PR DESCRIPTION
The EXPECT_NEAR and ASSERT_NEAR macros expect double parameters, which potentially means loss of precision or for types with greater accuracy than double, or compile errors for types not implicitly convertible to double (gcc/intel quad precision long double, Boost.MultiPrecision, etc.).

This is essentially the same fix as the patch I submitted in issue #890. I fixed a problem where I called the wrong absolute value funciton (abs vs. fabs).

Side note: I don't know why the original bug report was closed without comment.