### PR TITLE
Ignore `-Wsign-conversion` issues

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -78,7 +78,7 @@ macro(config_compiler_and_linker)
     # http://stackoverflow.com/questions/3232669 explains the issue.
     set(cxx_base_flags "${cxx_base_flags} -wd4702")
   elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(cxx_base_flags "-Wall -Wshadow -Werror")
+    set(cxx_base_flags "-Wall -Wshadow -Werror -Wno-error=sign-conversion")
     set(cxx_exception_flags "-fexceptions")
     set(cxx_no_exception_flags "-fno-exceptions")
   elseif (CMAKE_COMPILER_IS_GNUCXX)


### PR DESCRIPTION
clang++ compilation when `-Wsign-conversion` is currently broken and the
issues within the code are varied and widespread. For the time being
ignore `-Wsign-conversion` issues, even though some of them are valid
and bleed over into issues that would be found with
`-Wtautological-compare`, et al.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>