### PR TITLE
Don't hardcode the filename in `CxxExceptionDeathTest.PrintsMessageForStdException`

### DIFF
--- a/googletest/test/googletest-death-test_ex_test.cc
+++ b/googletest/test/googletest-death-test_ex_test.cc
@@ -68,7 +68,7 @@ TEST(CxxExceptionDeathTest, PrintsMessageForStdExceptions) {
                           "exceptional message");
   // Verifies that the location is mentioned in the failure text.
   EXPECT_NONFATAL_FAILURE(EXPECT_DEATH(throw TestException(), ""),
-                          "googletest-death-test_ex_test.cc");
+                          __FILE__);
 }
 # endif  // GTEST_HAS_EXCEPTIONS
 


### PR DESCRIPTION
Due to some caveats in the FreeBSD build system and the fact that the
source file is used to compile 2 different death tests with different
flags, I needed (as a shortterm workaround) to copy the test to 2
differently named files.

While this works for compiling the test, as I discovered, this doesn't
work with running `CxxExceptionDeathTest.PrintsMessageForStdException`,
as the testcase hardcodes `googletest-death-test_ex_test.cc`. Use `__FILE__`
when looking for failures, as opposed to looking for the hardcoded name as it
can vary depending on how the test was built.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>