### PR TITLE
Prefix googletest binaries under its own subtree instead of `gtest`

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -49,7 +49,7 @@ endif()
 # targets to the current scope.  We are placing Google Test's binary
 # directory in a subdirectory of our own as VC compilation may break
 # if they are the same (the default).
-add_subdirectory("${gtest_dir}" "${gmock_BINARY_DIR}/gtest")
+add_subdirectory("${gtest_dir}" "${gmock_BINARY_DIR}/${gtest_dir}")
 
 
 # These commands only run if this is the main project


### PR DESCRIPTION
Building all test binaries under their respective subtrees makes
building the project via cmake easier to grok without additional hacks.
In particular, when dealing with the conversion I proposed in
https://reviews.freebsd.org/D19430 (switching from autotools to cmake),
I ran into unexpected gtest prefixing under the googlemock directory, as
opposed to the googletest directory. Example:

Before: `googlemock/gtest/googletest-break-on-failure-unittest_`
After:  `googletest/googletest-break-on-failure-unittest_`

The latter form is easier to translate to packaging manifests and will
remain consistent with the `GMOCK_BUILD=BOOL:false` based builds.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>