### PR TITLE
Added new macros to specify override or noexcept specifiers #533 #1821

### DIFF
--- a/googlemock/include/gmock/gmock-generated-function-mockers.h
+++ b/googlemock/include/gmock/gmock-generated-function-mockers.h
@@ -134,17 +134,18 @@ using internal::FunctionMocker;
     GTEST_CONCAT_TOKEN_(gmock##constness##arity##_##Method##_, __LINE__)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD0_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD0_(tn, constness, noexceptness, overrideness, ct, Method, \
+    ...) \
   static_assert(0 == \
       ::testing::internal::Function<__VA_ARGS__>::ArgumentCount, \
       "MOCK_METHOD<N> must match argument count.");\
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
-      ) constness { \
+      ) constness noexceptness overrideness { \
     GMOCK_MOCKER_(0, constness, Method).SetOwnerAndName(this, #Method); \
     return GMOCK_MOCKER_(0, constness, Method).Invoke(); \
   } \
   ::testing::MockSpec<__VA_ARGS__> \
-      gmock_##Method() constness { \
+      gmock_##Method() constness noexceptness { \
     GMOCK_MOCKER_(0, constness, Method).RegisterOwner(this); \
     return GMOCK_MOCKER_(0, constness, Method).With(); \
   } \
@@ -158,19 +159,22 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD1_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD1_(tn, constness, noexceptness, overrideness, ct, Method, \
+    ...) \
   static_assert(1 == \
       ::testing::internal::Function<__VA_ARGS__>::ArgumentCount, \
       "MOCK_METHOD<N> must match argument count.");\
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
-      GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1) constness { \
+      GMOCK_ARG_(tn, 1, \
+          __VA_ARGS__) gmock_a1) constness noexceptness overrideness { \
     GMOCK_MOCKER_(1, constness, Method).SetOwnerAndName(this, #Method); \
     return GMOCK_MOCKER_(1, constness, \
         Method).Invoke(::std::forward<GMOCK_ARG_(tn, 1, \
         __VA_ARGS__)>(gmock_a1)); \
   } \
   ::testing::MockSpec<__VA_ARGS__> \
-      gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1) constness { \
+      gmock_##Method(GMOCK_MATCHER_(tn, 1, \
+          __VA_ARGS__) gmock_a1) constness noexceptness { \
     GMOCK_MOCKER_(1, constness, Method).RegisterOwner(this); \
     return GMOCK_MOCKER_(1, constness, Method).With(gmock_a1); \
   } \
