### PR TITLE
Fixed "make dist"

### DIFF
--- a/googlemock/Makefile.am
+++ b/googlemock/Makefile.am
@@ -129,7 +129,6 @@ EXTRA_DIST += \
 
 # Nonstandard package files for distribution.
 EXTRA_DIST += \
-  CHANGES \
   CONTRIBUTORS \
   make/Makefile
 

--- a/googletest/Makefile.am
+++ b/googletest/Makefile.am
@@ -4,7 +4,6 @@ ACLOCAL_AMFLAGS = -I m4
 
 # Nonstandard package files for distribution
 EXTRA_DIST = \
-  CHANGES \
   CONTRIBUTORS \
   LICENSE \
   include/gtest/gtest-param-test.h.pump \
@@ -22,6 +21,7 @@ GTEST_SRC = \
   src/gtest-death-test.cc \
   src/gtest-filepath.cc \
   src/gtest-internal-inl.h \
+  src/gtest-matchers.cc \
   src/gtest-port.cc \
   src/gtest-printers.cc \
   src/gtest-test-part.cc \
@@ -45,21 +45,21 @@ EXTRA_DIST += \
 
 # C++ test files that we don't compile directly.
 EXTRA_DIST += \
-  test/gtest-death-test_ex_test.cc \
-  test/gtest-death-test_test.cc \
-  test/gtest-filepath_test.cc \
-  test/gtest-listener_test.cc \
-  test/gtest-message_test.cc \
-  test/gtest-options_test.cc \
+  test/googletest-death-test_ex_test.cc \
+  test/googletest-death-test-test.cc \
+  test/googletest-filepath-test.cc \
+  test/googletest-listener-test.cc \
+  test/googletest-message-test.cc \
+  test/googletest-options-test.cc \
   test/googletest-param-test2-test.cc \
   test/googletest-param-test2-test.cc \
   test/googletest-param-test-test.cc \
   test/googletest-param-test-test.cc \
-  test/gtest-param-test_test.h \
-  test/gtest-port_test.cc \
+  test/googletest-param-test-test.h \
+  test/googletest-port-test.cc \
   test/gtest_premature_exit_test.cc \
-  test/gtest-printers_test.cc \
-  test/gtest-test-part_test.cc \
+  test/googletest-printers-test.cc \
+  test/googletest-test-part-test.cc \
   test/gtest-typed-test2_test.cc \
   test/gtest-typed-test_test.cc \
   test/gtest-typed-test_test.h \
@@ -102,7 +102,7 @@ EXTRA_DIST += \
   test/gtest_help_test.py \
   test/googletest-list-tests-unittest.py \
   test/googletest-output-test.py \
-  test/googletest-output-test_golden_lin.txt \
+  test/googletest-output-test-golden-lin.txt \
   test/googletest-shuffle-test.py \
   test/gtest_test_utils.py \
   test/googletest-throw-on-failure-test.py \
@@ -184,6 +184,7 @@ lib_libgtest_la_SOURCES = src/gtest-all.cc
 
 pkginclude_HEADERS = \
   include/gtest/gtest-death-test.h \
+  include/gtest/gtest-matchers.h \
   include/gtest/gtest-message.h \
   include/gtest/gtest-param-test.h \
   include/gtest/gtest-printers.h \


### PR DESCRIPTION
I made a few updates to the Makefile.am files so that "make dist"
succeeds and produces a usable tarball. We need this for protobuf
because the protobuf tarballs include a bundled copy of googletest.