### PR TITLE
Add a SO_VERSION to shared libraries for consistency with autotools build

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -170,6 +170,9 @@ function(cxx_library_with_type name type cxx_flags)
     set_target_properties(${name}
       PROPERTIES
       COMPILE_DEFINITIONS "GTEST_CREATE_SHARED_LIBRARY=1")
+    set_target_properties(${name}
+      PROPERTIES
+      SOVERSION "0")
     if (NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
       target_compile_definitions(${name} INTERFACE
         $<INSTALL_INTERFACE:GTEST_LINKED_AS_SHARED_LIBRARY=1>)


### PR DESCRIPTION
This improves compatibility with the autotools build method slightly, as
it would create `libname.so.0` and `libname.so.0.0.0.0` links to
`libname.so`. Example:

```
$ find . -name 'libgtest.*so*'
./lib/libgtest.so
./lib/libgtest.so.0
./googletest/lib/.libs/libgtest.so
./googletest/lib/.libs/libgtest.so.0.0.0
./googletest/lib/.libs/libgtest.so.0
```

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>