### PR TITLE
gcc: add braces around conditional statements

### DIFF
--- a/googletest/test/googletest-death-test-test.cc
+++ b/googletest/test/googletest-death-test-test.cc
@@ -280,24 +280,26 @@ TEST(ExitStatusPredicateTest, KilledBySignal) {
 // be followed by operator<<, and that in either case the complete text
 // comprises only a single C++ statement.
 TEST_F(TestForDeathTest, SingleStatement) {
-  if (AlwaysFalse())
+  if (AlwaysFalse()) {
     // This would fail if executed; this is a compilation test only
     ASSERT_DEATH(return, "");
-
-  if (AlwaysTrue())
+  }
+  if (AlwaysTrue()) {
     EXPECT_DEATH(_exit(1), "");
-  else
+  } else {
     // This empty "else" branch is meant to ensure that EXPECT_DEATH
     // doesn't expand into an "if" statement without an "else"
     ;
+  }
 
-  if (AlwaysFalse())
+  if (AlwaysFalse()) {
     ASSERT_DEATH(return, "") << "did not die";
-
-  if (AlwaysFalse())
+  }
+  if (AlwaysFalse()) {
     ;
-  else
+  } else {
     EXPECT_DEATH(_exit(1), "") << 1 << 2 << 3;
+  }
 }
 
 # if GTEST_USES_PCRE
@@ -1421,24 +1423,25 @@ namespace {
 //
 // The syntax should work whether death tests are available or not.
 TEST(ConditionalDeathMacrosSyntaxDeathTest, SingleStatement) {
-  if (AlwaysFalse())
+  if (AlwaysFalse()) {
     // This would fail if executed; this is a compilation test only
     ASSERT_DEATH_IF_SUPPORTED(return, "");
-
-  if (AlwaysTrue())
+  }
+  if (AlwaysTrue()) {
     EXPECT_DEATH_IF_SUPPORTED(_exit(1), "");
-  else
+  } else {
     // This empty "else" branch is meant to ensure that EXPECT_DEATH
     // doesn't expand into an "if" statement without an "else"
     ;  // NOLINT
-
-  if (AlwaysFalse())
+  }
+  if (AlwaysFalse()) {
     ASSERT_DEATH_IF_SUPPORTED(return, "") << "did not die";
-
-  if (AlwaysFalse())
+  }
+  if (AlwaysFalse()) {
     ;  // NOLINT
-  else
+  } else {
     EXPECT_DEATH_IF_SUPPORTED(_exit(1), "") << 1 << 2 << 3;
+  }
 }
 
 // Tests that conditional death test macros expand to code which interacts

--- a/googletest/test/googletest-port-test.cc
+++ b/googletest/test/googletest-port-test.cc
@@ -220,19 +220,20 @@ TEST(IteratorTraitsTest, WorksForPointerToConst) {
 }
 
 TEST(GtestCheckSyntaxTest, BehavesLikeASingleStatement) {
-  if (AlwaysFalse())
+  if (AlwaysFalse()) {
     GTEST_CHECK_(false) << "This should never be executed; "
                            "It's a compilation test only.";
-
-  if (AlwaysTrue())
+  }
+  if (AlwaysTrue()) {
     GTEST_CHECK_(true);
-  else
+  } else {
     ;  // NOLINT
-
-  if (AlwaysFalse())
+  }
+  if (AlwaysFalse()) {
     ;  // NOLINT
-  else
+  } else {
     GTEST_CHECK_(true) << "";
+  }
 }
 
 TEST(GtestCheckSyntaxTest, WorksWithSwitch) {

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -4079,22 +4079,23 @@ TEST(HRESULTAssertionTest, Streaming) {
 
 // Tests that the assertion macros behave like single statements.
 TEST(AssertionSyntaxTest, BasicAssertionsBehavesLikeSingleStatement) {
-  if (AlwaysFalse())
+  if (AlwaysFalse()) {
     ASSERT_TRUE(false) << "This should never be executed; "
                           "It's a compilation test only.";
-
-  if (AlwaysTrue())
+  }
+  if (AlwaysTrue()) {
     EXPECT_FALSE(false);
-  else
+  } else {
     ;  // NOLINT
-
-  if (AlwaysFalse())
+  }
+  if (AlwaysFalse()) {
     ASSERT_LT(1, 3);
-
-  if (AlwaysFalse())
+  }
+  if (AlwaysFalse()) {
     ;  // NOLINT
-  else
+  } else {
     EXPECT_GT(3, 2) << "";
+  }
 }
 
 #if GTEST_HAS_EXCEPTIONS
@@ -4113,53 +4114,56 @@ TEST(ExpectThrowTest, DoesNotGenerateUnreachableCodeWarning) {
 }
 
 TEST(AssertionSyntaxTest, ExceptionAssertionsBehavesLikeSingleStatement) {
-  if (AlwaysFalse())
+  if (AlwaysFalse()) {
     EXPECT_THROW(ThrowNothing(), bool);
-
-  if (AlwaysTrue())
+  }
+  if (AlwaysTrue()) {
     EXPECT_THROW(ThrowAnInteger(), int);
-  else
+  } else {
     ;  // NOLINT
-
-  if (AlwaysFalse())
+  }
+  if (AlwaysFalse()) {
     EXPECT_NO_THROW(ThrowAnInteger());
-
-  if (AlwaysTrue())
+  }
+  if (AlwaysTrue()) {
     EXPECT_NO_THROW(ThrowNothing());
-  else
+  } else {
     ;  // NOLINT
-
-  if (AlwaysFalse())
+  }
+  if (AlwaysFalse()) {
     EXPECT_ANY_THROW(ThrowNothing());
-
-  if (AlwaysTrue())
+  }
+  if (AlwaysTrue()) {
     EXPECT_ANY_THROW(ThrowAnInteger());
-  else
+  } else {
     ;  // NOLINT
+  }
 }
 #endif  // GTEST_HAS_EXCEPTIONS
 
 TEST(AssertionSyntaxTest, NoFatalFailureAssertionsBehavesLikeSingleStatement) {
-  if (AlwaysFalse())
+  if (AlwaysFalse()) {
     EXPECT_NO_FATAL_FAILURE(FAIL()) << "This should never be executed. "
                                     << "It's a compilation test only.";
-  else
+  } else {
     ;  // NOLINT
+  }
 
-  if (AlwaysFalse())
+  if (AlwaysFalse()) {
     ASSERT_NO_FATAL_FAILURE(FAIL()) << "";
-  else
+  } else {
     ;  // NOLINT
-
-  if (AlwaysTrue())
+  }
+  if (AlwaysTrue()) {
     EXPECT_NO_FATAL_FAILURE(SUCCEED());
-  else
+  } else {
     ;  // NOLINT
-
-  if (AlwaysFalse())
+  }
+  if (AlwaysFalse()) {
     ;  // NOLINT
-  else
+  } else {
     ASSERT_NO_FATAL_FAILURE(SUCCEED());
+  }
 }
 
 // Tests that the assertion macros work well with switch statements.


### PR DESCRIPTION
g++ 8.2 was citing issues with `-Wdangling-else`. Add additional curly
braces around conditional statements to avoid triggering these compiler
warnings.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>