### PR TITLE
Proof-of-concept: fix `-Wsign-conversion` issues

### DIFF
--- a/googlemock/test/gmock-spec-builders_test.cc
+++ b/googlemock/test/gmock-spec-builders_test.cc
@@ -1140,7 +1140,7 @@ TEST(UnexpectedCallTest, UnsatisifiedPrerequisites) {
   }
 
   // There should be one non-fatal failure.
-  ASSERT_EQ(1, failures.size());
+  ASSERT_EQ(1U, failures.size());
   const ::testing::TestPartResult& r = failures.GetTestPartResult(0);
   EXPECT_EQ(::testing::TestPartResult::kNonFatalFailure, r.type());
 

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -78,7 +78,7 @@ macro(config_compiler_and_linker)
     # http://stackoverflow.com/questions/3232669 explains the issue.
     set(cxx_base_flags "${cxx_base_flags} -wd4702")
   elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(cxx_base_flags "-Wall -Wshadow -Werror -Wno-error=sign-conversion")
+    set(cxx_base_flags "-Wall -Wshadow -Werror -Wconversion -Wno-error=conversion")
     set(cxx_exception_flags "-fexceptions")
     set(cxx_no_exception_flags "-fno-exceptions")
     set(cxx_strict_flags "-W -Wpointer-arith -Wreturn-type -Wcast-qual -Wwrite-strings -Wswitch -Wunused-parameter -Wcast-align -Wchar-subscripts -Winline -Wredundant-decls")

