### PR TITLE
Stop TestInfo::Run() calling a function through null pointer

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -2675,10 +2675,12 @@ void TestInfo::Run() {
     test->Run();
   }
 
+  if (test != NULL) {
     // Deletes the test object.
     impl->os_stack_trace_getter()->UponLeavingGTest();
     internal::HandleExceptionsInMethodIfSupported(
-        test, &Test::DeleteSelf_, "the test fixture's destructor");
+	test, &Test::DeleteSelf_, "the test fixture's destructor");
+  }
 
   result_.set_elapsed_time(internal::GetTimeInMillis() - start);
 


### PR DESCRIPTION
If the object was never created then trying to call &Test::DeleteSelf_
will dereference a null pointer, with undefined behaviour.

Fixes #845