### PR TITLE
Fix clang `-Winconsistent-missing-override` warnings

### DIFF
--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -6943,10 +6943,10 @@ TEST(ArgsTest, ExplainsMatchResultWithoutInnerExplanation) {
 // For testing Args<>'s explanation.
 class LessThanMatcher : public MatcherInterface<std::tuple<char, int> > {
  public:
-  virtual void DescribeTo(::std::ostream* os) const {}
+  void DescribeTo(::std::ostream* os) const override {}
 
-  virtual bool MatchAndExplain(std::tuple<char, int> value,
-                               MatchResultListener* listener) const {
+  bool MatchAndExplain(std::tuple<char, int> value,
+                       MatchResultListener* listener) const override {
     const int diff = std::get<0>(value) - std::get<1>(value);
     if (diff > 0) {
       *listener << "where the first value is " << diff


### PR DESCRIPTION
`MatchAndExplain(..)` in `gmock-matchers_test` overrides a virtual method.
Remove the `virtual` keyword and apply `override` to it instead.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>