### PR TITLE
Fix -Wunused-private-field issues with clang

### DIFF
--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -982,6 +982,8 @@ class Unprintable {
   Unprintable() : c_('a') {}
 
   bool operator==(const Unprintable& /* rhs */) const { return true; }
+  // -Wunused-private-field: dummy accessor for `c_`.
+  char dummy_c() { return c_; }
  private:
   char c_;
 };

--- a/googletest/test/googletest-param-test-test.cc
+++ b/googletest/test/googletest-param-test-test.cc
@@ -964,6 +964,8 @@ INSTANTIATE_TEST_SUITE_P(StatefulNamingFunctor, StatefulNamingTest, Range(0, 5),
 class Unstreamable {
  public:
   explicit Unstreamable(int value) : value_(value) {}
+  // -Wunused-private-field: dummy accessor for `value_`.
+  const int& dummy_value() const { return value_; }
 
  private:
   int value_;


### PR DESCRIPTION
Provide dummy accessors for private values that are set in initializers,
but not actually used.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>