### PR TITLE
[WIP] Let's see if this unbreaks Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,10 @@ addons:
     packages:
     - g++-4.9
     - clang-3.9
-    update: true
+    # Updating the pkg repository caused Travis CI failures when trying to
+    # fetch GPG keys to check whether or not the repo was signed. Thus, updating
+    # is explicitly disabled.
+    #update: true
   homebrew:
     packages:
     - ccache


### PR DESCRIPTION
This is resulting in CI failures with the Linux images as some of the
package repositories can't be validated to determine whether or not they
are signed.

This issue was introduced in 9df5475b8267e3b6e485bcb55febd208149e96af.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>