### PR TITLE
Handle GTEST_SKIP() when calling `Environment::SetUp()`

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -222,6 +222,7 @@ $env:Path = \"$project_bin;$env:Path\"
     test/gtest-typed-test2_test.cc)
   cxx_test(gtest_unittest gtest_main)
   cxx_test(gtest-unittest-api_test gtest)
+  cxx_test(gtest_skip_in_environment_setup_test gtest_main)
   cxx_test(gtest_skip_test gtest_main)
 
   ############################################################

--- a/googletest/Makefile.am
+++ b/googletest/Makefile.am
@@ -283,6 +283,12 @@ test_gtest_all_test_SOURCES = test/gtest_all_test.cc
 test_gtest_all_test_LDADD = lib/libgtest_main.la \
                             lib/libgtest.la
 
+TESTS += test/gtest_skip_in_environment_setup_test
+check_PROGRAMS += test/gtest_skip_in_environment_setup_test
+test_gtest_skip_in_environment_setup_test_SOURCES = test/gtest_skip_in_environment_setup_test.cc
+test_gtest_skip_in_environment_setup_test_LDADD= lib/libgtest_main.la \
+                                                 lib/libgtest.la
+
 # Tests that fused gtest files compile and work.
 FUSED_GTEST_SRC = \
   fused-src/gtest/gtest-all.cc \

--- a/googletest/docs/advanced.md
+++ b/googletest/docs/advanced.md
@@ -1289,8 +1289,10 @@ Environment* AddGlobalTestEnvironment(Environment* env);
 ```
 
 Now, when `RUN_ALL_TESTS()` is called, it first calls the `SetUp()` method of
-the environment object, then runs the tests if there was no fatal failures, and
-finally calls `TearDown()` of the environment object.
+each environment object, then runs the tests if none of the environments
+reported fatal failures and `GTEST_SKIP()` was not called. `RUN_ALL_TESTS()`
+always calls `TearDown()` with each environment object, regardless of whether
+or not the tests were run.
 
 It's OK to register multiple environment objects. In this case, their `SetUp()`
 will be called in the order they are registered, and their `TearDown()` will be

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -5263,9 +5263,23 @@ bool UnitTestImpl::RunAllTests() {
       ForEach(environments_, SetUpEnvironment);
       repeater->OnEnvironmentsSetUpEnd(*parent_);
 
-      // Runs the tests only if there was no fatal failure during global
-      // set-up.
-      if (!Test::HasFatalFailure()) {
+      // Runs the tests only if there was no fatal failure or skip triggered
+      // during global set-up.
+      if (Test::IsSkipped()) {
+        // Emit diagnostics when global set-up calls skip, as it will not be
+        // emitted by default.
+        TestResult& test_result =
+          *internal::GetUnitTestImpl()->current_test_result();
+        for (int j = 0; j < test_result.total_part_count(); ++j) {
+          const TestPartResult& test_part_result =
+            test_result.GetTestPartResult(j);
+          if (test_part_result.type() == TestPartResult::kSkip) {
+            const std::string& result = test_part_result.message();
+            printf("%s\n", result.c_str());
+          }
+        }
+        fflush(stdout);
+      } else if (!Test::HasFatalFailure()) {
         for (int test_index = 0; test_index < total_test_suite_count();
              test_index++) {
           GetMutableSuiteCase(test_index)->Run();

--- a/googletest/test/BUILD.bazel
+++ b/googletest/test/BUILD.bazel
@@ -285,6 +285,13 @@ cc_test(
     deps = ["//:gtest_main"],
 )
 
+cc_test(
+    name = "gtest_skip_in_environment_setup_test",
+    size = "small",
+    srcs = ["gtest_skip_in_environment_setup_test.cc"],
+    deps = ["//:gtest_main"],
+)
+
 py_test(
     name = "googletest-list-tests-unittest",
     size = "small",

--- a/googletest/test/gtest_skip_in_environment_setup_test.cc
+++ b/googletest/test/gtest_skip_in_environment_setup_test.cc
@@ -1,0 +1,60 @@
+// Copyright 2019, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// This test verifies that skipping in the environment results in the
+// testcases being skipped.
+//
+// This is a reproduction case for
+// https://github.com/google/googletest/issues/2189 .
+
+#include <iostream>
+#include <gtest/gtest.h>
+
+class SetupEnvironment : public testing::Environment {
+public:
+  void SetUp() override {
+    GTEST_SKIP() << "Skipping the entire environment";
+  }
+};
+
+TEST(Test, AlwaysPasses) {
+  EXPECT_EQ(true, true);
+}
+
+TEST(Test, AlwaysFails) {
+  EXPECT_EQ(true, false);
+}
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+
+  testing::AddGlobalTestEnvironment(new SetupEnvironment());
+
+  return (RUN_ALL_TESTS());
+}


### PR DESCRIPTION
gtest prior to this change would completely ignore `GTEST_SKIP()` if
called in `Environment::SetUp()`, instead of bailing out early, unlike
`Test::SetUp()`, which would cause the tests themselves to be skipped.
The only way (prior to this change) to skip the tests would be to
trigger a fatal error via `GTEST_FAIL()`.

Desirable behavior, in this case, when dealing with
`Environment::SetUp()` is to check for prerequisites on a system
(example, kernel supports a particular featureset, e.g., capsicum), and
skip the tests. The alternatives prior to this change would be
undesirable:

- Failing sends the wrong message to the test user, as the result of the
  tests is indeterminate, not failed.
- Having to add per-test class abstractions that override `SetUp()` to
  test for the capsicum feature set, then skip all of the tests in their
  respective SetUp fixtures, would be a lot of human and computational
  work; checking for the feature would need to be done for all of the
  tests, instead of once for all of the tests.

For those reasons, making `Environment::SetUp()` handle `GTEST_SKIP()`,
by not executing the testcases, is the most desirable solution.

In order to properly diagnose what happened when running the tests if
they are skipped, print out the diagnostics in an ad hoc manner.

Update the documentation to note this change and integrate a new test,
gtest_skip_in_environment_setup_test, into the test suite.

This change addresses #2189.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>