### PR TITLE
Provide a complete example for `EXPECT_NONFATAL_FAILURE(..)`

### DIFF
--- a/googletest/docs/advanced.md
+++ b/googletest/docs/advanced.md
@@ -1789,7 +1789,33 @@ current thread whose message contains the given `substring`, or use
   EXPECT_NONFATAL_FAILURE(statement, substring);
 ```
 
-if you are expecting a non-fatal (e.g. `EXPECT_*`) failure.
+if you are expecting a non-fatal (e.g. `EXPECT_*`) failure. A full example is
+as follows:
+
+```c++
+  #include <gtest/gtest.h>
+  #include <gtest/gtest-spi.h>
+
+  class TestClass {
+  public:
+    bool always_false() const {
+      return false;
+    }
+  };
+  void call_that_fails() {
+    TestClass test_obj;
+    EXPECT_EQ(test_obj.always_false(), true);
+  }
+  class FailingTest : public ::testing::Test { };
+  TEST_F(FailingTest, AlwaysFails) {
+    EXPECT_NONFATAL_FAILURE(call_that_fails(), "");
+    EXPECT_NONFATAL_FAILURE({ call_that_fails(); }, "");
+  }
+  int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+  }
+```
 
 Only failures in the current thread are checked to determine the result of this
 type of expectations. If `statement` creates new threads, failures in these


### PR DESCRIPTION
The existing example is a bit lean on details, in particular, the
headers that are required in order to use the API and the method for
calling the API.

The new example provides a fully functional test program that
demonstrates how to implement the calls, in both the non-curly brace and
curly brace form. I originally got confused when trying to augment
existing testcases (which were expected to fail on FreeBSD) in
https://github.com/google/capsicum-test/pull/36 .

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>