--- a/googletest/include/gtest/gtest-test-part.h
+++ b/googletest/include/gtest/gtest-test-part.h
@@ -137,7 +137,7 @@ class GTEST_API_ TestPartResultArray {
   const TestPartResult& GetTestPartResult(int index) const;
 
   // Returns the number of TestPartResult objects in the array.
-  int size() const;
+  size_t size() const;
 
  private:
   std::vector<TestPartResult> array_;

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -862,28 +862,28 @@ class GTEST_API_ TestSuite {
   bool should_run() const { return should_run_; }
 
   // Gets the number of successful tests in this test suite.
-  int successful_test_count() const;
+  size_t successful_test_count() const;
 
   // Gets the number of skipped tests in this test suite.
-  int skipped_test_count() const;
+  size_t skipped_test_count() const;
 
   // Gets the number of failed tests in this test suite.
-  int failed_test_count() const;
+  size_t failed_test_count() const;
 
   // Gets the number of disabled tests that will be reported in the XML report.
-  int reportable_disabled_test_count() const;
+  size_t reportable_disabled_test_count() const;
 
   // Gets the number of disabled tests in this test suite.
-  int disabled_test_count() const;
+  size_t disabled_test_count() const;
 
   // Gets the number of tests to be printed in the XML report.
-  int reportable_test_count() const;
+  size_t reportable_test_count() const;
 
   // Get the number of tests in this test suite that should run.
-  int test_to_run_count() const;
+  size_t test_to_run_count() const;
 
   // Gets the number of all tests in this test suite.
-  int total_test_count() const;
+  size_t total_test_count() const;
 
   // Returns true iff the test suite passed.
   bool Passed() const { return !Failed(); }
@@ -1292,49 +1292,49 @@ class GTEST_API_ UnitTest {
       GTEST_LOCK_EXCLUDED_(mutex_);
 
   // Gets the number of successful test suites.
-  int successful_test_suite_count() const;
+  size_t successful_test_suite_count() const;
 
   // Gets the number of failed test suites.
-  int failed_test_suite_count() const;
+  size_t failed_test_suite_count() const;
 
   // Gets the number of all test suites.
-  int total_test_suite_count() const;
+  size_t total_test_suite_count() const;
 
   // Gets the number of all test suites that contain at least one test
   // that should run.
-  int test_suite_to_run_count() const;
+  size_t test_suite_to_run_count() const;
 
   //  Legacy API is deprecated but still available
 #ifndef GTEST_REMOVE_LEGACY_TEST_CASEAPI_
-  int successful_test_case_count() const;
-  int failed_test_case_count() const;
-  int total_test_case_count() const;
-  int test_case_to_run_count() const;
+  size_t successful_test_case_count() const;
+  size_t failed_test_case_count() const;
+  size_t total_test_case_count() const;
+  size_t test_case_to_run_count() const;
 #endif  //  EMOVE_LEGACY_TEST_CASEAPI
 
   // Gets the number of successful tests.
-  int successful_test_count() const;
+  size_t successful_test_count() const;
 
   // Gets the number of skipped tests.
-  int skipped_test_count() const;
+  size_t skipped_test_count() const;
 
   // Gets the number of failed tests.
-  int failed_test_count() const;
+  size_t failed_test_count() const;
 
   // Gets the number of disabled tests that will be reported in the XML report.
-  int reportable_disabled_test_count() const;
+  size_t reportable_disabled_test_count() const;
 
   // Gets the number of disabled tests.
-  int disabled_test_count() const;
+  size_t disabled_test_count() const;
 
   // Gets the number of tests to be printed in the XML report.
-  int reportable_test_count() const;
+  size_t reportable_test_count() const;
 
   // Gets the number of all tests.
-  int total_test_count() const;
+  size_t total_test_count() const;
 
   // Gets the number of tests that should run.
-  int test_to_run_count() const;
+  size_t test_to_run_count() const;
 
   // Gets the time of the test program start, in ms from the start of the
   // UNIX epoch.

--- a/googletest/samples/sample9_unittest.cc
+++ b/googletest/samples/sample9_unittest.cc
@@ -134,11 +134,11 @@ int main(int argc, char **argv) {
 
   // This is an example of using the UnitTest reflection API to inspect test
   // results. Here we discount failures from the tests we expected to fail.
-  int unexpectedly_failed_tests = 0;
-  for (int i = 0; i < unit_test.total_test_case_count(); ++i) {
-    const TestCase& test_case = *unit_test.GetTestCase(i);
-    for (int j = 0; j < test_case.total_test_count(); ++j) {
-      const TestInfo& test_info = *test_case.GetTestInfo(j);
+  size_t unexpectedly_failed_tests = 0;
+  for (size_t i = 0; i < unit_test.total_test_case_count(); ++i) {
+    const TestCase& test_case = *unit_test.GetTestCase(static_cast<int>(i));
+    for (size_t j = 0; j < test_case.total_test_count(); ++j) {
+      const TestInfo& test_info = *test_case.GetTestInfo(static_cast<int>(j));
       // Counts failed tests that were not meant to fail (those without
       // 'Fails' in the name).
       if (test_info.result()->Failed() &&

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -277,7 +277,7 @@ GTEST_API_ bool ShouldRunTestOnShard(
 // Returns the number of elements in the given container that satisfy
 // the given predicate.
 template <class Container, typename Predicate>
-inline int CountIf(const Container& c, Predicate predicate) {
+inline size_t CountIf(const Container& c, Predicate predicate) {
   // Implemented as an explicit loop since std::count_if() in libCstd on
   // Solaris has a non-standard signature.
   int count = 0;
@@ -530,41 +530,41 @@ class GTEST_API_ UnitTestImpl {
       TestPartResultReporterInterface* reporter);
 
   // Gets the number of successful test suites.
-  int successful_test_suite_count() const;
+  size_t successful_test_suite_count() const;
 
   // Gets the number of failed test suites.
-  int failed_test_suite_count() const;
+  size_t failed_test_suite_count() const;
 
   // Gets the number of all test suites.
-  int total_test_suite_count() const;
+  size_t total_test_suite_count() const;
 
   // Gets the number of all test suites that contain at least one test
   // that should run.
-  int test_suite_to_run_count() const;
+  size_t test_suite_to_run_count() const;
 
   // Gets the number of successful tests.
-  int successful_test_count() const;
+  size_t successful_test_count() const;
 
   // Gets the number of skipped tests.
-  int skipped_test_count() const;
+  size_t skipped_test_count() const;
 
   // Gets the number of failed tests.
-  int failed_test_count() const;
+  size_t failed_test_count() const;
 
   // Gets the number of disabled tests that will be reported in the XML report.
-  int reportable_disabled_test_count() const;
+  size_t reportable_disabled_test_count() const;
 
   // Gets the number of disabled tests.
-  int disabled_test_count() const;
+  size_t disabled_test_count() const;
 
   // Gets the number of tests to be printed in the XML report.
-  int reportable_test_count() const;
+  size_t reportable_test_count() const;
 
   // Gets the number of all tests.
-  int total_test_count() const;
+  size_t total_test_count() const;
 
   // Gets the number of tests that should run.
-  int test_to_run_count() const;
+  size_t test_to_run_count() const;
 
   // Gets the time of the test program start, in ms from the start of the
   // UNIX epoch.

--- a/googletest/src/gtest-test-part.cc
+++ b/googletest/src/gtest-test-part.cc
@@ -65,7 +65,7 @@ void TestPartResultArray::Append(const TestPartResult& result) {
 
 // Returns the TestPartResult at the given index (0-based).
 const TestPartResult& TestPartResultArray::GetTestPartResult(int index) const {
-  if (index < 0 || index >= size()) {
+  if (index < 0 || static_cast<size_t>(index) >= size()) {
     printf("\nInvalid index (%d) into TestPartResultArray.\n", index);
     internal::posix::Abort();
   }
@@ -74,8 +74,8 @@ const TestPartResult& TestPartResultArray::GetTestPartResult(int index) const {
 }
 
 // Returns the number of TestPartResult objects in the array.
-int TestPartResultArray::size() const {
-  return static_cast<int>(array_.size());
+size_t TestPartResultArray::size() const {
+  return array_.size();
 }
 
 namespace internal {

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -362,9 +362,9 @@ static bool GTestIsInitialized() { return GetArgvs().size() > 0; }
 // Iterates over a vector of TestSuites, keeping a running sum of the
 // results of calling a given int-returning method on each.
 // Returns the sum.
-static int SumOverTestSuiteList(const std::vector<TestSuite*>& case_list,
-                                int (TestSuite::*method)() const) {
-  int sum = 0;
+static size_t SumOverTestSuiteList(const std::vector<TestSuite*>& case_list,
+                                   size_t (TestSuite::*method)() const) {
+  size_t sum = 0;
   for (size_t i = 0; i < case_list.size(); i++) {
     sum += (case_list[i]->*method)();
   }
@@ -668,8 +668,8 @@ static AssertionResult HasOneFailure(const char* /* results_expr */,
   if (results.size() != 1) {
     msg << "Expected: " << expected << "\n"
         << "  Actual: " << results.size() << " failures";
-    for (int i = 0; i < results.size(); i++) {
-      msg << "\n" << results.GetTestPartResult(i);
+    for (size_t i = 0; i < results.size(); i++) {
+      msg << "\n" << results.GetTestPartResult(static_cast<int>(i));
     }
     return AssertionFailure() << msg;
   }
@@ -751,64 +751,64 @@ void UnitTestImpl::SetTestPartResultReporterForCurrentThread(
 }
 
 // Gets the number of successful test suites.
-int UnitTestImpl::successful_test_suite_count() const {
+size_t UnitTestImpl::successful_test_suite_count() const {
   return CountIf(test_suites_, TestSuitePassed);
 }
 
 // Gets the number of failed test suites.
-int UnitTestImpl::failed_test_suite_count() const {
+size_t UnitTestImpl::failed_test_suite_count() const {
   return CountIf(test_suites_, TestSuiteFailed);
 }
 
 // Gets the number of all test suites.
-int UnitTestImpl::total_test_suite_count() const {
-  return static_cast<int>(test_suites_.size());
+size_t UnitTestImpl::total_test_suite_count() const {
+  return test_suites_.size();
 }
 
 // Gets the number of all test suites that contain at least one test
 // that should run.
-int UnitTestImpl::test_suite_to_run_count() const {
+size_t UnitTestImpl::test_suite_to_run_count() const {
   return CountIf(test_suites_, ShouldRunTestSuite);
 }
 
 // Gets the number of successful tests.
-int UnitTestImpl::successful_test_count() const {
+size_t UnitTestImpl::successful_test_count() const {
   return SumOverTestSuiteList(test_suites_, &TestSuite::successful_test_count);
 }
 
 // Gets the number of skipped tests.
-int UnitTestImpl::skipped_test_count() const {
+size_t UnitTestImpl::skipped_test_count() const {
   return SumOverTestSuiteList(test_suites_, &TestSuite::skipped_test_count);
 }
 
 // Gets the number of failed tests.
-int UnitTestImpl::failed_test_count() const {
+size_t UnitTestImpl::failed_test_count() const {
   return SumOverTestSuiteList(test_suites_, &TestSuite::failed_test_count);
 }
 
 // Gets the number of disabled tests that will be reported in the XML report.
-int UnitTestImpl::reportable_disabled_test_count() const {
+size_t UnitTestImpl::reportable_disabled_test_count() const {
   return SumOverTestSuiteList(test_suites_,
                               &TestSuite::reportable_disabled_test_count);
 }
 
 // Gets the number of disabled tests.
-int UnitTestImpl::disabled_test_count() const {
+size_t UnitTestImpl::disabled_test_count() const {
   return SumOverTestSuiteList(test_suites_, &TestSuite::disabled_test_count);
 }
 
 // Gets the number of tests to be printed in the XML report.
-int UnitTestImpl::reportable_test_count() const {
+size_t UnitTestImpl::reportable_test_count() const {
   return SumOverTestSuiteList(test_suites_, &TestSuite::reportable_test_count);
 }
 
 // Gets the number of all tests.
-int UnitTestImpl::total_test_count() const {
+size_t UnitTestImpl::total_test_count() const {
   return SumOverTestSuiteList(test_suites_, &TestSuite::total_test_count);
 }
 
 // Gets the number of tests that should run.
-int UnitTestImpl::test_to_run_count() const {
+size_t UnitTestImpl::test_to_run_count() const {
   return SumOverTestSuiteList(test_suites_, &TestSuite::test_to_run_count);
 }
 
@@ -2695,43 +2695,43 @@ void TestInfo::Run() {
 // class TestSuite
 
 // Gets the number of successful tests in this test suite.
-int TestSuite::successful_test_count() const {
+size_t TestSuite::successful_test_count() const {
   return CountIf(test_info_list_, TestPassed);
 }
 
 // Gets the number of successful tests in this test suite.
-int TestSuite::skipped_test_count() const {
+size_t TestSuite::skipped_test_count() const {
   return CountIf(test_info_list_, TestSkipped);
 }
 
 // Gets the number of failed tests in this test suite.
-int TestSuite::failed_test_count() const {
+size_t TestSuite::failed_test_count() const {
   return CountIf(test_info_list_, TestFailed);
 }
 
 // Gets the number of disabled tests that will be reported in the XML report.
-int TestSuite::reportable_disabled_test_count() const {
+size_t TestSuite::reportable_disabled_test_count() const {
   return CountIf(test_info_list_, TestReportableDisabled);
 }
 
 // Gets the number of disabled tests in this test suite.
-int TestSuite::disabled_test_count() const {
+size_t TestSuite::disabled_test_count() const {
   return CountIf(test_info_list_, TestDisabled);
 }
 
 // Gets the number of tests to be printed in the XML report.
-int TestSuite::reportable_test_count() const {
+size_t TestSuite::reportable_test_count() const {
   return CountIf(test_info_list_, TestReportable);
 }
 
 // Get the number of tests in this test suite that should run.
-int TestSuite::test_to_run_count() const {
+size_t TestSuite::test_to_run_count() const {
   return CountIf(test_info_list_, ShouldRunTest);
 }
 
 // Gets the number of all tests.
-int TestSuite::total_test_count() const {
-  return static_cast<int>(test_info_list_.size());
+size_t TestSuite::total_test_count() const {
+  return test_info_list_.size();
 }
 
 // Creates a TestSuite with the given name.
@@ -2801,8 +2801,8 @@ void TestSuite::Run() {
       this, &TestSuite::RunSetUpTestSuite, "SetUpTestSuite()");
 
   const internal::TimeInMillis start = internal::GetTimeInMillis();
-  for (int i = 0; i < total_test_count(); i++) {
-    GetMutableTestInfo(i)->Run();
+  for (size_t i = 0; i < total_test_count(); i++) {
+    GetMutableTestInfo(static_cast<int>(i))->Run();
   }
   elapsed_time_ = internal::GetTimeInMillis() - start;
 
@@ -2843,7 +2843,7 @@ void TestSuite::UnshuffleTests() {
 //
 // FormatCountableNoun(1, "formula", "formuli") returns "1 formula".
 // FormatCountableNoun(5, "book", "books") returns "5 books".
-static std::string FormatCountableNoun(int count,
+static std::string FormatCountableNoun(size_t count,
                                        const char * singular_form,
                                        const char * plural_form) {
   return internal::StreamableToString(count) + " " +
@@ -2851,12 +2851,12 @@ static std::string FormatCountableNoun(int count,
 }
 
 // Formats the count of tests.
-static std::string FormatTestCount(int test_count) {
+static std::string FormatTestCount(size_t test_count) {
   return FormatCountableNoun(test_count, "test", "tests");
 }
 
 // Formats the count of test suites.
-static std::string FormatTestSuiteCount(int test_suite_count) {
+static std::string FormatTestSuiteCount(size_t test_suite_count) {
   return FormatCountableNoun(test_suite_count, "test suite", "test suites");
 }
 
@@ -3236,18 +3236,18 @@ void PrettyUnitTestResultPrinter::OnEnvironmentsTearDownStart(
 
 // Internal helper for printing the list of failed tests.
 void PrettyUnitTestResultPrinter::PrintFailedTests(const UnitTest& unit_test) {
-  const int failed_test_count = unit_test.failed_test_count();
+  const size_t failed_test_count = unit_test.failed_test_count();
   if (failed_test_count == 0) {
     return;
   }
 
-  for (int i = 0; i < unit_test.total_test_suite_count(); ++i) {
-    const TestSuite& test_suite = *unit_test.GetTestSuite(i);
+  for (size_t i = 0; i < unit_test.total_test_suite_count(); ++i) {
+    const TestSuite& test_suite = *unit_test.GetTestSuite(static_cast<int>(i));
     if (!test_suite.should_run() || (test_suite.failed_test_count() == 0)) {
       continue;
     }
-    for (int j = 0; j < test_suite.total_test_count(); ++j) {
-      const TestInfo& test_info = *test_suite.GetTestInfo(j);
+    for (size_t j = 0; j < test_suite.total_test_count(); ++j) {
+      const TestInfo& test_info = *test_suite.GetTestInfo(static_cast<int>(j));
       if (!test_info.should_run() || !test_info.result()->Failed()) {
         continue;
       }
@@ -3261,18 +3261,18 @@ void PrettyUnitTestResultPrinter::PrintFailedTests(const UnitTest& unit_test) {
 
 // Internal helper for printing the list of skipped tests.
 void PrettyUnitTestResultPrinter::PrintSkippedTests(const UnitTest& unit_test) {
-  const int skipped_test_count = unit_test.skipped_test_count();
+  const size_t skipped_test_count = unit_test.skipped_test_count();
   if (skipped_test_count == 0) {
     return;
   }
 
-  for (int i = 0; i < unit_test.total_test_suite_count(); ++i) {
-    const TestSuite& test_suite = *unit_test.GetTestSuite(i);
+  for (size_t i = 0; i < unit_test.total_test_suite_count(); ++i) {
+    const TestSuite& test_suite = *unit_test.GetTestSuite(static_cast<int>(i));
     if (!test_suite.should_run() || (test_suite.skipped_test_count() == 0)) {
       continue;
     }
-    for (int j = 0; j < test_suite.total_test_count(); ++j) {
-      const TestInfo& test_info = *test_suite.GetTestInfo(j);
+    for (size_t j = 0; j < test_suite.total_test_count(); ++j) {
+      const TestInfo& test_info = *test_suite.GetTestInfo(static_cast<int>(j));
       if (!test_info.should_run() || !test_info.result()->Skipped()) {
         continue;
       }
@@ -3297,7 +3297,7 @@ void PrettyUnitTestResultPrinter::OnTestIterationEnd(const UnitTest& unit_test,
   ColoredPrintf(COLOR_GREEN,  "[  PASSED  ] ");
   printf("%s.\n", FormatTestCount(unit_test.successful_test_count()).c_str());
 
-  const int skipped_test_count = unit_test.skipped_test_count();
+  const size_t skipped_test_count = unit_test.skipped_test_count();
   if (skipped_test_count > 0) {
     ColoredPrintf(COLOR_GREEN, "[  SKIPPED ] ");
     printf("%s, listed below:\n", FormatTestCount(skipped_test_count).c_str());
@@ -3815,9 +3815,10 @@ void XmlUnitTestResultPrinter::PrintXmlTestSuite(std::ostream* stream,
     *stream << TestPropertiesAsXmlAttributes(test_suite.ad_hoc_test_result());
   }
   *stream << ">\n";
-  for (int i = 0; i < test_suite.total_test_count(); ++i) {
-    if (test_suite.GetTestInfo(i)->is_reportable())
-      OutputXmlTestInfo(stream, test_suite.name(), *test_suite.GetTestInfo(i));
+  for (size_t i = 0; i < test_suite.total_test_count(); ++i) {
+    auto testSuiteInfo = test_suite.GetTestInfo(i);
+    if (testSuiteInfo->is_reportable())
+      OutputXmlTestInfo(stream, test_suite.name(), *testSuiteInfo);
   }
   *stream << "  </" << kTestsuite << ">\n";
 }
@@ -3853,7 +3854,8 @@ void XmlUnitTestResultPrinter::PrintXmlUnitTest(std::ostream* stream,
   OutputXmlAttribute(stream, kTestsuites, "name", "AllTests");
   *stream << ">\n";
 
-  for (int i = 0; i < unit_test.total_test_suite_count(); ++i) {
+  for (int i = 0; i < static_cast<int>(unit_test.total_test_suite_count());
+       ++i) {
     if (unit_test.GetTestSuite(i)->reportable_test_count() > 0)
       PrintXmlTestSuite(stream, *unit_test.GetTestSuite(i));
   }
@@ -3867,7 +3869,7 @@ void XmlUnitTestResultPrinter::PrintXmlTestsList(
   *stream << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
   *stream << "<" << kTestsuites;
 
-  int total_tests = 0;
+  size_t total_tests = 0;
   for (auto test_suite : test_suites) {
     total_tests += test_suite->total_test_count();
   }
@@ -4183,14 +4185,15 @@ void JsonUnitTestResultPrinter::PrintJsonTestSuite(
   *stream << kIndent << "\"" << kTestsuite << "\": [\n";
 
   bool comma = false;
-  for (int i = 0; i < test_suite.total_test_count(); ++i) {
-    if (test_suite.GetTestInfo(i)->is_reportable()) {
+  for (size_t i = 0; i < test_suite.total_test_count(); ++i) {
+    auto testSuiteInfo = test_suite.GetTestInfo(static_cast<int>(i));
+    if (testSuiteInfo->is_reportable()) {
       if (comma) {
         *stream << ",\n";
       } else {
         comma = true;
       }
-      OutputJsonTestInfo(stream, test_suite.name(), *test_suite.GetTestInfo(i));
+      OutputJsonTestInfo(stream, test_suite.name(), *testSuiteInfo);
     }
   }
   *stream << "\n" << kIndent << "]\n" << Indent(4) << "}";
@@ -4228,7 +4231,8 @@ void JsonUnitTestResultPrinter::PrintJsonUnitTest(std::ostream* stream,
   *stream << kIndent << "\"" << kTestsuites << "\": [\n";
 
   bool comma = false;
-  for (int i = 0; i < unit_test.total_test_suite_count(); ++i) {
+  for (int i = 0; i < static_cast<int>(unit_test.total_test_suite_count());
+        ++i) {
     if (unit_test.GetTestSuite(i)->reportable_test_count() > 0) {
       if (comma) {
         *stream << ",\n";
@@ -4247,7 +4251,7 @@ void JsonUnitTestResultPrinter::PrintJsonTestList(
   const std::string kTestsuites = "testsuites";
   const std::string kIndent = Indent(2);
   *stream << "{\n";
-  int total_tests = 0;
+  size_t total_tests = 0;
   for (auto test_suite : test_suites) {
     total_tests += test_suite->total_test_count();
   }
@@ -4552,75 +4556,75 @@ UnitTest* UnitTest::GetInstance() {
 }
 
 // Gets the number of successful test suites.
-int UnitTest::successful_test_suite_count() const {
+size_t UnitTest::successful_test_suite_count() const {
   return impl()->successful_test_suite_count();
 }
 
 // Gets the number of failed test suites.
-int UnitTest::failed_test_suite_count() const {
+size_t UnitTest::failed_test_suite_count() const {
   return impl()->failed_test_suite_count();
 }
 
 // Gets the number of all test suites.
-int UnitTest::total_test_suite_count() const {
+size_t UnitTest::total_test_suite_count() const {
   return impl()->total_test_suite_count();
 }
 
 // Gets the number of all test suites that contain at least one test
 // that should run.
-int UnitTest::test_suite_to_run_count() const {
+size_t UnitTest::test_suite_to_run_count() const {
   return impl()->test_suite_to_run_count();
 }
 
 //  Legacy API is deprecated but still available
 #ifndef GTEST_REMOVE_LEGACY_TEST_CASEAPI_
-int UnitTest::successful_test_case_count() const {
+size_t UnitTest::successful_test_case_count() const {
   return impl()->successful_test_suite_count();
 }
-int UnitTest::failed_test_case_count() const {
+size_t UnitTest::failed_test_case_count() const {
   return impl()->failed_test_suite_count();
 }
-int UnitTest::total_test_case_count() const {
+size_t UnitTest::total_test_case_count() const {
   return impl()->total_test_suite_count();
 }
-int UnitTest::test_case_to_run_count() const {
+size_t UnitTest::test_case_to_run_count() const {
   return impl()->test_suite_to_run_count();
 }
 #endif  //  GTEST_REMOVE_LEGACY_TEST_CASEAPI_
 
 // Gets the number of successful tests.
-int UnitTest::successful_test_count() const {
+size_t UnitTest::successful_test_count() const {
   return impl()->successful_test_count();
 }
 
 // Gets the number of skipped tests.
-int UnitTest::skipped_test_count() const {
+size_t UnitTest::skipped_test_count() const {
   return impl()->skipped_test_count();
 }
 
 // Gets the number of failed tests.
-int UnitTest::failed_test_count() const { return impl()->failed_test_count(); }
+size_t UnitTest::failed_test_count() const { return impl()->failed_test_count(); }
 
 // Gets the number of disabled tests that will be reported in the XML report.
-int UnitTest::reportable_disabled_test_count() const {
+size_t UnitTest::reportable_disabled_test_count() const {
   return impl()->reportable_disabled_test_count();
 }
 
 // Gets the number of disabled tests.
-int UnitTest::disabled_test_count() const {
+size_t UnitTest::disabled_test_count() const {
   return impl()->disabled_test_count();
 }
 
 // Gets the number of tests to be printed in the XML report.
-int UnitTest::reportable_test_count() const {
+size_t UnitTest::reportable_test_count() const {
   return impl()->reportable_test_count();
 }
 
 // Gets the number of all tests.
-int UnitTest::total_test_count() const { return impl()->total_test_count(); }
+size_t UnitTest::total_test_count() const { return impl()->total_test_count(); }
 
 // Gets the number of tests that should run.
-int UnitTest::test_to_run_count() const { return impl()->test_to_run_count(); }
+size_t UnitTest::test_to_run_count() const { return impl()->test_to_run_count(); }
 
 // Gets the time of the test program start, in ms from the start of the
 // UNIX epoch.
@@ -5238,7 +5242,8 @@ bool UnitTestImpl::RunAllTests() {
       // Runs the tests only if there was no fatal failure during global
       // set-up.
       if (!Test::HasFatalFailure()) {
-        for (int test_index = 0; test_index < total_test_suite_count();
+        for (int test_index = 0;
+             test_index < static_cast<int>(total_test_suite_count());
              test_index++) {
           GetMutableSuiteCase(test_index)->Run();
         }

--- a/googletest/test/googletest-param-test-test.cc
+++ b/googletest/test/googletest-param-test-test.cc
@@ -871,12 +871,14 @@ INSTANTIATE_TEST_SUITE_P(CustomParamNameLambda, CustomLambdaNamingTest,
 TEST(CustomNamingTest, CheckNameRegistry) {
   ::testing::UnitTest* unit_test = ::testing::UnitTest::GetInstance();
   std::set<std::string> test_names;
-  for (int suite_num = 0; suite_num < unit_test->total_test_suite_count();
+  for (size_t suite_num = 0; suite_num < unit_test->total_test_suite_count();
        ++suite_num) {
-    const ::testing::TestSuite* test_suite = unit_test->GetTestSuite(suite_num);
-    for (int test_num = 0; test_num < test_suite->total_test_count();
+    const ::testing::TestSuite* test_suite =
+      unit_test->GetTestSuite(static_cast<int>(suite_num));
+    for (size_t test_num = 0; test_num < test_suite->total_test_count();
          ++test_num) {
-      const ::testing::TestInfo* test_info = test_suite->GetTestInfo(test_num);
+      const ::testing::TestInfo* test_info =
+        test_suite->GetTestInfo(static_cast<int>(test_num));
       test_names.insert(std::string(test_info->name()));
     }
   }

--- a/googletest/test/googletest-test-part-test.cc
+++ b/googletest/test/googletest-test-part-test.cc
@@ -192,7 +192,7 @@ class TestPartResultArrayTest : public Test {
 // Tests that TestPartResultArray initially has size 0.
 TEST_F(TestPartResultArrayTest, InitialSizeIsZero) {
   TestPartResultArray results;
-  EXPECT_EQ(0, results.size());
+  EXPECT_EQ(0U, results.size());
 }
 
 // Tests that TestPartResultArray contains the given TestPartResult
@@ -200,7 +200,7 @@ TEST_F(TestPartResultArrayTest, InitialSizeIsZero) {
 TEST_F(TestPartResultArrayTest, ContainsGivenResultAfterAppend) {
   TestPartResultArray results;
   results.Append(r1_);
-  EXPECT_EQ(1, results.size());
+  EXPECT_EQ(1U, results.size());
   EXPECT_STREQ("Failure 1", results.GetTestPartResult(0).message());
 }
 
@@ -210,7 +210,7 @@ TEST_F(TestPartResultArrayTest, ContainsGivenResultsAfterTwoAppends) {
   TestPartResultArray results;
   results.Append(r1_);
   results.Append(r2_);
-  EXPECT_EQ(2, results.size());
+  EXPECT_EQ(2U, results.size());
   EXPECT_STREQ("Failure 1", results.GetTestPartResult(0).message());
   EXPECT_STREQ("Failure 2", results.GetTestPartResult(1).message());
 }

--- a/googletest/test/gtest-unittest-api_test.cc
+++ b/googletest/test/gtest-unittest-api_test.cc
@@ -58,8 +58,8 @@ class UnitTestHelper {
     auto const** const test_suites =
         new const TestSuite*[unit_test.total_test_suite_count()];
 
-    for (int i = 0; i < unit_test.total_test_suite_count(); ++i)
-      test_suites[i] = unit_test.GetTestSuite(i);
+    for (size_t i = 0; i < unit_test.total_test_suite_count(); ++i)
+      test_suites[i] = unit_test.GetTestSuite(static_cast<int>(i));
 
     std::sort(test_suites,
               test_suites + unit_test.total_test_suite_count(),
@@ -71,8 +71,8 @@ class UnitTestHelper {
   // pointer.
   static const TestSuite* FindTestSuite(const char* name) {
     UnitTest& unit_test = *UnitTest::GetInstance();
-    for (int i = 0; i < unit_test.total_test_suite_count(); ++i) {
-      const TestSuite* test_suite = unit_test.GetTestSuite(i);
+    for (size_t i = 0; i < unit_test.total_test_suite_count(); ++i) {
+      const TestSuite* test_suite = unit_test.GetTestSuite(static_cast<int>(i));
       if (0 == strcmp(test_suite->name(), name))
         return test_suite;
     }
@@ -86,8 +86,8 @@ class UnitTestHelper {
     TestInfo const** const tests =
         new const TestInfo*[test_suite->total_test_count()];
 
-    for (int i = 0; i < test_suite->total_test_count(); ++i)
-      tests[i] = test_suite->GetTestInfo(i);
+    for (size_t i = 0; i < test_suite->total_test_count(); ++i)
+      tests[i] = test_suite->GetTestInfo(static_cast<int>(i));
 
     std::sort(tests, tests + test_suite->total_test_count(),
               LessByName<TestInfo>());

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -794,16 +794,16 @@ static bool IsPositive(int n) { return n > 0; }
 
 TEST(ContainerUtilityTest, CountIf) {
   std::vector<int> v;
-  EXPECT_EQ(0, CountIf(v, IsPositive));  // Works for an empty container.
+  EXPECT_EQ(0U, CountIf(v, IsPositive));  // Works for an empty container.
 
   v.push_back(-1);
   v.push_back(0);
-  EXPECT_EQ(0, CountIf(v, IsPositive));  // Works when no value satisfies.
+  EXPECT_EQ(0U, CountIf(v, IsPositive));  // Works when no value satisfies.
 
   v.push_back(2);
   v.push_back(-10);
   v.push_back(10);
-  EXPECT_EQ(2, CountIf(v, IsPositive));
+  EXPECT_EQ(2U, CountIf(v, IsPositive));
 }
 
 // Tests ForEach().
@@ -1152,7 +1152,7 @@ TEST_F(ScopedFakeTestPartResultReporterTest, InterceptsTestFailures) {
     AddFailure(FATAL_FAILURE);
   }
 
-  EXPECT_EQ(2, results.size());
+  EXPECT_EQ(2U, results.size());
   EXPECT_TRUE(results.GetTestPartResult(0).nonfatally_failed());
   EXPECT_TRUE(results.GetTestPartResult(1).fatally_failed());
 }
@@ -1164,7 +1164,7 @@ TEST_F(ScopedFakeTestPartResultReporterTest, DeprecatedConstructor) {
     ScopedFakeTestPartResultReporter reporter(&results);
     AddFailure(NONFATAL_FAILURE);
   }
-  EXPECT_EQ(1, results.size());
+  EXPECT_EQ(1U, results.size());
 }
 
 #if GTEST_IS_THREADSAFE
@@ -1190,7 +1190,7 @@ TEST_F(ScopedFakeTestPartResultReporterWithThreadsTest,
     AddFailureInOtherThread(FATAL_FAILURE);
   }
 
-  EXPECT_EQ(4, results.size());
+  EXPECT_EQ(4U, results.size());
   EXPECT_TRUE(results.GetTestPartResult(0).nonfatally_failed());
   EXPECT_TRUE(results.GetTestPartResult(1).fatally_failed());
   EXPECT_TRUE(results.GetTestPartResult(2).nonfatally_failed());
@@ -3412,7 +3412,7 @@ TEST_F(NoFatalFailureTest, AssertNoFatalFailureOnFatalFailure) {
     ScopedFakeTestPartResultReporter gtest_reporter(&gtest_failures);
     DoAssertNoFatalFailureOnFails();
   }
-  ASSERT_EQ(2, gtest_failures.size());
+  ASSERT_EQ(2U, gtest_failures.size());
   EXPECT_EQ(TestPartResult::kFatalFailure,
             gtest_failures.GetTestPartResult(0).type());
   EXPECT_EQ(TestPartResult::kFatalFailure,
@@ -3429,7 +3429,7 @@ TEST_F(NoFatalFailureTest, ExpectNoFatalFailureOnFatalFailure) {
     ScopedFakeTestPartResultReporter gtest_reporter(&gtest_failures);
     DoExpectNoFatalFailureOnFails();
   }
-  ASSERT_EQ(3, gtest_failures.size());
+  ASSERT_EQ(3U, gtest_failures.size());
   EXPECT_EQ(TestPartResult::kFatalFailure,
             gtest_failures.GetTestPartResult(0).type());
   EXPECT_EQ(TestPartResult::kNonFatalFailure,
@@ -3450,7 +3450,7 @@ TEST_F(NoFatalFailureTest, MessageIsStreamable) {
     ScopedFakeTestPartResultReporter gtest_reporter(&gtest_failures);
     EXPECT_NO_FATAL_FAILURE(FAIL() << "foo") << "my message";
   }
-  ASSERT_EQ(2, gtest_failures.size());
+  ASSERT_EQ(2U, gtest_failures.size());
   EXPECT_EQ(TestPartResult::kNonFatalFailure,
             gtest_failures.GetTestPartResult(0).type());
   EXPECT_EQ(TestPartResult::kNonFatalFailure,
@@ -5314,8 +5314,9 @@ class TestInfoTest : public Test {
     const TestSuite* const test_suite =
         GetUnitTestImpl()->GetTestSuite("TestInfoTest", "", nullptr, nullptr);
 
-    for (int i = 0; i < test_suite->total_test_count(); ++i) {
-      const TestInfo* const test_info = test_suite->GetTestInfo(i);
+    for (size_t i = 0; i < test_suite->total_test_count(); ++i) {
+      const TestInfo* const test_info =
+        test_suite->GetTestInfo(static_cast<int>(i));
       if (strcmp(test_name, test_info->name()) == 0)
         return test_info;
     }
@@ -7582,14 +7583,15 @@ auto* dynamic_test = testing::RegisterTest(
 
 TEST(RegisterTest, WasRegistered) {
   auto* unittest = testing::UnitTest::GetInstance();
-  for (int i = 0; i < unittest->total_test_suite_count(); ++i) {
-    auto* tests = unittest->GetTestSuite(i);
+  for (size_t i = 0; i < unittest->total_test_suite_count(); ++i) {
+    auto* tests = unittest->GetTestSuite(static_cast<int>(i));
     if (tests->name() != std::string("DynamicUnitTestFixture")) continue;
-    for (int j = 0; j < tests->total_test_count(); ++j) {
-      if (tests->GetTestInfo(j)->name() != std::string("DynamicTest")) continue;
+    for (size_t j = 0; j < tests->total_test_count(); ++j) {
+      auto testInfo = tests->GetTestInfo(j);
+      if (testInfo->name() != std::string("DynamicTest")) continue;
       // Found it.
-      EXPECT_STREQ(tests->GetTestInfo(j)->value_param(), "VALUE");
-      EXPECT_STREQ(tests->GetTestInfo(j)->type_param(), "TYPE");
+      EXPECT_STREQ(testInfo->value_param(), "VALUE");
+      EXPECT_STREQ(testInfo->type_param(), "TYPE");
       return;
     }
   }


### PR DESCRIPTION
This proof of concept replaces some int scalars used as loop counters and int
returning methods with size_t equivalents, as it's a viable type for
counting values and indexing arrays.

This is just a small amount of what needs to be done to make googletest
compile cleanly with `-Wsign-conversion`.

This starts to address #2146.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>