### PR TITLE
Add missing typedefs for WINCE800 (Windows Embedded Compact 2013)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,7 @@
 workspace(name = "com_google_googletest")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 # Abseil
 http_archive(
      name = "com_google_absl",

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -22,6 +22,8 @@ macro(fix_default_compiler_settings_)
     # This replacement code is taken from sample in the CMake Wiki at
     # https://gitlab.kitware.com/cmake/community/wikis/FAQ#dynamic-replace.
     foreach (flag_var
+             CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+             CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
              CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
              CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
       if (NOT BUILD_SHARED_LIBS AND NOT gtest_force_shared_crt)

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -271,7 +271,14 @@
 #ifndef _WIN32_WCE
 # include <sys/types.h>
 # include <sys/stat.h>
-#endif  // !_WIN32_WCE
+#elif _WIN32_WCE >= 0x800 // Windows Embedded Compact 2013
+// Forward declare instead of including <windows.h> / <windef.h> / <winnt.h>
+typedef wchar_t WCHAR;
+typedef WCHAR *PWCHAR, *LPWCH, *PWCH;
+typedef const WCHAR *LPCWCH, *PCWCH;
+typedef __readableTo(sentinel(0)) const WCHAR *LPCWSTR, *PCWSTR;
+typedef const WCHAR *LPCWCHAR, *PCWCHAR;
+#endif
 
 #if defined __APPLE__
 # include <AvailabilityMacros.h>
@@ -430,6 +437,8 @@
 // MinGW defined _CRITICAL_SECTION and _RTL_CRITICAL_SECTION as two
 // separate (equivalent) structs, instead of using typedef
 typedef struct _CRITICAL_SECTION GTEST_CRITICAL_SECTION;
+#elif _WIN32_WCE >= 0x800
+typedef struct CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 #else
 // Assume CRITICAL_SECTION is a typedef of _RTL_CRITICAL_SECTION.
 // This assumption is verified by
@@ -2468,7 +2477,7 @@ inline char* StrDup(const char* src) { return _strdup(src); }
 # endif  // __BORLANDC__
 
 # if GTEST_OS_WINDOWS_MOBILE
-inline int FileNo(FILE* file) { return reinterpret_cast<int>(_fileno(file)); }
+inline int FileNo(FILE* file) { return static_cast<int>(_fileno(file)); }
 // Stat(), RmDir(), and IsDir() are not needed on Windows CE at this
 // time and thus not defined there.
 # else


### PR DESCRIPTION
Currently, 1.8.x does not compile using MSVC 1700 and WINCE800 aka. Windows Embedded Compact 2013. Use `-DGTEST_USE_OWN_TR1_TUPLE=1 -DGTEST_HAS_TR1_TUPLE=0` to compile. 

I hope that this is considered critical as it does not compile for the platform. 

Some of the errors:
```
error C2440: 'reinterpret_cast' : cannot convert from 'int' to 'int'
error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
error C2061: syntax error : identifier 'LPCWSTR'
```
