### PR TITLE
Report the number of actually executed assertions, and the number of filtered out tests

### DIFF
--- a/googlemock/test/gmock_output_test_golden.txt
+++ b/googlemock/test/gmock_output_test_golden.txt
@@ -7,7 +7,7 @@ FILE:#: Mock function call matches EXPECT_CALL(foo_, Bar2(0, _))...
     Function call: Bar2(0, 0)
           Returns: false
 Stack trace:
-[       OK ] GMockOutputTest.ExpectedCall
+[       OK ] GMockOutputTest.ExpectedCall, 0 assertions
 [ RUN      ] GMockOutputTest.ExpectedCallToVoidFunction
 
 FILE:#: EXPECT_CALL(foo_, Bar3(0, _)) invoked
@@ -16,7 +16,7 @@ Stack trace:
 FILE:#: Mock function call matches EXPECT_CALL(foo_, Bar3(0, _))...
     Function call: Bar3(0, 0)
 Stack trace:
-[       OK ] GMockOutputTest.ExpectedCallToVoidFunction
+[       OK ] GMockOutputTest.ExpectedCallToVoidFunction, 0 assertions
 [ RUN      ] GMockOutputTest.ExplicitActionsRunOut
 
 GMOCK WARNING:
@@ -26,7 +26,7 @@ GMOCK WARNING:
 FILE:#: Actions ran out in EXPECT_CALL(foo_, Bar2(_, _))...
 Called 2 times, but only 1 WillOnce() is specified - returning default value.
 Stack trace:
-[       OK ] GMockOutputTest.ExplicitActionsRunOut
+[       OK ] GMockOutputTest.ExplicitActionsRunOut, 0 assertions
 [ RUN      ] GMockOutputTest.UnexpectedCall
 unknown file: Failure
 
@@ -40,7 +40,7 @@ FILE:#: EXPECT_CALL(foo_, Bar2(0, _))...
            Actual: 1
          Expected: to be called once
            Actual: never called - unsatisfied and active
-[  FAILED  ] GMockOutputTest.UnexpectedCall
+[  FAILED  ] GMockOutputTest.UnexpectedCall, 1 assertions
 [ RUN      ] GMockOutputTest.UnexpectedCallToVoidFunction
 unknown file: Failure
 
@@ -53,7 +53,7 @@ FILE:#: EXPECT_CALL(foo_, Bar3(0, _))...
            Actual: 1
          Expected: to be called once
            Actual: never called - unsatisfied and active
-[  FAILED  ] GMockOutputTest.UnexpectedCallToVoidFunction
+[  FAILED  ] GMockOutputTest.UnexpectedCallToVoidFunction, 1 assertions
 [ RUN      ] GMockOutputTest.ExcessiveCall
 FILE:#: Failure
 Mock function called more times than expected - returning default value.
@@ -61,14 +61,14 @@ Mock function called more times than expected - returning default value.
           Returns: false
          Expected: to be called once
            Actual: called twice - over-saturated and active
-[  FAILED  ] GMockOutputTest.ExcessiveCall
+[  FAILED  ] GMockOutputTest.ExcessiveCall, 1 assertions
 [ RUN      ] GMockOutputTest.ExcessiveCallToVoidFunction
 FILE:#: Failure
 Mock function called more times than expected - returning directly.
     Function call: Bar3(0, 1)
          Expected: to be called once
            Actual: called twice - over-saturated and active
-[  FAILED  ] GMockOutputTest.ExcessiveCallToVoidFunction
+[  FAILED  ] GMockOutputTest.ExcessiveCallToVoidFunction, 1 assertions
 [ RUN      ] GMockOutputTest.UninterestingCall
 
 GMOCK WARNING:
@@ -76,14 +76,14 @@ Uninteresting mock function call - returning default value.
     Function call: Bar2(0, 1)
           Returns: false
 NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
-[       OK ] GMockOutputTest.UninterestingCall
+[       OK ] GMockOutputTest.UninterestingCall, 0 assertions
 [ RUN      ] GMockOutputTest.UninterestingCallToVoidFunction
 
 GMOCK WARNING:
 Uninteresting mock function call - returning directly.
     Function call: Bar3(0, 1)
 NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
-[       OK ] GMockOutputTest.UninterestingCallToVoidFunction
+[       OK ] GMockOutputTest.UninterestingCallToVoidFunction, 0 assertions
 [ RUN      ] GMockOutputTest.RetiredExpectation
 unknown file: Failure
 
@@ -104,7 +104,7 @@ FILE:#: tried expectation #1: EXPECT_CALL(foo_, Bar2(0, 0))...
            Actual: 1
          Expected: to be called once
            Actual: never called - unsatisfied and active
-[  FAILED  ] GMockOutputTest.RetiredExpectation
+[  FAILED  ] GMockOutputTest.RetiredExpectation, 1 assertions
 [ RUN      ] GMockOutputTest.UnsatisfiedPrerequisite
 unknown file: Failure
 
@@ -125,7 +125,7 @@ FILE:#: pre-requisite #0
                    (end of pre-requisites)
          Expected: to be called once
            Actual: never called - unsatisfied and active
-[  FAILED  ] GMockOutputTest.UnsatisfiedPrerequisite
+[  FAILED  ] GMockOutputTest.UnsatisfiedPrerequisite, 1 assertions
 [ RUN      ] GMockOutputTest.UnsatisfiedPrerequisites
 unknown file: Failure
 
@@ -147,14 +147,14 @@ FILE:#: pre-requisite #1
                    (end of pre-requisites)
          Expected: to be called once
            Actual: never called - unsatisfied and active
-[  FAILED  ] GMockOutputTest.UnsatisfiedPrerequisites
+[  FAILED  ] GMockOutputTest.UnsatisfiedPrerequisites, 1 assertions
 [ RUN      ] GMockOutputTest.UnsatisfiedWith
 FILE:#: Failure
 Actual function call count doesn't match EXPECT_CALL(foo_, Bar2(_, _))...
     Expected args: are a pair where the first >= the second
          Expected: to be called once
            Actual: never called - unsatisfied and active
-[  FAILED  ] GMockOutputTest.UnsatisfiedWith
+[  FAILED  ] GMockOutputTest.UnsatisfiedWith, 1 assertions
 [ RUN      ] GMockOutputTest.UnsatisfiedExpectation
 FILE:#: Failure
 Actual function call count doesn't match EXPECT_CALL(foo_, Bar2(0, _))...
@@ -164,7 +164,7 @@ FILE:#: Failure
 Actual function call count doesn't match EXPECT_CALL(foo_, Bar(_, _, _))...
          Expected: to be called once
            Actual: never called - unsatisfied and active
-[  FAILED  ] GMockOutputTest.UnsatisfiedExpectation
+[  FAILED  ] GMockOutputTest.UnsatisfiedExpectation, 2 assertions
 [ RUN      ] GMockOutputTest.MismatchArguments
 unknown file: Failure
 
@@ -180,7 +180,7 @@ FILE:#: EXPECT_CALL(foo_, Bar(Ref(s), _, Ge(0)))...
            Actual: -0.1
          Expected: to be called once
            Actual: never called - unsatisfied and active
-[  FAILED  ] GMockOutputTest.MismatchArguments
+[  FAILED  ] GMockOutputTest.MismatchArguments, 1 assertions
 [ RUN      ] GMockOutputTest.MismatchWith
 unknown file: Failure
 