@@ -184,13 +188,14 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD2_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD2_(tn, constness, noexceptness, overrideness, ct, Method, \
+    ...) \
   static_assert(2 == \
       ::testing::internal::Function<__VA_ARGS__>::ArgumentCount, \
       "MOCK_METHOD<N> must match argument count.");\
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, GMOCK_ARG_(tn, 2, \
-          __VA_ARGS__) gmock_a2) constness { \
+          __VA_ARGS__) gmock_a2) constness noexceptness overrideness { \
     GMOCK_MOCKER_(2, constness, Method).SetOwnerAndName(this, #Method); \
     return GMOCK_MOCKER_(2, constness, \
         Method).Invoke(::std::forward<GMOCK_ARG_(tn, 1, \
@@ -199,7 +204,8 @@ using internal::FunctionMocker;
   } \
   ::testing::MockSpec<__VA_ARGS__> \
       gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
-                     GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2) constness { \
+                     GMOCK_MATCHER_(tn, 2, \
+                         __VA_ARGS__) gmock_a2) constness noexceptness { \
     GMOCK_MOCKER_(2, constness, Method).RegisterOwner(this); \
     return GMOCK_MOCKER_(2, constness, Method).With(gmock_a1, gmock_a2); \
   } \
@@ -214,14 +220,15 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD3_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD3_(tn, constness, noexceptness, overrideness, ct, Method, \
+    ...) \
   static_assert(3 == \
       ::testing::internal::Function<__VA_ARGS__>::ArgumentCount, \
       "MOCK_METHOD<N> must match argument count.");\
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, GMOCK_ARG_(tn, 2, \
           __VA_ARGS__) gmock_a2, GMOCK_ARG_(tn, 3, \
-          __VA_ARGS__) gmock_a3) constness { \
+          __VA_ARGS__) gmock_a3) constness noexceptness overrideness { \
     GMOCK_MOCKER_(3, constness, Method).SetOwnerAndName(this, #Method); \
     return GMOCK_MOCKER_(3, constness, \
         Method).Invoke(::std::forward<GMOCK_ARG_(tn, 1, \
@@ -232,7 +239,8 @@ using internal::FunctionMocker;
   ::testing::MockSpec<__VA_ARGS__> \
       gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
                      GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2, \
-                     GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3) constness { \
+                     GMOCK_MATCHER_(tn, 3, \
+                         __VA_ARGS__) gmock_a3) constness noexceptness { \
     GMOCK_MOCKER_(3, constness, Method).RegisterOwner(this); \
     return GMOCK_MOCKER_(3, constness, Method).With(gmock_a1, gmock_a2, \
         gmock_a3); \
@@ -249,14 +257,16 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD4_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD4_(tn, constness, noexceptness, overrideness, ct, Method, \
+    ...) \
   static_assert(4 == \
       ::testing::internal::Function<__VA_ARGS__>::ArgumentCount, \
       "MOCK_METHOD<N> must match argument count.");\
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, GMOCK_ARG_(tn, 2, \
           __VA_ARGS__) gmock_a2, GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
-          GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4) constness { \
+          GMOCK_ARG_(tn, 4, \
+          __VA_ARGS__) gmock_a4) constness noexceptness overrideness { \
     GMOCK_MOCKER_(4, constness, Method).SetOwnerAndName(this, #Method); \
     return GMOCK_MOCKER_(4, constness, \
         Method).Invoke(::std::forward<GMOCK_ARG_(tn, 1, \
@@ -269,7 +279,8 @@ using internal::FunctionMocker;
       gmock_##Method(GMOCK_MATCHER_(tn, 1, __VA_ARGS__) gmock_a1, \
                      GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2, \
                      GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3, \
-                     GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4) constness { \
+                     GMOCK_MATCHER_(tn, 4, \
+                         __VA_ARGS__) gmock_a4) constness noexceptness { \
     GMOCK_MOCKER_(4, constness, Method).RegisterOwner(this); \
     return GMOCK_MOCKER_(4, constness, Method).With(gmock_a1, gmock_a2, \
         gmock_a3, gmock_a4); \
@@ -287,7 +298,8 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD5_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD5_(tn, constness, noexceptness, overrideness, ct, Method, \
+    ...) \
   static_assert(5 == \
       ::testing::internal::Function<__VA_ARGS__>::ArgumentCount, \
       "MOCK_METHOD<N> must match argument count.");\
@@ -295,7 +307,7 @@ using internal::FunctionMocker;
       GMOCK_ARG_(tn, 1, __VA_ARGS__) gmock_a1, GMOCK_ARG_(tn, 2, \
           __VA_ARGS__) gmock_a2, GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
           GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, GMOCK_ARG_(tn, 5, \
-          __VA_ARGS__) gmock_a5) constness { \
+          __VA_ARGS__) gmock_a5) constness noexceptness overrideness { \
     GMOCK_MOCKER_(5, constness, Method).SetOwnerAndName(this, #Method); \
     return GMOCK_MOCKER_(5, constness, \
         Method).Invoke(::std::forward<GMOCK_ARG_(tn, 1, \
@@ -310,7 +322,8 @@ using internal::FunctionMocker;
                      GMOCK_MATCHER_(tn, 2, __VA_ARGS__) gmock_a2, \
                      GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3, \
                      GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4, \
-                     GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5) constness { \
+                     GMOCK_MATCHER_(tn, 5, \
+                         __VA_ARGS__) gmock_a5) constness noexceptness { \
     GMOCK_MOCKER_(5, constness, Method).RegisterOwner(this); \
     return GMOCK_MOCKER_(5, constness, Method).With(gmock_a1, gmock_a2, \
         gmock_a3, gmock_a4, gmock_a5); \
@@ -329,7 +342,8 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD6_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD6_(tn, constness, noexceptness, overrideness, ct, Method, \
+    ...) \
   static_assert(6 == \
       ::testing::internal::Function<__VA_ARGS__>::ArgumentCount, \
       "MOCK_METHOD<N> must match argument count.");\
@@ -338,7 +352,7 @@ using internal::FunctionMocker;
           __VA_ARGS__) gmock_a2, GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
           GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, GMOCK_ARG_(tn, 5, \
           __VA_ARGS__) gmock_a5, GMOCK_ARG_(tn, 6, \
-          __VA_ARGS__) gmock_a6) constness { \
+          __VA_ARGS__) gmock_a6) constness noexceptness overrideness { \
     GMOCK_MOCKER_(6, constness, Method).SetOwnerAndName(this, #Method); \
     return GMOCK_MOCKER_(6, constness, \
         Method).Invoke(::std::forward<GMOCK_ARG_(tn, 1, \
@@ -355,7 +369,8 @@ using internal::FunctionMocker;
                      GMOCK_MATCHER_(tn, 3, __VA_ARGS__) gmock_a3, \
                      GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4, \
                      GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5, \
-                     GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6) constness { \
+                     GMOCK_MATCHER_(tn, 6, \
+                         __VA_ARGS__) gmock_a6) constness noexceptness { \
     GMOCK_MOCKER_(6, constness, Method).RegisterOwner(this); \
     return GMOCK_MOCKER_(6, constness, Method).With(gmock_a1, gmock_a2, \
         gmock_a3, gmock_a4, gmock_a5, gmock_a6); \
@@ -375,7 +390,8 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD7_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD7_(tn, constness, noexceptness, overrideness, ct, Method, \
+    ...) \
   static_assert(7 == \
       ::testing::internal::Function<__VA_ARGS__>::ArgumentCount, \
       "MOCK_METHOD<N> must match argument count.");\
@@ -384,7 +400,8 @@ using internal::FunctionMocker;
           __VA_ARGS__) gmock_a2, GMOCK_ARG_(tn, 3, __VA_ARGS__) gmock_a3, \
           GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, GMOCK_ARG_(tn, 5, \
           __VA_ARGS__) gmock_a5, GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
-          GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7) constness { \
+          GMOCK_ARG_(tn, 7, \
+          __VA_ARGS__) gmock_a7) constness noexceptness overrideness { \
     GMOCK_MOCKER_(7, constness, Method).SetOwnerAndName(this, #Method); \
     return GMOCK_MOCKER_(7, constness, \
         Method).Invoke(::std::forward<GMOCK_ARG_(tn, 1, \
@@ -403,7 +420,8 @@ using internal::FunctionMocker;
                      GMOCK_MATCHER_(tn, 4, __VA_ARGS__) gmock_a4, \
                      GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5, \
                      GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6, \
-                     GMOCK_MATCHER_(tn, 7, __VA_ARGS__) gmock_a7) constness { \
+                     GMOCK_MATCHER_(tn, 7, \
+                         __VA_ARGS__) gmock_a7) constness noexceptness { \
     GMOCK_MOCKER_(7, constness, Method).RegisterOwner(this); \
     return GMOCK_MOCKER_(7, constness, Method).With(gmock_a1, gmock_a2, \
         gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7); \
@@ -424,7 +442,8 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD8_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD8_(tn, constness, noexceptness, overrideness, ct, Method, \
+    ...) \
   static_assert(8 == \
       ::testing::internal::Function<__VA_ARGS__>::ArgumentCount, \
       "MOCK_METHOD<N> must match argument count.");\
@@ -434,7 +453,7 @@ using internal::FunctionMocker;
           GMOCK_ARG_(tn, 4, __VA_ARGS__) gmock_a4, GMOCK_ARG_(tn, 5, \
           __VA_ARGS__) gmock_a5, GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
           GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7, GMOCK_ARG_(tn, 8, \
-          __VA_ARGS__) gmock_a8) constness { \
+          __VA_ARGS__) gmock_a8) constness noexceptness overrideness { \
     GMOCK_MOCKER_(8, constness, Method).SetOwnerAndName(this, #Method); \
     return GMOCK_MOCKER_(8, constness, \
         Method).Invoke(::std::forward<GMOCK_ARG_(tn, 1, \
@@ -455,7 +474,8 @@ using internal::FunctionMocker;
                      GMOCK_MATCHER_(tn, 5, __VA_ARGS__) gmock_a5, \
                      GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6, \
                      GMOCK_MATCHER_(tn, 7, __VA_ARGS__) gmock_a7, \
-                     GMOCK_MATCHER_(tn, 8, __VA_ARGS__) gmock_a8) constness { \
+                     GMOCK_MATCHER_(tn, 8, \
+                         __VA_ARGS__) gmock_a8) constness noexceptness { \
     GMOCK_MOCKER_(8, constness, Method).RegisterOwner(this); \
     return GMOCK_MOCKER_(8, constness, Method).With(gmock_a1, gmock_a2, \
         gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8); \
@@ -477,7 +497,8 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD9_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD9_(tn, constness, noexceptness, overrideness, ct, Method, \
+    ...) \
   static_assert(9 == \
       ::testing::internal::Function<__VA_ARGS__>::ArgumentCount, \
       "MOCK_METHOD<N> must match argument count.");\
@@ -488,7 +509,7 @@ using internal::FunctionMocker;
           __VA_ARGS__) gmock_a5, GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
           GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7, GMOCK_ARG_(tn, 8, \
           __VA_ARGS__) gmock_a8, GMOCK_ARG_(tn, 9, \
-          __VA_ARGS__) gmock_a9) constness { \
+          __VA_ARGS__) gmock_a9) constness noexceptness overrideness { \
     GMOCK_MOCKER_(9, constness, Method).SetOwnerAndName(this, #Method); \
     return GMOCK_MOCKER_(9, constness, \
         Method).Invoke(::std::forward<GMOCK_ARG_(tn, 1, \
@@ -511,7 +532,8 @@ using internal::FunctionMocker;
                      GMOCK_MATCHER_(tn, 6, __VA_ARGS__) gmock_a6, \
                      GMOCK_MATCHER_(tn, 7, __VA_ARGS__) gmock_a7, \
                      GMOCK_MATCHER_(tn, 8, __VA_ARGS__) gmock_a8, \
-                     GMOCK_MATCHER_(tn, 9, __VA_ARGS__) gmock_a9) constness { \
+                     GMOCK_MATCHER_(tn, 9, \
+                         __VA_ARGS__) gmock_a9) constness noexceptness { \
     GMOCK_MOCKER_(9, constness, Method).RegisterOwner(this); \
     return GMOCK_MOCKER_(9, constness, Method).With(gmock_a1, gmock_a2, \
         gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, \
@@ -535,7 +557,8 @@ using internal::FunctionMocker;
       Method)
 
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD10_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD10_(tn, constness, noexceptness, overrideness, ct, \
+    Method, ...) \
   static_assert(10 == \
       ::testing::internal::Function<__VA_ARGS__>::ArgumentCount, \
       "MOCK_METHOD<N> must match argument count.");\
@@ -546,7 +569,8 @@ using internal::FunctionMocker;
           __VA_ARGS__) gmock_a5, GMOCK_ARG_(tn, 6, __VA_ARGS__) gmock_a6, \
           GMOCK_ARG_(tn, 7, __VA_ARGS__) gmock_a7, GMOCK_ARG_(tn, 8, \
           __VA_ARGS__) gmock_a8, GMOCK_ARG_(tn, 9, __VA_ARGS__) gmock_a9, \
-          GMOCK_ARG_(tn, 10, __VA_ARGS__) gmock_a10) constness { \
+          GMOCK_ARG_(tn, 10, \
+          __VA_ARGS__) gmock_a10) constness noexceptness overrideness { \
     GMOCK_MOCKER_(10, constness, Method).SetOwnerAndName(this, #Method); \
     return GMOCK_MOCKER_(10, constness, \
         Method).Invoke(::std::forward<GMOCK_ARG_(tn, 1, \
@@ -572,7 +596,7 @@ using internal::FunctionMocker;
                      GMOCK_MATCHER_(tn, 8, __VA_ARGS__) gmock_a8, \
                      GMOCK_MATCHER_(tn, 9, __VA_ARGS__) gmock_a9, \
                      GMOCK_MATCHER_(tn, 10, \
-                         __VA_ARGS__) gmock_a10) constness { \
+                         __VA_ARGS__) gmock_a10) constness noexceptness { \
     GMOCK_MOCKER_(10, constness, Method).RegisterOwner(this); \
     return GMOCK_MOCKER_(10, constness, Method).With(gmock_a1, gmock_a2, \
         gmock_a3, gmock_a4, gmock_a5, gmock_a6, gmock_a7, gmock_a8, gmock_a9, \
@@ -596,156 +620,316 @@ using internal::FunctionMocker;
   mutable ::testing::FunctionMocker<__VA_ARGS__> GMOCK_MOCKER_(10, constness, \
       Method)
 
-#define MOCK_METHOD0(m, ...) GMOCK_METHOD0_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD1(m, ...) GMOCK_METHOD1_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD2(m, ...) GMOCK_METHOD2_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD3(m, ...) GMOCK_METHOD3_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD4(m, ...) GMOCK_METHOD4_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD5(m, ...) GMOCK_METHOD5_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD6(m, ...) GMOCK_METHOD6_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD7(m, ...) GMOCK_METHOD7_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD8(m, ...) GMOCK_METHOD8_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD9(m, ...) GMOCK_METHOD9_(, , , m, __VA_ARGS__)
-#define MOCK_METHOD10(m, ...) GMOCK_METHOD10_(, , , m, __VA_ARGS__)
+#define MOCK_METHOD0(m, ...) GMOCK_METHOD0_(, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD1(m, ...) GMOCK_METHOD1_(, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD2(m, ...) GMOCK_METHOD2_(, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD3(m, ...) GMOCK_METHOD3_(, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD4(m, ...) GMOCK_METHOD4_(, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD5(m, ...) GMOCK_METHOD5_(, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD6(m, ...) GMOCK_METHOD6_(, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD7(m, ...) GMOCK_METHOD7_(, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD8(m, ...) GMOCK_METHOD8_(, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD9(m, ...) GMOCK_METHOD9_(, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD10(m, ...) GMOCK_METHOD10_(, , , , , m, __VA_ARGS__)
 
-#define MOCK_CONST_METHOD0(m, ...) GMOCK_METHOD0_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD1(m, ...) GMOCK_METHOD1_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD2(m, ...) GMOCK_METHOD2_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD3(m, ...) GMOCK_METHOD3_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD4(m, ...) GMOCK_METHOD4_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD5(m, ...) GMOCK_METHOD5_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD6(m, ...) GMOCK_METHOD6_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD7(m, ...) GMOCK_METHOD7_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD8(m, ...) GMOCK_METHOD8_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD9(m, ...) GMOCK_METHOD9_(, const, , m, __VA_ARGS__)
-#define MOCK_CONST_METHOD10(m, ...) GMOCK_METHOD10_(, const, , m, __VA_ARGS__)
+#define MOCK_CONST_METHOD0(m, ...) GMOCK_METHOD0_(, const, , , , m, __VA_ARGS__)
+#define MOCK_CONST_METHOD1(m, ...) GMOCK_METHOD1_(, const, , , , m, __VA_ARGS__)
+#define MOCK_CONST_METHOD2(m, ...) GMOCK_METHOD2_(, const, , , , m, __VA_ARGS__)
+#define MOCK_CONST_METHOD3(m, ...) GMOCK_METHOD3_(, const, , , , m, __VA_ARGS__)
+#define MOCK_CONST_METHOD4(m, ...) GMOCK_METHOD4_(, const, , , , m, __VA_ARGS__)
+#define MOCK_CONST_METHOD5(m, ...) GMOCK_METHOD5_(, const, , , , m, __VA_ARGS__)
+#define MOCK_CONST_METHOD6(m, ...) GMOCK_METHOD6_(, const, , , , m, __VA_ARGS__)
+#define MOCK_CONST_METHOD7(m, ...) GMOCK_METHOD7_(, const, , , , m, __VA_ARGS__)
+#define MOCK_CONST_METHOD8(m, ...) GMOCK_METHOD8_(, const, , , , m, __VA_ARGS__)
+#define MOCK_CONST_METHOD9(m, ...) GMOCK_METHOD9_(, const, , , , m, __VA_ARGS__)
+#define MOCK_CONST_METHOD10(m, ...) GMOCK_METHOD10_(, const, , , , m, \
+    __VA_ARGS__)
 
-#define MOCK_METHOD0_T(m, ...) GMOCK_METHOD0_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD1_T(m, ...) GMOCK_METHOD1_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD2_T(m, ...) GMOCK_METHOD2_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD3_T(m, ...) GMOCK_METHOD3_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD4_T(m, ...) GMOCK_METHOD4_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD5_T(m, ...) GMOCK_METHOD5_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD6_T(m, ...) GMOCK_METHOD6_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD7_T(m, ...) GMOCK_METHOD7_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD8_T(m, ...) GMOCK_METHOD8_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD9_T(m, ...) GMOCK_METHOD9_(typename, , , m, __VA_ARGS__)
-#define MOCK_METHOD10_T(m, ...) GMOCK_METHOD10_(typename, , , m, __VA_ARGS__)
+#define MOCK_VIRTUAL_METHOD0(m, ...) GMOCK_METHOD0_(, , , override , , m, \
+    __VA_ARGS__)
+#define MOCK_VIRTUAL_METHOD1(m, ...) GMOCK_METHOD1_(, , , override , , m, \
+    __VA_ARGS__)
+#define MOCK_VIRTUAL_METHOD2(m, ...) GMOCK_METHOD2_(, , , override , , m, \
+    __VA_ARGS__)
+#define MOCK_VIRTUAL_METHOD3(m, ...) GMOCK_METHOD3_(, , , override , , m, \
+    __VA_ARGS__)
+#define MOCK_VIRTUAL_METHOD4(m, ...) GMOCK_METHOD4_(, , , override , , m, \
+    __VA_ARGS__)
+#define MOCK_VIRTUAL_METHOD5(m, ...) GMOCK_METHOD5_(, , , override , , m, \
+    __VA_ARGS__)
+#define MOCK_VIRTUAL_METHOD6(m, ...) GMOCK_METHOD6_(, , , override , , m, \
+    __VA_ARGS__)
+#define MOCK_VIRTUAL_METHOD7(m, ...) GMOCK_METHOD7_(, , , override , , m, \
+    __VA_ARGS__)
+#define MOCK_VIRTUAL_METHOD8(m, ...) GMOCK_METHOD8_(, , , override , , m, \
+    __VA_ARGS__)
+#define MOCK_VIRTUAL_METHOD9(m, ...) GMOCK_METHOD9_(, , , override , , m, \
+    __VA_ARGS__)
+#define MOCK_VIRTUAL_METHOD10(m, ...) GMOCK_METHOD10_(, , , override , , m, \
+    __VA_ARGS__)
+
+#define MOCK_NOEXCEPT_METHOD0(m, ...) GMOCK_METHOD0_(, , noexcept, , , m, \
+    __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD1(m, ...) GMOCK_METHOD1_(, , noexcept, , , m, \
+    __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD2(m, ...) GMOCK_METHOD2_(, , noexcept, , , m, \
+    __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD3(m, ...) GMOCK_METHOD3_(, , noexcept, , , m, \
+    __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD4(m, ...) GMOCK_METHOD4_(, , noexcept, , , m, \
+    __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD5(m, ...) GMOCK_METHOD5_(, , noexcept, , , m, \
+    __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD6(m, ...) GMOCK_METHOD6_(, , noexcept, , , m, \
+    __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD7(m, ...) GMOCK_METHOD7_(, , noexcept, , , m, \
+    __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD8(m, ...) GMOCK_METHOD8_(, , noexcept, , , m, \
+    __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD9(m, ...) GMOCK_METHOD9_(, , noexcept, , , m, \
+    __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD10(m, ...) GMOCK_METHOD10_(, , noexcept, , , m, \
+    __VA_ARGS__)
+
+#define MOCK_CONST_VIRTUAL_METHOD0(m, ...) GMOCK_METHOD0_(, const, , \
+    override, , m, __VA_ARGS__)
+#define MOCK_CONST_VIRTUAL_METHOD1(m, ...) GMOCK_METHOD1_(, const, , \
+    override, , m, __VA_ARGS__)
+#define MOCK_CONST_VIRTUAL_METHOD2(m, ...) GMOCK_METHOD2_(, const, , \
+    override, , m, __VA_ARGS__)
+#define MOCK_CONST_VIRTUAL_METHOD3(m, ...) GMOCK_METHOD3_(, const, , \
+    override, , m, __VA_ARGS__)
+#define MOCK_CONST_VIRTUAL_METHOD4(m, ...) GMOCK_METHOD4_(, const, , \
+    override, , m, __VA_ARGS__)
+#define MOCK_CONST_VIRTUAL_METHOD5(m, ...) GMOCK_METHOD5_(, const, , \
+    override, , m, __VA_ARGS__)
+#define MOCK_CONST_VIRTUAL_METHOD6(m, ...) GMOCK_METHOD6_(, const, , \
+    override, , m, __VA_ARGS__)
+#define MOCK_CONST_VIRTUAL_METHOD7(m, ...) GMOCK_METHOD7_(, const, , \
+    override, , m, __VA_ARGS__)
+#define MOCK_CONST_VIRTUAL_METHOD8(m, ...) GMOCK_METHOD8_(, const, , \
+    override, , m, __VA_ARGS__)
+#define MOCK_CONST_VIRTUAL_METHOD9(m, ...) GMOCK_METHOD9_(, const, , \
+    override, , m, __VA_ARGS__)
+#define MOCK_CONST_VIRTUAL_METHOD10(m, ...) GMOCK_METHOD10_(, const, , \
+    override, , m, __VA_ARGS__)
+
+#define MOCK_NOEXCEPT_VIRTUAL_METHOD0(m, ...) GMOCK_METHOD0_(, , noexcept, \
+    override, , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_VIRTUAL_METHOD1(m, ...) GMOCK_METHOD1_(, , noexcept, \
+    override, , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_VIRTUAL_METHOD2(m, ...) GMOCK_METHOD2_(, , noexcept, \
+    override, , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_VIRTUAL_METHOD3(m, ...) GMOCK_METHOD3_(, , noexcept, \
+    override, , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_VIRTUAL_METHOD4(m, ...) GMOCK_METHOD4_(, , noexcept, \
+    override, , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_VIRTUAL_METHOD5(m, ...) GMOCK_METHOD5_(, , noexcept, \
+    override, , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_VIRTUAL_METHOD6(m, ...) GMOCK_METHOD6_(, , noexcept, \
+    override, , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_VIRTUAL_METHOD7(m, ...) GMOCK_METHOD7_(, , noexcept, \
+    override, , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_VIRTUAL_METHOD8(m, ...) GMOCK_METHOD8_(, , noexcept, \
+    override, , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_VIRTUAL_METHOD9(m, ...) GMOCK_METHOD9_(, , noexcept, \
+    override, , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_VIRTUAL_METHOD10(m, ...) GMOCK_METHOD10_(, , noexcept, \
+    override, , m, __VA_ARGS__)
+
+#define MOCK_CONST_NOEXCEPT_VIRTUAL_METHOD0(m, ...) GMOCK_METHOD0_(, const, \
+    noexcept, override, , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_VIRTUAL_METHOD1(m, ...) GMOCK_METHOD1_(, const, \
+    noexcept, override, , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_VIRTUAL_METHOD2(m, ...) GMOCK_METHOD2_(, const, \
+    noexcept, override, , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_VIRTUAL_METHOD3(m, ...) GMOCK_METHOD3_(, const, \
+    noexcept, override, , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_VIRTUAL_METHOD4(m, ...) GMOCK_METHOD4_(, const, \
+    noexcept, override, , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_VIRTUAL_METHOD5(m, ...) GMOCK_METHOD5_(, const, \
+    noexcept, override, , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_VIRTUAL_METHOD6(m, ...) GMOCK_METHOD6_(, const, \
+    noexcept, override, , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_VIRTUAL_METHOD7(m, ...) GMOCK_METHOD7_(, const, \
+    noexcept, override, , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_VIRTUAL_METHOD8(m, ...) GMOCK_METHOD8_(, const, \
+    noexcept, override, , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_VIRTUAL_METHOD9(m, ...) GMOCK_METHOD9_(, const, \
+    noexcept, override, , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_VIRTUAL_METHOD10(m, ...) GMOCK_METHOD10_(, const, \
+    noexcept, override, , m, __VA_ARGS__)
+
+#define MOCK_METHOD0_T(m, ...) GMOCK_METHOD0_(typename, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD1_T(m, ...) GMOCK_METHOD1_(typename, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD2_T(m, ...) GMOCK_METHOD2_(typename, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD3_T(m, ...) GMOCK_METHOD3_(typename, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD4_T(m, ...) GMOCK_METHOD4_(typename, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD5_T(m, ...) GMOCK_METHOD5_(typename, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD6_T(m, ...) GMOCK_METHOD6_(typename, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD7_T(m, ...) GMOCK_METHOD7_(typename, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD8_T(m, ...) GMOCK_METHOD8_(typename, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD9_T(m, ...) GMOCK_METHOD9_(typename, , , , , m, __VA_ARGS__)
+#define MOCK_METHOD10_T(m, ...) GMOCK_METHOD10_(typename, , , , , m, \
+    __VA_ARGS__)
 
 #define MOCK_CONST_METHOD0_T(m, ...) \
-    GMOCK_METHOD0_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD0_(typename, const, , , , m, __VA_ARGS__)
 #define MOCK_CONST_METHOD1_T(m, ...) \
-    GMOCK_METHOD1_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD1_(typename, const, , , , m, __VA_ARGS__)
 #define MOCK_CONST_METHOD2_T(m, ...) \
-    GMOCK_METHOD2_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD2_(typename, const, , , , m, __VA_ARGS__)
 #define MOCK_CONST_METHOD3_T(m, ...) \
-    GMOCK_METHOD3_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD3_(typename, const, , , , m, __VA_ARGS__)
 #define MOCK_CONST_METHOD4_T(m, ...) \
-    GMOCK_METHOD4_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD4_(typename, const, , , , m, __VA_ARGS__)
 #define MOCK_CONST_METHOD5_T(m, ...) \
-    GMOCK_METHOD5_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD5_(typename, const, , , , m, __VA_ARGS__)
 #define MOCK_CONST_METHOD6_T(m, ...) \
-    GMOCK_METHOD6_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD6_(typename, const, , , , m, __VA_ARGS__)
 #define MOCK_CONST_METHOD7_T(m, ...) \
-    GMOCK_METHOD7_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD7_(typename, const, , , , m, __VA_ARGS__)
 #define MOCK_CONST_METHOD8_T(m, ...) \
-    GMOCK_METHOD8_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD8_(typename, const, , , , m, __VA_ARGS__)
 #define MOCK_CONST_METHOD9_T(m, ...) \
-    GMOCK_METHOD9_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD9_(typename, const, , , , m, __VA_ARGS__)
 #define MOCK_CONST_METHOD10_T(m, ...) \
-    GMOCK_METHOD10_(typename, const, , m, __VA_ARGS__)
-
+    GMOCK_METHOD10_(typename, const, , , , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD0_T(m, ...) \
+    GMOCK_METHOD0_(typename, , noexcept, , , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD1_T(m, ...) \
+    GMOCK_METHOD1_(typename, , noexcept, , , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD2_T(m, ...) \
+    GMOCK_METHOD2_(typename, , noexcept, , , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD3_T(m, ...) \
+    GMOCK_METHOD3_(typename, , noexcept, , , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD4_T(m, ...) \
+    GMOCK_METHOD4_(typename, , noexcept, , , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD5_T(m, ...) \
+    GMOCK_METHOD5_(typename, , noexcept, , , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD6_T(m, ...) \
+    GMOCK_METHOD6_(typename, , noexcept, , , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD7_T(m, ...) \
+    GMOCK_METHOD7_(typename, , noexcept, , , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD8_T(m, ...) \
+    GMOCK_METHOD8_(typename, , noexcept, , , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD9_T(m, ...) \
+    GMOCK_METHOD9_(typename, , noexcept, , , m, __VA_ARGS__)
+#define MOCK_NOEXCEPT_METHOD10_T(m, ...) \
+    GMOCK_METHOD10_(typename, , noexcept, , , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_METHOD0_T(m, ...) \
+    GMOCK_METHOD0_(typename, const, noexcept, , , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_METHOD1_T(m, ...) \
+    GMOCK_METHOD1_(typename, const, noexcept, , , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_METHOD2_T(m, ...) \
+    GMOCK_METHOD2_(typename, const, noexcept, , , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_METHOD3_T(m, ...) \
+    GMOCK_METHOD3_(typename, const, noexcept, , , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_METHOD4_T(m, ...) \
+    GMOCK_METHOD4_(typename, const, noexcept, , , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_METHOD5_T(m, ...) \
+    GMOCK_METHOD5_(typename, const, noexcept, , , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_METHOD6_T(m, ...) \
+    GMOCK_METHOD6_(typename, const, noexcept, , , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_METHOD7_T(m, ...) \
+    GMOCK_METHOD7_(typename, const, noexcept, , , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_METHOD8_T(m, ...) \
+    GMOCK_METHOD8_(typename, const, noexcept, , , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_METHOD9_T(m, ...) \
+    GMOCK_METHOD9_(typename, const, noexcept, , , m, __VA_ARGS__)
+#define MOCK_CONST_NOEXCEPT_METHOD10_T(m, ...) \
+    GMOCK_METHOD10_(typename, const, noexcept, , , m, __VA_ARGS__)
 #define MOCK_METHOD0_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD0_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD0_(, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD1_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD1_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD1_(, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD2_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD2_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD2_(, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD3_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD3_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD3_(, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD4_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD4_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD4_(, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD5_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD5_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD5_(, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD6_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD6_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD6_(, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD7_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD7_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD7_(, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD8_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD8_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD8_(, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD9_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD9_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD9_(, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD10_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD10_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD10_(, , , , ct, m, __VA_ARGS__)
 
 #define MOCK_CONST_METHOD0_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD0_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD0_(, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD1_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD1_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD1_(, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD2_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD2_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD2_(, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD3_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD3_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD3_(, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD4_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD4_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD4_(, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD5_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD5_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD5_(, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD6_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD6_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD6_(, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD7_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD7_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD7_(, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD8_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD8_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD8_(, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD9_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD9_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD9_(, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD10_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD10_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD10_(, const, , , ct, m, __VA_ARGS__)
 
 #define MOCK_METHOD0_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD0_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD0_(typename, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD1_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD1_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD1_(typename, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD2_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD2_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD2_(typename, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD3_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD3_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD3_(typename, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD4_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD4_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD4_(typename, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD5_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD5_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD5_(typename, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD6_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD6_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD6_(typename, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD7_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD7_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD7_(typename, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD8_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD8_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD8_(typename, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD9_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD9_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD9_(typename, , , , ct, m, __VA_ARGS__)
 #define MOCK_METHOD10_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD10_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD10_(typename, , , , ct, m, __VA_ARGS__)
 
 #define MOCK_CONST_METHOD0_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD0_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD0_(typename, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD1_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD1_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD1_(typename, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD2_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD2_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD2_(typename, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD3_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD3_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD3_(typename, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD4_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD4_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD4_(typename, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD5_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD5_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD5_(typename, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD6_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD6_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD6_(typename, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD7_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD7_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD7_(typename, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD8_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD8_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD8_(typename, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD9_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD9_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD9_(typename, const, , , ct, m, __VA_ARGS__)
 #define MOCK_CONST_METHOD10_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD10_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD10_(typename, const, , , ct, m, __VA_ARGS__)
 
 }  // namespace testing
 

--- a/googlemock/include/gmock/gmock-generated-function-mockers.h.pump
+++ b/googlemock/include/gmock/gmock-generated-function-mockers.h.pump
@@ -148,15 +148,15 @@ $var matcher_as = [[$for j, [[gmock_a$j]]]]
 $var anything_matchers = [[$for j, \
                      [[::testing::A<GMOCK_ARG_(tn, $j, __VA_ARGS__)>()]]]]
 // INTERNAL IMPLEMENTATION - DON'T USE IN USER CODE!!!
-#define GMOCK_METHOD$i[[]]_(tn, constness, ct, Method, ...) \
+#define GMOCK_METHOD$i[[]]_(tn, constness, noexceptness, overrideness, ct, Method, ...) \
   static_assert($i == ::testing::internal::Function<__VA_ARGS__>::ArgumentCount, "MOCK_METHOD<N> must match argument count.");\
   GMOCK_RESULT_(tn, __VA_ARGS__) ct Method( \
-      $arg_as) constness { \
+      $arg_as) constness noexceptness overrideness { \
     GMOCK_MOCKER_($i, constness, Method).SetOwnerAndName(this, #Method); \
     return GMOCK_MOCKER_($i, constness, Method).Invoke($as); \
   } \
   ::testing::MockSpec<__VA_ARGS__> \
-      gmock_##Method($matcher_arg_as) constness { \
+      gmock_##Method($matcher_arg_as) constness noexceptness { \
     GMOCK_MOCKER_($i, constness, Method).RegisterOwner(this); \
     return GMOCK_MOCKER_($i, constness, Method).With($matcher_as); \
   } \
@@ -171,54 +171,95 @@ $var anything_matchers = [[$for j, \
 
 ]]
 $for i [[
-#define MOCK_METHOD$i(m, ...) GMOCK_METHOD$i[[]]_(, , , m, __VA_ARGS__)
+#define MOCK_METHOD$i(m, ...) GMOCK_METHOD$i[[]]_(, , , , , m, __VA_ARGS__)
 
 ]]
 
 
 $for i [[
-#define MOCK_CONST_METHOD$i(m, ...) GMOCK_METHOD$i[[]]_(, const, , m, __VA_ARGS__)
+#define MOCK_CONST_METHOD$i(m, ...) GMOCK_METHOD$i[[]]_(, const, , , , m, __VA_ARGS__)
 
 ]]
 
 
 $for i [[
-#define MOCK_METHOD$i[[]]_T(m, ...) GMOCK_METHOD$i[[]]_(typename, , , m, __VA_ARGS__)
+#define MOCK_VIRTUAL_METHOD$i(m, ...) GMOCK_METHOD$i[[]]_(, , , override , , m, __VA_ARGS__)
+
+]]
+
+
+$for i [[
+#define MOCK_NOEXCEPT_METHOD$i(m, ...) GMOCK_METHOD$i[[]]_(, , noexcept, , , m, __VA_ARGS__) 
+
+]]
+
+
+$for i [[
+#define MOCK_CONST_VIRTUAL_METHOD$i(m, ...) GMOCK_METHOD$i[[]]_(, const, , override, , m, __VA_ARGS__) 
+
+]]
+
+
+$for i [[
+#define MOCK_NOEXCEPT_VIRTUAL_METHOD$i(m, ...) GMOCK_METHOD$i[[]]_(, , noexcept, override, , m, __VA_ARGS__) 
+
+]]
+
+
+$for i [[
+#define MOCK_CONST_NOEXCEPT_VIRTUAL_METHOD$i(m, ...) GMOCK_METHOD$i[[]]_(, const, noexcept, override, , m, __VA_ARGS__)
+
+]]
+
+
+$for i [[
+#define MOCK_METHOD$i[[]]_T(m, ...) GMOCK_METHOD$i[[]]_(typename, , , , , m, __VA_ARGS__)
 
 ]]
 
 
 $for i [[
 #define MOCK_CONST_METHOD$i[[]]_T(m, ...) \
-    GMOCK_METHOD$i[[]]_(typename, const, , m, __VA_ARGS__)
+    GMOCK_METHOD$i[[]]_(typename, const, , , , m, __VA_ARGS__)
 
 ]]
 
+$for i [[
+#define MOCK_NOEXCEPT_METHOD$i[[]]_T(m, ...) \
+    GMOCK_METHOD$i[[]]_(typename, , noexcept, , , m, __VA_ARGS__)
+
+]]
+
+$for i [[
+#define MOCK_CONST_NOEXCEPT_METHOD$i[[]]_T(m, ...) \
+    GMOCK_METHOD$i[[]]_(typename, const, noexcept, , , m, __VA_ARGS__)
+
+]]
 
 $for i [[
 #define MOCK_METHOD$i[[]]_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD$i[[]]_(, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD$i[[]]_(, , , , ct, m, __VA_ARGS__)
 
 ]]
 
 
 $for i [[
 #define MOCK_CONST_METHOD$i[[]]_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD$i[[]]_(, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD$i[[]]_(, const, , , ct, m, __VA_ARGS__)
 
 ]]
 
 
 $for i [[
 #define MOCK_METHOD$i[[]]_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD$i[[]]_(typename, , ct, m, __VA_ARGS__)
+    GMOCK_METHOD$i[[]]_(typename, , , , ct, m, __VA_ARGS__)
 
 ]]
 
 
 $for i [[
 #define MOCK_CONST_METHOD$i[[]]_T_WITH_CALLTYPE(ct, m, ...) \
-    GMOCK_METHOD$i[[]]_(typename, const, ct, m, __VA_ARGS__)
+    GMOCK_METHOD$i[[]]_(typename, const, , , ct, m, __VA_ARGS__)
 
 ]]
 


### PR DESCRIPTION
* following the model of MOCK_CONST_METHOD, added MOCK_NOEXCEPT_METHOD
* also added the MOCK_VIRTUAL_METHOD, which adds the override keyword
* added all combination of CONST / NOEXCEPT / VIRTUAL where it made
sense.