### PR TITLE
Remove / from parameterized test names if base test name is empty

### DIFF
--- a/googletest/include/gtest/internal/gtest-param-util.h
+++ b/googletest/include/gtest/internal/gtest-param-util.h
@@ -565,7 +565,10 @@ class ParameterizedTestSuiteInfo : public ParameterizedTestSuiteInfoBase {
 
           test_param_names.insert(param_name);
 
-          test_name_stream << test_info->test_base_name << "/" << param_name;
+	  if (!test_info->test_base_name.empty()) {
+	    test_name_stream << test_info->test_base_name << "/";
+	  }
+	  test_name_stream << param_name;
           MakeAndRegisterTestInfo(
               test_suite_name.c_str(), test_name_stream.GetString().c_str(),
               nullptr,  // No type parameter.

--- a/googletest/test/googletest-output-test-golden-lin.txt
+++ b/googletest/test/googletest-output-test-golden-lin.txt
@@ -12,7 +12,7 @@ Expected equality of these values:
   3
 Stack trace: (omitted)
 
-[0;32m[==========] [mRunning 84 tests from 39 test suites.
+[0;32m[==========] [mRunning 85 tests from 40 test suites.
 [0;32m[----------] [mGlobal test environment set-up.
 FooEnvironment::SetUp() called.
 BarEnvironment::SetUp() called.
@@ -966,6 +966,9 @@ Expected equality of these values:
 Stack trace: (omitted)
 
 [0;31m[  FAILED  ] [mPrintingFailingParams/FailingParamTest.Fails/0, where GetParam() = 2
+[0;32m[----------] [m1 test from EmptyBasenameParamInst
+[0;32m[ RUN      ] [mEmptyBasenameParamInst.Passes/0
+[0;32m[       OK ] [mEmptyBasenameParamInst.Passes/0
 [0;32m[----------] [m2 tests from PrintingStrings/ParamTest
 [0;32m[ RUN      ] [mPrintingStrings/ParamTest.Success/a
 [0;32m[       OK ] [mPrintingStrings/ParamTest.Success/a
@@ -992,8 +995,8 @@ Failed
 Expected fatal failure.
 Stack trace: (omitted)
 
-[0;32m[==========] [m84 tests from 39 test suites ran.
-[0;32m[  PASSED  ] [m30 tests.
+[0;32m[==========] [m85 tests from 40 test suites ran.
+[0;32m[  PASSED  ] [m31 tests.
 [0;31m[  FAILED  ] [m54 tests, listed below:
 [0;31m[  FAILED  ] [mNonfatalFailureTest.EscapesStringOperands
 [0;31m[  FAILED  ] [mNonfatalFailureTest.DiffForLongStrings

--- a/googletest/test/googletest-output-test_.cc
+++ b/googletest/test/googletest-output-test_.cc
@@ -96,6 +96,18 @@ INSTANTIATE_TEST_SUITE_P(PrintingFailingParams,
                          FailingParamTest,
                          testing::Values(2));
 
+// Tests that an empty value for the test suite basename yields just
+// the test name without any prior /
+class EmptyBasenameParamInst : public testing::TestWithParam<int> {};
+
+TEST_P(EmptyBasenameParamInst, Passes) {
+  EXPECT_EQ(1, GetParam());
+}
+
+INSTANTIATE_TEST_SUITE_P(,
+			 EmptyBasenameParamInst,
+                         testing::Values(1));
+
 static const char kGoldenString[] = "\"Line\0 1\"\nLine 2";
 
 TEST(NonfatalFailureTest, EscapesStringOperands) {


### PR DESCRIPTION
This is useful to let a subsystem generate test names based on parameterized tests
without exposing them as such to the user.

Signed-off-by: Knut Omang <knut.omang@oracle.com>