### PR TITLE
misspelling may happen when using “SetUpTestCase” or “TearDownTestCase”

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ googletest/m4/ltoptions.m4
 googletest/m4/ltsugar.m4
 googletest/m4/ltversion.m4
 googletest/m4/lt~obsolete.m4
+googlemock/m4
 
 # Ignore generated directories.
 googlemock/fused-src/

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,4 @@
 ## Process this file with automake to produce Makefile.in
-ACLOCAL_AMFLAGS = -I m4
-
 AUTOMAKE_OPTIONS = foreign
 
 # Build . before src so that our all-local and clean-local hooks kicks in at

--- a/googlemock/Makefile.am
+++ b/googlemock/Makefile.am
@@ -1,5 +1,7 @@
 # Automake file
 
+ACLOCAL_AMFLAGS = -I m4
+
 # Nonstandard package files for distribution.
 EXTRA_DIST = LICENSE
 

--- a/googlemock/configure.ac
+++ b/googlemock/configure.ac
@@ -8,6 +8,7 @@ AC_INIT([Google C++ Mocking Framework],
 # Provide various options to initialize the Autoconf and configure processes.
 AC_PREREQ([2.59])
 AC_CONFIG_SRCDIR([./LICENSE])
+AC_CONFIG_MACRO_DIRS([m4])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([build-aux/config.h])
 AC_CONFIG_FILES([Makefile])

--- a/googlemock/test/gmock-internal-utils_test.cc
+++ b/googlemock/test/gmock-internal-utils_test.cc
@@ -558,7 +558,7 @@ void ExpectCallLogger() {
   DummyMock mock;
   EXPECT_CALL(mock, TestMethod());
   mock.TestMethod();
-};
+}
 
 // Verifies that EXPECT_CALL logs if the --gmock_verbose flag is set to "info".
 TEST(ExpectCallTest, LogsWhenVerbosityIsInfo) {
@@ -581,7 +581,7 @@ TEST(ExpectCallTest,  DoesNotLogWhenVerbosityIsError) {
 void OnCallLogger() {
   DummyMock mock;
   ON_CALL(mock, TestMethod());
-};
+}
 
 // Verifies that ON_CALL logs if the --gmock_verbose flag is set to "info".
 TEST(OnCallTest, LogsWhenVerbosityIsInfo) {

--- a/googletest/configure.ac
+++ b/googletest/configure.ac
@@ -12,7 +12,7 @@ AC_INIT([Google C++ Testing Framework],
 # Provide various options to initialize the Autoconf and configure processes.
 AC_PREREQ([2.59])
 AC_CONFIG_SRCDIR([./LICENSE])
-AC_CONFIG_MACRO_DIR([m4])
+AC_CONFIG_MACRO_DIRS([m4])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([build-aux/config.h])
 AC_CONFIG_FILES([Makefile])

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -124,37 +124,6 @@ class IgnoredValue {
   IgnoredValue(const T& /* ignored */) {}  // NOLINT(runtime/explicit)
 };
 
-// The only type that should be convertible to Secret* is nullptr.
-// The other null pointer constants are not of a type that is convertible to
-// Secret*. Only the literal with the right value is.
-template <typename T>
-using TypeIsValidNullptrConstant = std::integral_constant<
-    bool, std::is_same<typename std::decay<T>::type, std::nullptr_t>::value ||
-              !std::is_convertible<T, Secret*>::value>;
-
-// Two overloaded helpers for checking at compile time whether an
-// expression is a null pointer literal (i.e. NULL or any 0-valued
-// compile-time integral constant).  These helpers have no
-// implementations, as we only need their signatures.
-//
-// Given IsNullLiteralHelper(x), the compiler will pick the first
-// version if x can be implicitly converted to Secret*, and pick the
-// second version otherwise.  Since Secret is a secret and incomplete
-// type, the only expression a user can write that has type Secret* is
-// a null pointer literal.  Therefore, we know that x is a null
-// pointer literal if and only if the first version is picked by the
-// compiler.
-std::true_type IsNullLiteralHelper(Secret*, std::true_type);
-std::false_type IsNullLiteralHelper(IgnoredValue, std::false_type);
-std::false_type IsNullLiteralHelper(IgnoredValue, std::true_type);
-
-// A compile-time bool constant that is true if and only if x is a null pointer
-// literal (i.e. nullptr, NULL or any 0-valued compile-time integral constant).
-#define GTEST_IS_NULL_LITERAL_(x)                    \
-  decltype(::testing::internal::IsNullLiteralHelper( \
-      x,                                             \
-      ::testing::internal::TypeIsValidNullptrConstant<decltype(x)>()))::value
-
 // Appends the user-supplied message to the Google-Test-generated message.
 GTEST_API_ std::string AppendUserMessage(
     const std::string& gtest_msg, const Message& user_msg);

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -2970,7 +2970,7 @@ static const char* GetAnsiColorCode(GTestColor color) {
     case COLOR_YELLOW:  return "3";
     default:
       return nullptr;
-  };
+  }
 }
 
 #endif  // GTEST_OS_WINDOWS && !GTEST_OS_WINDOWS_MOBILE


### PR DESCRIPTION
If we misspell for example `SetUpTestcase `instead of `SetUpTestCase`, no error/warning will be shown.
But this mistake may happen frequently. Although for `SetUp `and `TearDown `(Because they are virtual) we can use override keyword and any misspell will cause error but for `SetUpTestCase `and `TearDownTestCase `there is no similar solution.

I've created this PR based on the issue I had reported and its response:
[https://github.com/google/googletest/issues/2122](url)