### PR TITLE
Test out changes with clang/OSX each PR using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,8 @@ matrix:
       compiler: gcc
       env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11 HOMEBREW_LOGS=~/homebrew-logs HOMEBREW_TEMP=~/homebrew-temp
     - os: osx
+      compiler: clang
       env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11 HOMEBREW_LOGS=~/homebrew-logs HOMEBREW_TEMP=~/homebrew-temp
-      if: type != pull_request
 
 # These are the install and build (script) phases for the most common entries in the matrix.  They could be included
 # in each entry in the matrix, but that is just repetitive.
@@ -73,6 +73,13 @@ addons:
     packages:
     - g++-4.9
     - clang-3.9
+    update: true
+  homebrew:
+    packages:
+    - ccache
+    - gcc@4.9
+    - llvm@3.9
+    update: true
 
 notifications:
   email: false

--- a/ci/env-osx.sh
+++ b/ci/env-osx.sh
@@ -37,5 +37,11 @@
 #
 
 if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
-    if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.9" CC="clang-3.9"; fi
+    if [ "$CXX" = "clang++" ]; then
+        # $PATH needs to be adjusted because the llvm tap doesn't install the
+        # package to /usr/local/bin, etc, like the gcc tap does.
+        # See: https://github.com/Homebrew/legacy-homebrew/issues/29733
+        clang_version=3.9
+        export PATH="/usr/local/opt/llvm@${clang_version}/bin:$PATH";
+    fi
 fi

--- a/ci/install-osx.sh
+++ b/ci/install-osx.sh
@@ -36,4 +36,5 @@ if [ "${TRAVIS_OS_NAME}" != "osx" ]; then
     exit 0
 fi
 
-brew install ccache
+brew update
+brew install ccache gcc@4.9 llvm@3.9


### PR DESCRIPTION
This will help ensure that test coverage isn't missed when changes that
can impact OSX with clang are submitted. Although not perfect, testing
changes on OSX with clang is an ok proxy [for now] for testing changes on
FreeBSD with clang (testing on FreeBSD is non-trivial, as Travis CI doesn't
support operating systems other than Linux and OSX).

In order to support this, install the packages via homebrew using a
`addons::homebrew::packages` block (similar to `addons::apt::packages`
for Ubuntu), as documented in the Travis CI docs
( https://docs.travis-ci.com/user/installing-dependencies/ ). While
here, try pushing apt* calls into the Travis config for Ubuntu, instead
of delaying the equivalent calls in the `ci/*.sh` scripts. Keep the
`ci/*.sh` scripts for ease of testing locally (and extend the OSX one to
install gcc 4.9 and llvm 3.9, like the travis config does).

In order to accomodate this change (and because the homebrew package for
llvm@3.9 doesn't automatically add clang*-3.9 to `$PATH`), `$PATH` needs
to be adjusted to find the llvm@3.9 toolchain.

This PR was originally part of #2034.