@@ -194,7 +194,7 @@ FILE:#: EXPECT_CALL(foo_, Bar2(Ge(2), Ge(1)))...
            Actual: don't match
          Expected: to be called once
            Actual: never called - unsatisfied and active
-[  FAILED  ] GMockOutputTest.MismatchWith
+[  FAILED  ] GMockOutputTest.MismatchWith, 1 assertions
 [ RUN      ] GMockOutputTest.MismatchArgumentsAndWith
 unknown file: Failure
 
@@ -210,7 +210,7 @@ FILE:#: EXPECT_CALL(foo_, Bar2(Ge(2), Ge(1)))...
            Actual: don't match
          Expected: to be called once
            Actual: never called - unsatisfied and active
-[  FAILED  ] GMockOutputTest.MismatchArgumentsAndWith
+[  FAILED  ] GMockOutputTest.MismatchArgumentsAndWith, 1 assertions
 [ RUN      ] GMockOutputTest.UnexpectedCallWithDefaultAction
 unknown file: Failure
 
@@ -242,7 +242,7 @@ FILE:#: EXPECT_CALL(foo_, Bar2(2, 2))...
            Actual: 0
          Expected: to be called once
            Actual: never called - unsatisfied and active
-[  FAILED  ] GMockOutputTest.UnexpectedCallWithDefaultAction
+[  FAILED  ] GMockOutputTest.UnexpectedCallWithDefaultAction, 2 assertions
 [ RUN      ] GMockOutputTest.ExcessiveCallWithDefaultAction
 FILE:#: Failure
 Mock function called more times than expected - taking default action specified at:
@@ -258,7 +258,7 @@ FILE:#:
           Returns: false
          Expected: to be called once
            Actual: called twice - over-saturated and active
-[  FAILED  ] GMockOutputTest.ExcessiveCallWithDefaultAction
+[  FAILED  ] GMockOutputTest.ExcessiveCallWithDefaultAction, 2 assertions
 [ RUN      ] GMockOutputTest.UninterestingCallWithDefaultAction
 
 GMOCK WARNING:
@@ -274,7 +274,7 @@ FILE:#:
     Function call: Bar2(1, 1)
           Returns: false
 NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect for details.
-[       OK ] GMockOutputTest.UninterestingCallWithDefaultAction
+[       OK ] GMockOutputTest.UninterestingCallWithDefaultAction, 0 assertions
 [ RUN      ] GMockOutputTest.ExplicitActionsRunOutWithDefaultAction
 
 GMOCK WARNING:
@@ -285,15 +285,15 @@ FILE:#: Actions ran out in EXPECT_CALL(foo_, Bar2(_, _))...
 Called 2 times, but only 1 WillOnce() is specified - taking default action specified at:
 FILE:#:
 Stack trace:
-[       OK ] GMockOutputTest.ExplicitActionsRunOutWithDefaultAction
+[       OK ] GMockOutputTest.ExplicitActionsRunOutWithDefaultAction, 0 assertions
 [ RUN      ] GMockOutputTest.CatchesLeakedMocks
-[       OK ] GMockOutputTest.CatchesLeakedMocks
+[       OK ] GMockOutputTest.CatchesLeakedMocks, 0 assertions
 [ RUN      ] GMockOutputTest.PrintsMatcher
 FILE:#: Failure
 Value of: (std::pair<int, bool>(42, true))
 Expected: is pair (is >= 48, true)
   Actual: (42, true) (of type std::pair<int, bool>)
-[  FAILED  ] GMockOutputTest.PrintsMatcher
+[  FAILED  ] GMockOutputTest.PrintsMatcher, 1 assertions
 [  FAILED  ] GMockOutputTest.UnexpectedCall
 [  FAILED  ] GMockOutputTest.UnexpectedCallToVoidFunction
 [  FAILED  ] GMockOutputTest.ExcessiveCall

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -596,6 +596,9 @@ class GTEST_API_ TestResult {
   // UNIX epoch.
   TimeInMillis start_timestamp() const { return start_timestamp_; }
 
+  // Return the number of assert executed with no errors in this test.
+  int success_assert_count() const { return success_assert_count_; }
+
   // Returns the i-th test part result among all the results. i can range from 0
   // to total_part_count() - 1. If i is not in that range, aborts the program.
   const TestPartResult& GetTestPartResult(int i) const;
@@ -656,6 +659,9 @@ class GTEST_API_ TestResult {
   // Increments the death test count, returning the new count.
   int increment_death_test_count() { return ++death_test_count_; }
 
+  // Increments the successful assert count, returning the new count.
+  int increment_success_assert_count(int v = 1) { return success_assert_count_ += v; }
+
   // Clears the test part results.
   void ClearTestPartResults();
 
@@ -674,6 +680,8 @@ class GTEST_API_ TestResult {
   int death_test_count_;
   // The start time, in milliseconds since UNIX Epoch.
   TimeInMillis start_timestamp_;
+  // Running count of number of successful asserts.
+  int success_assert_count_;
   // The elapsed time, in milliseconds.
   TimeInMillis elapsed_time_;
 
@@ -760,6 +768,13 @@ class GTEST_API_ TestInfo {
   // Returns the result of the test.
   const TestResult* result() const { return &result_; }
 
+  // Returns the number of executed assertions that has passed silently:
+  int success_assert_count() const { return result_.success_assert_count(); }
+
+  // Increment the number of assertions executed without errors:
+  int increment_success_assert_count(int v = 1) {
+    return result_.increment_success_assert_count(v);
+  }
  private:
 #if GTEST_HAS_DEATH_TEST
   friend class internal::DefaultDeathTestFactory;
@@ -1348,6 +1363,10 @@ class GTEST_API_ UnitTest {
 
   // Gets the elapsed time, in milliseconds.
   TimeInMillis elapsed_time() const;
+
+  // Increment the number of assertions executed without errors:
+  int increment_success_assert_count(int v = 1)
+      GTEST_LOCK_EXCLUDED_(mutex_);
 
   // Returns true if and only if the unit test passed (i.e. all test suites
   // passed).

--- a/googletest/include/gtest/gtest_pred_impl.h
+++ b/googletest/include/gtest/gtest_pred_impl.h
@@ -75,7 +75,7 @@ namespace testing {
 #define GTEST_ASSERT_(expression, on_failure) \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
   if (const ::testing::AssertionResult gtest_ar = (expression)) \
-    ; \
+    ::testing::UnitTest::GetInstance()->increment_success_assert_count(); \
   else \
     on_failure(gtest_ar.failure_message())
 

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1266,6 +1266,7 @@ constexpr bool InstantiateTypedTestCase_P_IsDeprecated() { return true; }
     } \
     catch (expected_exception const&) { \
       gtest_caught_expected = true; \
+      ::testing::UnitTest::GetInstance()->increment_success_assert_count(); \
     } \
     catch (...) { \
       gtest_msg.value = \
@@ -1306,6 +1307,7 @@ constexpr bool InstantiateTypedTestCase_P_IsDeprecated() { return true; }
     } \
     catch (...) { \
       gtest_caught_any = true; \
+      ::testing::UnitTest::GetInstance()->increment_success_assert_count(); \
     } \
     if (!gtest_caught_any) { \
       goto GTEST_CONCAT_TOKEN_(gtest_label_testanythrow_, __LINE__); \
@@ -1323,7 +1325,7 @@ constexpr bool InstantiateTypedTestCase_P_IsDeprecated() { return true; }
   GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
   if (const ::testing::AssertionResult gtest_ar_ = \
       ::testing::AssertionResult(expression)) \
-    ; \
+    ::testing::UnitTest::GetInstance()->increment_success_assert_count(); \
   else \
     fail(::testing::internal::GetBoolAssertionFailureMessage(\
         gtest_ar_, text, #actual, #expected).c_str())

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -577,6 +577,11 @@ class GTEST_API_ UnitTestImpl {
   // Gets the elapsed time, in milliseconds.
   TimeInMillis elapsed_time() const { return elapsed_time_; }
 
+  // Return the number of assert executed with no errors in this test.
+  int increment_success_assert_count(int v = 1) {
+    return current_test_info_ ? current_test_info_->increment_success_assert_count(v) : 0;
+  }
+
   // Returns true if and only if the unit test passed (i.e. all test suites
   // passed).
   bool Passed() const { return !Failed(); }

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -2026,7 +2026,11 @@ std::string AppendUserMessage(const std::string& gtest_msg,
 
 // Creates an empty TestResult.
 TestResult::TestResult()
-    : death_test_count_(0), start_timestamp_(0), elapsed_time_(0) {}
+    : death_test_count_(0),
+      start_timestamp_(0),
+      success_assert_count_(0),
+      elapsed_time_(0) {
+}
 
 // D'tor.
 TestResult::~TestResult() {
@@ -2184,6 +2188,7 @@ void TestResult::Clear() {
   test_part_results_.clear();
   test_properties_.clear();
   death_test_count_ = 0;
+  success_assert_count_ = 0;
   elapsed_time_ = 0;
 }
 
@@ -3245,6 +3250,8 @@ void PrettyUnitTestResultPrinter::OnTestEnd(const TestInfo& test_info) {
   if (test_info.result()->Failed())
     PrintFullTestCommentIfPresent(test_info);
 
+  printf(", %d assertions",
+	 test_info.result()->total_part_count() + test_info.result()->success_assert_count());
   if (GTEST_FLAG(print_time)) {
     printf(" (%s ms)\n", internal::StreamableToString(
            test_info.result()->elapsed_time()).c_str());
@@ -4696,6 +4703,13 @@ int UnitTest::test_to_run_count() const { return impl()->test_to_run_count(); }
 // UNIX epoch.
 internal::TimeInMillis UnitTest::start_timestamp() const {
     return impl()->start_timestamp();
+}
+
+// Increment the number of assertions executed without errors:
+int UnitTest::increment_success_assert_count(int v)
+  GTEST_LOCK_EXCLUDED_(mutex_) {
+  internal::MutexLock lock(&mutex_);
+  return impl_->increment_success_assert_count(v);
 }
 
 // Gets the elapsed time, in milliseconds.

--- a/googletest/test/googletest-output-test-golden-lin.txt
+++ b/googletest/test/googletest-output-test-golden-lin.txt
@@ -18,24 +18,24 @@ FooEnvironment::SetUp() called.
 BarEnvironment::SetUp() called.
 [0;32m[----------] [m1 test from ADeathTest
 [0;32m[ RUN      ] [mADeathTest.ShouldRunFirst
-[0;32m[       OK ] [mADeathTest.ShouldRunFirst
+[0;32m[       OK ] [mADeathTest.ShouldRunFirst, 0 assertions
 [0;32m[----------] [m1 test from ATypedDeathTest/0, where TypeParam = int
 [0;32m[ RUN      ] [mATypedDeathTest/0.ShouldRunFirst
-[0;32m[       OK ] [mATypedDeathTest/0.ShouldRunFirst
+[0;32m[       OK ] [mATypedDeathTest/0.ShouldRunFirst, 0 assertions
 [0;32m[----------] [m1 test from ATypedDeathTest/1, where TypeParam = double
 [0;32m[ RUN      ] [mATypedDeathTest/1.ShouldRunFirst
-[0;32m[       OK ] [mATypedDeathTest/1.ShouldRunFirst
+[0;32m[       OK ] [mATypedDeathTest/1.ShouldRunFirst, 0 assertions
 [0;32m[----------] [m1 test from My/ATypeParamDeathTest/0, where TypeParam = int
 [0;32m[ RUN      ] [mMy/ATypeParamDeathTest/0.ShouldRunFirst
-[0;32m[       OK ] [mMy/ATypeParamDeathTest/0.ShouldRunFirst
+[0;32m[       OK ] [mMy/ATypeParamDeathTest/0.ShouldRunFirst, 0 assertions
 [0;32m[----------] [m1 test from My/ATypeParamDeathTest/1, where TypeParam = double
 [0;32m[ RUN      ] [mMy/ATypeParamDeathTest/1.ShouldRunFirst
-[0;32m[       OK ] [mMy/ATypeParamDeathTest/1.ShouldRunFirst
+[0;32m[       OK ] [mMy/ATypeParamDeathTest/1.ShouldRunFirst, 0 assertions
 [0;32m[----------] [m2 tests from PassingTest
 [0;32m[ RUN      ] [mPassingTest.PassingTest1
-[0;32m[       OK ] [mPassingTest.PassingTest1
+[0;32m[       OK ] [mPassingTest.PassingTest1, 0 assertions
 [0;32m[ RUN      ] [mPassingTest.PassingTest2
-[0;32m[       OK ] [mPassingTest.PassingTest2
+[0;32m[       OK ] [mPassingTest.PassingTest2, 0 assertions
 [0;32m[----------] [m2 tests from NonfatalFailureTest
 [0;32m[ RUN      ] [mNonfatalFailureTest.EscapesStringOperands
 googletest-output-test_.cc:#: Failure
@@ -54,7 +54,7 @@ Expected equality of these values:
     Which is: "actual \"string\""
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mNonfatalFailureTest.EscapesStringOperands
+[0;31m[  FAILED  ] [mNonfatalFailureTest.EscapesStringOperands, 2 assertions
 [0;32m[ RUN      ] [mNonfatalFailureTest.DiffForLongStrings
 googletest-output-test_.cc:#: Failure
 Expected equality of these values:
@@ -68,7 +68,7 @@ With diff:
 
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mNonfatalFailureTest.DiffForLongStrings
+[0;31m[  FAILED  ] [mNonfatalFailureTest.DiffForLongStrings, 1 assertions
 [0;32m[----------] [m3 tests from FatalFailureTest
 [0;32m[ RUN      ] [mFatalFailureTest.FatalFailureInSubroutine
 (expecting a failure that x should be 1)
@@ -79,7 +79,7 @@ Expected equality of these values:
     Which is: 2
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mFatalFailureTest.FatalFailureInSubroutine
+[0;31m[  FAILED  ] [mFatalFailureTest.FatalFailureInSubroutine, 1 assertions
 [0;32m[ RUN      ] [mFatalFailureTest.FatalFailureInNestedSubroutine
 (expecting a failure that x should be 1)
 googletest-output-test_.cc:#: Failure
@@ -89,7 +89,7 @@ Expected equality of these values:
     Which is: 2
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mFatalFailureTest.FatalFailureInNestedSubroutine
+[0;31m[  FAILED  ] [mFatalFailureTest.FatalFailureInNestedSubroutine, 1 assertions
 [0;32m[ RUN      ] [mFatalFailureTest.NonfatalFailureInSubroutine
 (expecting a failure on false)
 googletest-output-test_.cc:#: Failure
@@ -98,7 +98,7 @@ Value of: false
 Expected: true
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mFatalFailureTest.NonfatalFailureInSubroutine
+[0;31m[  FAILED  ] [mFatalFailureTest.NonfatalFailureInSubroutine, 2 assertions
 [0;32m[----------] [m1 test from LoggingTest
 [0;32m[ RUN      ] [mLoggingTest.InterleavingLoggingAndAssertions
 (expecting 2 failures on (3) >= (a[i]))
@@ -114,7 +114,7 @@ googletest-output-test_.cc:#: Failure
 Expected: (3) >= (a[i]), actual: 3 vs 6
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mLoggingTest.InterleavingLoggingAndAssertions
+[0;31m[  FAILED  ] [mLoggingTest.InterleavingLoggingAndAssertions, 4 assertions
 [0;32m[----------] [m7 tests from SCOPED_TRACETest
 [0;32m[ RUN      ] [mSCOPED_TRACETest.AcceptedValues
 googletest-output-test_.cc:#: Failure
@@ -127,7 +127,7 @@ googletest-output-test_.cc:#: std::string
 googletest-output-test_.cc:#: literal string
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mSCOPED_TRACETest.AcceptedValues
+[0;31m[  FAILED  ] [mSCOPED_TRACETest.AcceptedValues, 1 assertions
 [0;32m[ RUN      ] [mSCOPED_TRACETest.ObeysScopes
 (expected to fail)
 googletest-output-test_.cc:#: Failure
@@ -147,7 +147,7 @@ Failed
 This failure is expected, and shouldn't have a trace.
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mSCOPED_TRACETest.ObeysScopes
+[0;31m[  FAILED  ] [mSCOPED_TRACETest.ObeysScopes, 3 assertions
 [0;32m[ RUN      ] [mSCOPED_TRACETest.WorksInLoop
 (expected to fail)
 googletest-output-test_.cc:#: Failure
@@ -168,7 +168,7 @@ Google Test trace:
 googletest-output-test_.cc:#: i = 2
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mSCOPED_TRACETest.WorksInLoop
+[0;31m[  FAILED  ] [mSCOPED_TRACETest.WorksInLoop, 4 assertions
 [0;32m[ RUN      ] [mSCOPED_TRACETest.WorksInSubroutine
 (expected to fail)
 googletest-output-test_.cc:#: Failure
@@ -189,7 +189,7 @@ Google Test trace:
 googletest-output-test_.cc:#: n = 2
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mSCOPED_TRACETest.WorksInSubroutine
+[0;31m[  FAILED  ] [mSCOPED_TRACETest.WorksInSubroutine, 4 assertions
 [0;32m[ RUN      ] [mSCOPED_TRACETest.CanBeNested
 (expected to fail)
 googletest-output-test_.cc:#: Failure
@@ -202,7 +202,7 @@ googletest-output-test_.cc:#: n = 2
 googletest-output-test_.cc:#: 
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mSCOPED_TRACETest.CanBeNested
+[0;31m[  FAILED  ] [mSCOPED_TRACETest.CanBeNested, 2 assertions
 [0;32m[ RUN      ] [mSCOPED_TRACETest.CanBeRepeated
 (expected to fail)
 googletest-output-test_.cc:#: Failure
@@ -238,7 +238,7 @@ googletest-output-test_.cc:#: B
 googletest-output-test_.cc:#: A
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mSCOPED_TRACETest.CanBeRepeated
+[0;31m[  FAILED  ] [mSCOPED_TRACETest.CanBeRepeated, 4 assertions
 [0;32m[ RUN      ] [mSCOPED_TRACETest.WorksConcurrently
 (expecting 6 failures)
 googletest-output-test_.cc:#: Failure
@@ -279,7 +279,7 @@ Failed
 Expected failure #6 (in thread A, no trace alive).
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mSCOPED_TRACETest.WorksConcurrently
+[0;31m[  FAILED  ] [mSCOPED_TRACETest.WorksConcurrently, 6 assertions
 [0;32m[----------] [m1 test from ScopedTraceTest
 [0;32m[ RUN      ] [mScopedTraceTest.WithExplicitFileAndLine
 googletest-output-test_.cc:#: Failure
@@ -289,7 +289,7 @@ Google Test trace:
 explicit_file.cc:123: expected trace message
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mScopedTraceTest.WithExplicitFileAndLine
+[0;31m[  FAILED  ] [mScopedTraceTest.WithExplicitFileAndLine, 1 assertions
 [0;32m[----------] [m1 test from NonFatalFailureInFixtureConstructorTest
 [0;32m[ RUN      ] [mNonFatalFailureInFixtureConstructorTest.FailureInConstructor
 (expecting 5 failures)
@@ -318,7 +318,7 @@ Failed
 Expected failure #5, in the test fixture d'tor.
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mNonFatalFailureInFixtureConstructorTest.FailureInConstructor
+[0;31m[  FAILED  ] [mNonFatalFailureInFixtureConstructorTest.FailureInConstructor, 5 assertions
 [0;32m[----------] [m1 test from FatalFailureInFixtureConstructorTest
 [0;32m[ RUN      ] [mFatalFailureInFixtureConstructorTest.FailureInConstructor
 (expecting 2 failures)
@@ -332,7 +332,7 @@ Failed
 Expected failure #2, in the test fixture d'tor.
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mFatalFailureInFixtureConstructorTest.FailureInConstructor
+[0;31m[  FAILED  ] [mFatalFailureInFixtureConstructorTest.FailureInConstructor, 2 assertions
 [0;32m[----------] [m1 test from NonFatalFailureInSetUpTest
 [0;32m[ RUN      ] [mNonFatalFailureInSetUpTest.FailureInSetUp
 (expecting 4 failures)
@@ -356,7 +356,7 @@ Failed
 Expected failure #4, in the test fixture d'tor.
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mNonFatalFailureInSetUpTest.FailureInSetUp
+[0;31m[  FAILED  ] [mNonFatalFailureInSetUpTest.FailureInSetUp, 4 assertions
 [0;32m[----------] [m1 test from FatalFailureInSetUpTest
 [0;32m[ RUN      ] [mFatalFailureInSetUpTest.FailureInSetUp
 (expecting 3 failures)
@@ -375,7 +375,7 @@ Failed
 Expected failure #3, in the test fixture d'tor.
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mFatalFailureInSetUpTest.FailureInSetUp
+[0;31m[  FAILED  ] [mFatalFailureInSetUpTest.FailureInSetUp, 3 assertions
 [0;32m[----------] [m1 test from AddFailureAtTest
 [0;32m[ RUN      ] [mAddFailureAtTest.MessageContainsSpecifiedFileAndLineNumber
 foo.cc:42: Failure
@@ -383,7 +383,7 @@ Failed
 Expected nonfatal failure in foo.cc
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mAddFailureAtTest.MessageContainsSpecifiedFileAndLineNumber
+[0;31m[  FAILED  ] [mAddFailureAtTest.MessageContainsSpecifiedFileAndLineNumber, 1 assertions
 [0;32m[----------] [m1 test from GtestFailAtTest
 [0;32m[ RUN      ] [mGtestFailAtTest.MessageContainsSpecifiedFileAndLineNumber
 foo.cc:42: Failure
@@ -391,12 +391,12 @@ Failed
 Expected fatal failure in foo.cc
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mGtestFailAtTest.MessageContainsSpecifiedFileAndLineNumber
+[0;31m[  FAILED  ] [mGtestFailAtTest.MessageContainsSpecifiedFileAndLineNumber, 1 assertions
 [0;32m[----------] [m4 tests from MixedUpTestSuiteTest
 [0;32m[ RUN      ] [mMixedUpTestSuiteTest.FirstTestFromNamespaceFoo
-[0;32m[       OK ] [mMixedUpTestSuiteTest.FirstTestFromNamespaceFoo
+[0;32m[       OK ] [mMixedUpTestSuiteTest.FirstTestFromNamespaceFoo, 0 assertions
 [0;32m[ RUN      ] [mMixedUpTestSuiteTest.SecondTestFromNamespaceFoo
-[0;32m[       OK ] [mMixedUpTestSuiteTest.SecondTestFromNamespaceFoo
+[0;32m[       OK ] [mMixedUpTestSuiteTest.SecondTestFromNamespaceFoo, 0 assertions
 [0;32m[ RUN      ] [mMixedUpTestSuiteTest.ThisShouldFail
 gtest.cc:#: Failure
 Failed
@@ -409,7 +409,7 @@ units and have the same name.  You should probably rename one
 of the classes to put the tests into different test suites.
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mMixedUpTestSuiteTest.ThisShouldFail
+[0;31m[  FAILED  ] [mMixedUpTestSuiteTest.ThisShouldFail, 1 assertions
 [0;32m[ RUN      ] [mMixedUpTestSuiteTest.ThisShouldFailToo
 gtest.cc:#: Failure
 Failed
@@ -422,10 +422,10 @@ units and have the same name.  You should probably rename one
 of the classes to put the tests into different test suites.
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mMixedUpTestSuiteTest.ThisShouldFailToo
+[0;31m[  FAILED  ] [mMixedUpTestSuiteTest.ThisShouldFailToo, 1 assertions
 [0;32m[----------] [m2 tests from MixedUpTestSuiteWithSameTestNameTest
 [0;32m[ RUN      ] [mMixedUpTestSuiteWithSameTestNameTest.TheSecondTestWithThisNameShouldFail
-[0;32m[       OK ] [mMixedUpTestSuiteWithSameTestNameTest.TheSecondTestWithThisNameShouldFail
+[0;32m[       OK ] [mMixedUpTestSuiteWithSameTestNameTest.TheSecondTestWithThisNameShouldFail, 0 assertions
 [0;32m[ RUN      ] [mMixedUpTestSuiteWithSameTestNameTest.TheSecondTestWithThisNameShouldFail
 gtest.cc:#: Failure
 Failed
@@ -438,10 +438,10 @@ units and have the same name.  You should probably rename one
 of the classes to put the tests into different test suites.
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mMixedUpTestSuiteWithSameTestNameTest.TheSecondTestWithThisNameShouldFail
+[0;31m[  FAILED  ] [mMixedUpTestSuiteWithSameTestNameTest.TheSecondTestWithThisNameShouldFail, 1 assertions
 [0;32m[----------] [m2 tests from TEST_F_before_TEST_in_same_test_case
 [0;32m[ RUN      ] [mTEST_F_before_TEST_in_same_test_case.DefinedUsingTEST_F
-[0;32m[       OK ] [mTEST_F_before_TEST_in_same_test_case.DefinedUsingTEST_F
+[0;32m[       OK ] [mTEST_F_before_TEST_in_same_test_case.DefinedUsingTEST_F, 0 assertions
 [0;32m[ RUN      ] [mTEST_F_before_TEST_in_same_test_case.DefinedUsingTESTAndShouldFail
 gtest.cc:#: Failure
 Failed
@@ -454,10 +454,10 @@ want to change the TEST to TEST_F or move it to another test
 case.
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mTEST_F_before_TEST_in_same_test_case.DefinedUsingTESTAndShouldFail
+[0;31m[  FAILED  ] [mTEST_F_before_TEST_in_same_test_case.DefinedUsingTESTAndShouldFail, 1 assertions
 [0;32m[----------] [m2 tests from TEST_before_TEST_F_in_same_test_case
 [0;32m[ RUN      ] [mTEST_before_TEST_F_in_same_test_case.DefinedUsingTEST
-[0;32m[       OK ] [mTEST_before_TEST_F_in_same_test_case.DefinedUsingTEST
+[0;32m[       OK ] [mTEST_before_TEST_F_in_same_test_case.DefinedUsingTEST, 0 assertions
 [0;32m[ RUN      ] [mTEST_before_TEST_F_in_same_test_case.DefinedUsingTEST_FAndShouldFail
 gtest.cc:#: Failure
 Failed
@@ -470,14 +470,14 @@ want to change the TEST to TEST_F or move it to another test
 case.
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mTEST_before_TEST_F_in_same_test_case.DefinedUsingTEST_FAndShouldFail
+[0;31m[  FAILED  ] [mTEST_before_TEST_F_in_same_test_case.DefinedUsingTEST_FAndShouldFail, 1 assertions
 [0;32m[----------] [m8 tests from ExpectNonfatalFailureTest
 [0;32m[ RUN      ] [mExpectNonfatalFailureTest.CanReferenceGlobalVariables
-[0;32m[       OK ] [mExpectNonfatalFailureTest.CanReferenceGlobalVariables
+[0;32m[       OK ] [mExpectNonfatalFailureTest.CanReferenceGlobalVariables, 1 assertions
 [0;32m[ RUN      ] [mExpectNonfatalFailureTest.CanReferenceLocalVariables
-[0;32m[       OK ] [mExpectNonfatalFailureTest.CanReferenceLocalVariables
+[0;32m[       OK ] [mExpectNonfatalFailureTest.CanReferenceLocalVariables, 1 assertions
 [0;32m[ RUN      ] [mExpectNonfatalFailureTest.SucceedsWhenThereIsOneNonfatalFailure
-[0;32m[       OK ] [mExpectNonfatalFailureTest.SucceedsWhenThereIsOneNonfatalFailure
+[0;32m[       OK ] [mExpectNonfatalFailureTest.SucceedsWhenThereIsOneNonfatalFailure, 1 assertions
 [0;32m[ RUN      ] [mExpectNonfatalFailureTest.FailsWhenThereIsNoNonfatalFailure
 (expecting a failure)
 gtest.cc:#: Failure
@@ -485,7 +485,7 @@ Expected: 1 non-fatal failure
   Actual: 0 failures
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mExpectNonfatalFailureTest.FailsWhenThereIsNoNonfatalFailure
+[0;31m[  FAILED  ] [mExpectNonfatalFailureTest.FailsWhenThereIsNoNonfatalFailure, 1 assertions
 [0;32m[ RUN      ] [mExpectNonfatalFailureTest.FailsWhenThereAreTwoNonfatalFailures
 (expecting a failure)
 gtest.cc:#: Failure
@@ -505,7 +505,7 @@ Stack trace: (omitted)
 
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mExpectNonfatalFailureTest.FailsWhenThereAreTwoNonfatalFailures
+[0;31m[  FAILED  ] [mExpectNonfatalFailureTest.FailsWhenThereAreTwoNonfatalFailures, 1 assertions
 [0;32m[ RUN      ] [mExpectNonfatalFailureTest.FailsWhenThereIsOneFatalFailure
 (expecting a failure)
 gtest.cc:#: Failure
@@ -519,7 +519,7 @@ Stack trace: (omitted)
 
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mExpectNonfatalFailureTest.FailsWhenThereIsOneFatalFailure
+[0;31m[  FAILED  ] [mExpectNonfatalFailureTest.FailsWhenThereIsOneFatalFailure, 1 assertions
 [0;32m[ RUN      ] [mExpectNonfatalFailureTest.FailsWhenStatementReturns
 (expecting a failure)
 gtest.cc:#: Failure
@@ -527,7 +527,7 @@ Expected: 1 non-fatal failure
   Actual: 0 failures
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mExpectNonfatalFailureTest.FailsWhenStatementReturns
+[0;31m[  FAILED  ] [mExpectNonfatalFailureTest.FailsWhenStatementReturns, 1 assertions
 [0;32m[ RUN      ] [mExpectNonfatalFailureTest.FailsWhenStatementThrows
 (expecting a failure)
 gtest.cc:#: Failure
@@ -535,14 +535,14 @@ Expected: 1 non-fatal failure
   Actual: 0 failures
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mExpectNonfatalFailureTest.FailsWhenStatementThrows
+[0;31m[  FAILED  ] [mExpectNonfatalFailureTest.FailsWhenStatementThrows, 1 assertions
 [0;32m[----------] [m8 tests from ExpectFatalFailureTest
 [0;32m[ RUN      ] [mExpectFatalFailureTest.CanReferenceGlobalVariables
-[0;32m[       OK ] [mExpectFatalFailureTest.CanReferenceGlobalVariables
+[0;32m[       OK ] [mExpectFatalFailureTest.CanReferenceGlobalVariables, 1 assertions
 [0;32m[ RUN      ] [mExpectFatalFailureTest.CanReferenceLocalStaticVariables
-[0;32m[       OK ] [mExpectFatalFailureTest.CanReferenceLocalStaticVariables
+[0;32m[       OK ] [mExpectFatalFailureTest.CanReferenceLocalStaticVariables, 1 assertions
 [0;32m[ RUN      ] [mExpectFatalFailureTest.SucceedsWhenThereIsOneFatalFailure
-[0;32m[       OK ] [mExpectFatalFailureTest.SucceedsWhenThereIsOneFatalFailure
+[0;32m[       OK ] [mExpectFatalFailureTest.SucceedsWhenThereIsOneFatalFailure, 1 assertions
 [0;32m[ RUN      ] [mExpectFatalFailureTest.FailsWhenThereIsNoFatalFailure
 (expecting a failure)
 gtest.cc:#: Failure
@@ -550,7 +550,7 @@ Expected: 1 fatal failure
   Actual: 0 failures
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mExpectFatalFailureTest.FailsWhenThereIsNoFatalFailure
+[0;31m[  FAILED  ] [mExpectFatalFailureTest.FailsWhenThereIsNoFatalFailure, 1 assertions
 [0;32m[ RUN      ] [mExpectFatalFailureTest.FailsWhenThereAreTwoFatalFailures
 (expecting a failure)
 gtest.cc:#: Failure
@@ -570,7 +570,7 @@ Stack trace: (omitted)
 
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mExpectFatalFailureTest.FailsWhenThereAreTwoFatalFailures
+[0;31m[  FAILED  ] [mExpectFatalFailureTest.FailsWhenThereAreTwoFatalFailures, 1 assertions
 [0;32m[ RUN      ] [mExpectFatalFailureTest.FailsWhenThereIsOneNonfatalFailure
 (expecting a failure)
 gtest.cc:#: Failure
@@ -584,7 +584,7 @@ Stack trace: (omitted)
 
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mExpectFatalFailureTest.FailsWhenThereIsOneNonfatalFailure
+[0;31m[  FAILED  ] [mExpectFatalFailureTest.FailsWhenThereIsOneNonfatalFailure, 1 assertions
 [0;32m[ RUN      ] [mExpectFatalFailureTest.FailsWhenStatementReturns
 (expecting a failure)
 gtest.cc:#: Failure
@@ -592,7 +592,7 @@ Expected: 1 fatal failure
   Actual: 0 failures
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mExpectFatalFailureTest.FailsWhenStatementReturns
+[0;31m[  FAILED  ] [mExpectFatalFailureTest.FailsWhenStatementReturns, 1 assertions
 [0;32m[ RUN      ] [mExpectFatalFailureTest.FailsWhenStatementThrows
 (expecting a failure)
 gtest.cc:#: Failure
@@ -600,10 +600,10 @@ Expected: 1 fatal failure
   Actual: 0 failures
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mExpectFatalFailureTest.FailsWhenStatementThrows
+[0;31m[  FAILED  ] [mExpectFatalFailureTest.FailsWhenStatementThrows, 1 assertions
 [0;32m[----------] [m2 tests from TypedTest/0, where TypeParam = int
 [0;32m[ RUN      ] [mTypedTest/0.Success
-[0;32m[       OK ] [mTypedTest/0.Success
+[0;32m[       OK ] [mTypedTest/0.Success, 1 assertions
 [0;32m[ RUN      ] [mTypedTest/0.Failure
 googletest-output-test_.cc:#: Failure
 Expected equality of these values:
@@ -613,28 +613,28 @@ Expected equality of these values:
 Expected failure
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mTypedTest/0.Failure, where TypeParam = int
+[0;31m[  FAILED  ] [mTypedTest/0.Failure, where TypeParam = int, 1 assertions
 [0;32m[----------] [m2 tests from TypedTestWithNames/char0, where TypeParam = char
 [0;32m[ RUN      ] [mTypedTestWithNames/char0.Success
-[0;32m[       OK ] [mTypedTestWithNames/char0.Success
+[0;32m[       OK ] [mTypedTestWithNames/char0.Success, 0 assertions
 [0;32m[ RUN      ] [mTypedTestWithNames/char0.Failure
 googletest-output-test_.cc:#: Failure
 Failed
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mTypedTestWithNames/char0.Failure, where TypeParam = char
+[0;31m[  FAILED  ] [mTypedTestWithNames/char0.Failure, where TypeParam = char, 1 assertions
 [0;32m[----------] [m2 tests from TypedTestWithNames/int1, where TypeParam = int
 [0;32m[ RUN      ] [mTypedTestWithNames/int1.Success
-[0;32m[       OK ] [mTypedTestWithNames/int1.Success
+[0;32m[       OK ] [mTypedTestWithNames/int1.Success, 0 assertions
 [0;32m[ RUN      ] [mTypedTestWithNames/int1.Failure
 googletest-output-test_.cc:#: Failure
 Failed
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mTypedTestWithNames/int1.Failure, where TypeParam = int
+[0;31m[  FAILED  ] [mTypedTestWithNames/int1.Failure, where TypeParam = int, 1 assertions
 [0;32m[----------] [m2 tests from Unsigned/TypedTestP/0, where TypeParam = unsigned char
 [0;32m[ RUN      ] [mUnsigned/TypedTestP/0.Success
-[0;32m[       OK ] [mUnsigned/TypedTestP/0.Success
+[0;32m[       OK ] [mUnsigned/TypedTestP/0.Success, 1 assertions
 [0;32m[ RUN      ] [mUnsigned/TypedTestP/0.Failure
 googletest-output-test_.cc:#: Failure
 Expected equality of these values:
@@ -645,10 +645,10 @@ Expected equality of these values:
 Expected failure
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mUnsigned/TypedTestP/0.Failure, where TypeParam = unsigned char
+[0;31m[  FAILED  ] [mUnsigned/TypedTestP/0.Failure, where TypeParam = unsigned char, 1 assertions
 [0;32m[----------] [m2 tests from Unsigned/TypedTestP/1, where TypeParam = unsigned int
 [0;32m[ RUN      ] [mUnsigned/TypedTestP/1.Success
-[0;32m[       OK ] [mUnsigned/TypedTestP/1.Success
+[0;32m[       OK ] [mUnsigned/TypedTestP/1.Success, 1 assertions
 [0;32m[ RUN      ] [mUnsigned/TypedTestP/1.Failure
 googletest-output-test_.cc:#: Failure
 Expected equality of these values:
@@ -659,10 +659,10 @@ Expected equality of these values:
 Expected failure
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mUnsigned/TypedTestP/1.Failure, where TypeParam = unsigned int
+[0;31m[  FAILED  ] [mUnsigned/TypedTestP/1.Failure, where TypeParam = unsigned int, 1 assertions
 [0;32m[----------] [m2 tests from UnsignedCustomName/TypedTestP/unsignedChar0, where TypeParam = unsigned char
 [0;32m[ RUN      ] [mUnsignedCustomName/TypedTestP/unsignedChar0.Success
-[0;32m[       OK ] [mUnsignedCustomName/TypedTestP/unsignedChar0.Success
+[0;32m[       OK ] [mUnsignedCustomName/TypedTestP/unsignedChar0.Success, 1 assertions
 [0;32m[ RUN      ] [mUnsignedCustomName/TypedTestP/unsignedChar0.Failure
 googletest-output-test_.cc:#: Failure
 Expected equality of these values:
@@ -673,10 +673,10 @@ Expected equality of these values:
 Expected failure
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mUnsignedCustomName/TypedTestP/unsignedChar0.Failure, where TypeParam = unsigned char
+[0;31m[  FAILED  ] [mUnsignedCustomName/TypedTestP/unsignedChar0.Failure, where TypeParam = unsigned char, 1 assertions
 [0;32m[----------] [m2 tests from UnsignedCustomName/TypedTestP/unsignedInt1, where TypeParam = unsigned int
 [0;32m[ RUN      ] [mUnsignedCustomName/TypedTestP/unsignedInt1.Success
-[0;32m[       OK ] [mUnsignedCustomName/TypedTestP/unsignedInt1.Success
+[0;32m[       OK ] [mUnsignedCustomName/TypedTestP/unsignedInt1.Success, 1 assertions
 [0;32m[ RUN      ] [mUnsignedCustomName/TypedTestP/unsignedInt1.Failure
 googletest-output-test_.cc:#: Failure
 Expected equality of these values:
@@ -687,7 +687,7 @@ Expected equality of these values:
 Expected failure
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mUnsignedCustomName/TypedTestP/unsignedInt1.Failure, where TypeParam = unsigned int
+[0;31m[  FAILED  ] [mUnsignedCustomName/TypedTestP/unsignedInt1.Failure, where TypeParam = unsigned int, 1 assertions
 [0;32m[----------] [m4 tests from ExpectFailureTest
 [0;32m[ RUN      ] [mExpectFailureTest.ExpectFatalFailure
 (expecting 1 failure)
@@ -725,7 +725,7 @@ Stack trace: (omitted)
 
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mExpectFailureTest.ExpectFatalFailure
+[0;31m[  FAILED  ] [mExpectFailureTest.ExpectFatalFailure, 3 assertions
 [0;32m[ RUN      ] [mExpectFailureTest.ExpectNonFatalFailure
 (expecting 1 failure)
 gtest.cc:#: Failure
@@ -762,7 +762,7 @@ Stack trace: (omitted)
 
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mExpectFailureTest.ExpectNonFatalFailure
+[0;31m[  FAILED  ] [mExpectFailureTest.ExpectNonFatalFailure, 3 assertions
 [0;32m[ RUN      ] [mExpectFailureTest.ExpectFatalFailureOnAllThreads
 (expecting 1 failure)
 gtest.cc:#: Failure
@@ -799,7 +799,7 @@ Stack trace: (omitted)
 
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mExpectFailureTest.ExpectFatalFailureOnAllThreads
+[0;31m[  FAILED  ] [mExpectFailureTest.ExpectFatalFailureOnAllThreads, 3 assertions
 [0;32m[ RUN      ] [mExpectFailureTest.ExpectNonFatalFailureOnAllThreads
 (expecting 1 failure)
 gtest.cc:#: Failure
@@ -836,7 +836,7 @@ Stack trace: (omitted)
 
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mExpectFailureTest.ExpectNonFatalFailureOnAllThreads
+[0;31m[  FAILED  ] [mExpectFailureTest.ExpectNonFatalFailureOnAllThreads, 3 assertions
 [0;32m[----------] [m2 tests from ExpectFailureWithThreadsTest
 [0;32m[ RUN      ] [mExpectFailureWithThreadsTest.ExpectFatalFailure
 (expecting 2 failures)
@@ -850,7 +850,7 @@ Expected: 1 fatal failure
   Actual: 0 failures
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mExpectFailureWithThreadsTest.ExpectFatalFailure
+[0;31m[  FAILED  ] [mExpectFailureWithThreadsTest.ExpectFatalFailure, 2 assertions
 [0;32m[ RUN      ] [mExpectFailureWithThreadsTest.ExpectNonFatalFailure
 (expecting 2 failures)
 googletest-output-test_.cc:#: Failure
@@ -863,7 +863,7 @@ Expected: 1 non-fatal failure
   Actual: 0 failures
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mExpectFailureWithThreadsTest.ExpectNonFatalFailure
+[0;31m[  FAILED  ] [mExpectFailureWithThreadsTest.ExpectNonFatalFailure, 2 assertions
 [0;32m[----------] [m1 test from ScopedFakeTestPartResultReporterTest
 [0;32m[ RUN      ] [mScopedFakeTestPartResultReporterTest.InterceptOnlyCurrentThread
 (expecting 2 failures)
@@ -877,7 +877,7 @@ Failed
 Expected non-fatal failure.
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mScopedFakeTestPartResultReporterTest.InterceptOnlyCurrentThread
+[0;31m[  FAILED  ] [mScopedFakeTestPartResultReporterTest.InterceptOnlyCurrentThread, 3 assertions
 [0;32m[----------] [m2 tests from DynamicFixture
 DynamicFixture::SetUpTestSuite
 [0;32m[ RUN      ] [mDynamicFixture.DynamicTestPass
@@ -885,7 +885,7 @@ DynamicFixture()
 DynamicFixture::SetUp
 DynamicFixture::TearDown
 ~DynamicFixture()
-[0;32m[       OK ] [mDynamicFixture.DynamicTestPass
+[0;32m[       OK ] [mDynamicFixture.DynamicTestPass, 1 assertions
 [0;32m[ RUN      ] [mDynamicFixture.DynamicTestFail
 DynamicFixture()
 DynamicFixture::SetUp
@@ -897,7 +897,7 @@ Stack trace: (omitted)
 
 DynamicFixture::TearDown
 ~DynamicFixture()
-[0;31m[  FAILED  ] [mDynamicFixture.DynamicTestFail
+[0;31m[  FAILED  ] [mDynamicFixture.DynamicTestFail, 1 assertions
 DynamicFixture::TearDownTestSuite
 [0;32m[----------] [m1 test from DynamicFixtureAnotherName
 DynamicFixture::SetUpTestSuite
@@ -906,7 +906,7 @@ DynamicFixture()
 DynamicFixture::SetUp
 DynamicFixture::TearDown
 ~DynamicFixture()
-[0;32m[       OK ] [mDynamicFixtureAnotherName.DynamicTestPass
+[0;32m[       OK ] [mDynamicFixtureAnotherName.DynamicTestPass, 1 assertions
 DynamicFixture::TearDownTestSuite
 [0;32m[----------] [m2 tests from BadDynamicFixture1
 DynamicFixture::SetUpTestSuite
@@ -915,7 +915,7 @@ DynamicFixture()
 DynamicFixture::SetUp
 DynamicFixture::TearDown
 ~DynamicFixture()
-[0;32m[       OK ] [mBadDynamicFixture1.FixtureBase
+[0;32m[       OK ] [mBadDynamicFixture1.FixtureBase, 1 assertions
 [0;32m[ RUN      ] [mBadDynamicFixture1.TestBase
 DynamicFixture()
 gtest.cc:#: Failure
@@ -930,7 +930,7 @@ case.
 Stack trace: (omitted)
 
 ~DynamicFixture()
-[0;31m[  FAILED  ] [mBadDynamicFixture1.TestBase
+[0;31m[  FAILED  ] [mBadDynamicFixture1.TestBase, 1 assertions
 DynamicFixture::TearDownTestSuite
 [0;32m[----------] [m2 tests from BadDynamicFixture2
 DynamicFixture::SetUpTestSuite
@@ -939,7 +939,7 @@ DynamicFixture()
 DynamicFixture::SetUp
 DynamicFixture::TearDown
 ~DynamicFixture()
-[0;32m[       OK ] [mBadDynamicFixture2.FixtureBase
+[0;32m[       OK ] [mBadDynamicFixture2.FixtureBase, 1 assertions
 [0;32m[ RUN      ] [mBadDynamicFixture2.Derived
 DynamicFixture()
 gtest.cc:#: Failure
@@ -954,7 +954,7 @@ of the classes to put the tests into different test suites.
 Stack trace: (omitted)
 
 ~DynamicFixture()
-[0;31m[  FAILED  ] [mBadDynamicFixture2.Derived
+[0;31m[  FAILED  ] [mBadDynamicFixture2.Derived, 1 assertions
 DynamicFixture::TearDownTestSuite
 [0;32m[----------] [m1 test from PrintingFailingParams/FailingParamTest
 [0;32m[ RUN      ] [mPrintingFailingParams/FailingParamTest.Fails/0
@@ -965,13 +965,13 @@ Expected equality of these values:
     Which is: 2
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mPrintingFailingParams/FailingParamTest.Fails/0, where GetParam() = 2
+[0;31m[  FAILED  ] [mPrintingFailingParams/FailingParamTest.Fails/0, where GetParam() = 2, 1 assertions
 [0;32m[----------] [m1 test from EmptyBasenameParamInst
 [0;32m[ RUN      ] [mEmptyBasenameParamInst.Passes/0
-[0;32m[       OK ] [mEmptyBasenameParamInst.Passes/0
+[0;32m[       OK ] [mEmptyBasenameParamInst.Passes/0, 1 assertions
 [0;32m[----------] [m2 tests from PrintingStrings/ParamTest
 [0;32m[ RUN      ] [mPrintingStrings/ParamTest.Success/a
-[0;32m[       OK ] [mPrintingStrings/ParamTest.Success/a
+[0;32m[       OK ] [mPrintingStrings/ParamTest.Success/a, 1 assertions
 [0;32m[ RUN      ] [mPrintingStrings/ParamTest.Failure/a
 googletest-output-test_.cc:#: Failure
 Expected equality of these values:
@@ -981,7 +981,7 @@ Expected equality of these values:
 Expected failure
 Stack trace: (omitted)
 
-[0;31m[  FAILED  ] [mPrintingStrings/ParamTest.Failure/a, where GetParam() = "a"
+[0;31m[  FAILED  ] [mPrintingStrings/ParamTest.Failure/a, where GetParam() = "a", 1 assertions
 [0;32m[----------] [mGlobal test environment tear-down
 BarEnvironment::TearDown() called.
 googletest-output-test_.cc:#: Failure
@@ -1069,7 +1069,7 @@ Expected equality of these values:
     Which is: 2
 Stack trace: (omitted)
 
-[  FAILED  ] FatalFailureTest.FatalFailureInSubroutine (? ms)
+[  FAILED  ] FatalFailureTest.FatalFailureInSubroutine, 1 assertions (? ms)
 [ RUN      ] FatalFailureTest.FatalFailureInNestedSubroutine
 (expecting a failure that x should be 1)
 googletest-output-test_.cc:#: Failure
@@ -1079,7 +1079,7 @@ Expected equality of these values:
     Which is: 2
 Stack trace: (omitted)
 
-[  FAILED  ] FatalFailureTest.FatalFailureInNestedSubroutine (? ms)
+[  FAILED  ] FatalFailureTest.FatalFailureInNestedSubroutine, 1 assertions (? ms)
 [ RUN      ] FatalFailureTest.NonfatalFailureInSubroutine
 (expecting a failure on false)
 googletest-output-test_.cc:#: Failure
@@ -1088,7 +1088,7 @@ Value of: false
 Expected: true
 Stack trace: (omitted)
 
-[  FAILED  ] FatalFailureTest.NonfatalFailureInSubroutine (? ms)
+[  FAILED  ] FatalFailureTest.NonfatalFailureInSubroutine, 2 assertions (? ms)
 [----------] 3 tests from FatalFailureTest (? ms total)
 
 [----------] 1 test from LoggingTest
@@ -1106,7 +1106,7 @@ googletest-output-test_.cc:#: Failure
 Expected: (3) >= (a[i]), actual: 3 vs 6
 Stack trace: (omitted)
 
-[  FAILED  ] LoggingTest.InterleavingLoggingAndAssertions (? ms)
+[  FAILED  ] LoggingTest.InterleavingLoggingAndAssertions, 4 assertions (? ms)
 [----------] 1 test from LoggingTest (? ms total)
 
 [----------] Global test environment tear-down
@@ -1124,7 +1124,7 @@ Note: Google Test filter = *DISABLED_*
 [----------] Global test environment set-up.
 [----------] 1 test from DisabledTestsWarningTest
 [ RUN      ] DisabledTestsWarningTest.DISABLED_AlsoRunDisabledTestsFlagSuppressesWarning
-[       OK ] DisabledTestsWarningTest.DISABLED_AlsoRunDisabledTestsFlagSuppressesWarning
+[       OK ] DisabledTestsWarningTest.DISABLED_AlsoRunDisabledTestsFlagSuppressesWarning, 0 assertions
 [----------] Global test environment tear-down
 [==========] 1 test from 1 test suite ran.
 [  PASSED  ] 1 test.
@@ -1134,7 +1134,7 @@ Note: This is test shard 2 of 2.
 [----------] Global test environment set-up.
 [----------] 1 test from PassingTest
 [ RUN      ] PassingTest.PassingTest2
-[       OK ] PassingTest.PassingTest2
+[       OK ] PassingTest.PassingTest2, 0 assertions
 [----------] Global test environment tear-down
 [==========] 1 test from 1 test suite ran.
 [  PASSED  ] 1 test.


### PR DESCRIPTION
First part of split from PR #2109

Since these are falsely dependent I'd prefer to rebase only if you decide to keep 
one but reject the other.