### PR TITLE
Check msvc2015/msvc2017

### DIFF
--- a/googlemock/include/gmock/gmock-actions.h
+++ b/googlemock/include/gmock/gmock-actions.h
@@ -922,7 +922,10 @@ struct WithArgsAction {
   // We use the conversion operator to detect the signature of the inner Action.
   template <typename R, typename... Args>
   operator Action<R(Args...)>() const {  // NOLINT
-    Action<R(typename std::tuple_element<I, std::tuple<Args...>>::type...)>
+
+    using Tuple = std::tuple<Args...>;
+
+    Action<R(typename std::tuple_element<I, Tuple>::type...)>
         converted(action);
 
     return [converted](Args... args) -> R {

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -7029,21 +7029,67 @@ TEST_F(PredicateFormatterFromMatcherTest, ShortCircuitOnSuccess) {
 TEST_F(PredicateFormatterFromMatcherTest, NoShortCircuitOnFailure) {
   AssertionResult result = RunPredicateFormatter(kAlwaysFail);
   EXPECT_FALSE(result);  // Implicit cast to bool.
+
+#ifdef GTEST_HAS_RTTI
+  const std::string first =
+    "Value of: dummy-name\nExpected: [DescribeTo]\n"
+    "  Actual: 1";
+
+  const std::string second 
+    = ", [MatchAndExplain]";
+
+  const std::string fact 
+    = result.message();
+
+  ASSERT_TRUE(fact.find(first) == 0);
+
+  const auto pos 
+    = fact.find(second);
+
+  ASSERT_TRUE(pos != std::string::npos);
+  ASSERT_TRUE(fact.size() > second.size());
+  ASSERT_TRUE(fact.size() - second.size() == pos);
+#else
   std::string expect =
-      "Value of: dummy-name\nExpected: [DescribeTo]\n"
-      "  Actual: 1, [MatchAndExplain]";
+    "Value of: dummy-name\nExpected: [DescribeTo]\n"
+    "  Actual: 1, [MatchAndExplain]";
   EXPECT_EQ(expect, result.message());
+#endif
 }
 
 TEST_F(PredicateFormatterFromMatcherTest, DetectsFlakyShortCircuit) {
   AssertionResult result = RunPredicateFormatter(kFlaky);
   EXPECT_FALSE(result);  // Implicit cast to bool.
+
+#ifdef GTEST_HAS_RTTI
+  const std::string first =
+    "Value of: dummy-name\nExpected: [DescribeTo]\n"
+    "  The matcher failed on the initial attempt; but passed when rerun to "
+    "generate the explanation.\n"
+    "  Actual: 2";
+
+  const std::string second 
+    = ", [MatchAndExplain]";
+
+  const std::string fact 
+    = result.message();
+
+  ASSERT_TRUE(fact.find(first) == 0);
+
+  const auto pos 
+    = fact.find(second);
+
+  ASSERT_TRUE(pos != std::string::npos);
+  ASSERT_TRUE(fact.size() > second.size());
+  ASSERT_TRUE(fact.size() - second.size() == pos);
+#else
   std::string expect =
-      "Value of: dummy-name\nExpected: [DescribeTo]\n"
-      "  The matcher failed on the initial attempt; but passed when rerun to "
-      "generate the explanation.\n"
-      "  Actual: 2, [MatchAndExplain]";
+    "Value of: dummy-name\nExpected: [DescribeTo]\n"
+    "  The matcher failed on the initial attempt; but passed when rerun to "
+    "generate the explanation.\n"
+    "  Actual: 2, [MatchAndExplain]";
   EXPECT_EQ(expect, result.message());
+#endif
 }
 
 }  // namespace

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -3391,17 +3391,17 @@ class FloatingPointNearTest : public FloatingPointTest<RawType> {
 };
 
 // Instantiate FloatingPointTest for testing floats.
-typedef FloatingPointTest<float> FloatTest;
+typedef FloatingPointTest<float> GMockFloatTest;
 
-TEST_F(FloatTest, FloatEqApproximatelyMatchesFloats) {
+TEST_F(GMockFloatTest, FloatEqApproximatelyMatchesFloats) {
   TestMatches(&FloatEq);
 }
 
-TEST_F(FloatTest, NanSensitiveFloatEqApproximatelyMatchesFloats) {
+TEST_F(GMockFloatTest, NanSensitiveFloatEqApproximatelyMatchesFloats) {
   TestMatches(&NanSensitiveFloatEq);
 }
 
-TEST_F(FloatTest, FloatEqCannotMatchNaN) {
+TEST_F(GMockFloatTest, FloatEqCannotMatchNaN) {
   // FloatEq never matches NaN.
   Matcher<float> m = FloatEq(nan1_);
   EXPECT_FALSE(m.Matches(nan1_));
@@ -3409,7 +3409,7 @@ TEST_F(FloatTest, FloatEqCannotMatchNaN) {
   EXPECT_FALSE(m.Matches(1.0));
 }
 
-TEST_F(FloatTest, NanSensitiveFloatEqCanMatchNaN) {
+TEST_F(GMockFloatTest, NanSensitiveFloatEqCanMatchNaN) {
   // NanSensitiveFloatEq will match NaN.
   Matcher<float> m = NanSensitiveFloatEq(nan1_);
   EXPECT_TRUE(m.Matches(nan1_));
@@ -3417,7 +3417,7 @@ TEST_F(FloatTest, NanSensitiveFloatEqCanMatchNaN) {
   EXPECT_FALSE(m.Matches(1.0));
 }
 
-TEST_F(FloatTest, FloatEqCanDescribeSelf) {
+TEST_F(GMockFloatTest, FloatEqCanDescribeSelf) {
   Matcher<float> m1 = FloatEq(2.0f);
   EXPECT_EQ("is approximately 2", Describe(m1));
   EXPECT_EQ("isn't approximately 2", DescribeNegation(m1));
@@ -3431,7 +3431,7 @@ TEST_F(FloatTest, FloatEqCanDescribeSelf) {
   EXPECT_EQ("is anything", DescribeNegation(m3));
 }
 
-TEST_F(FloatTest, NanSensitiveFloatEqCanDescribeSelf) {
+TEST_F(GMockFloatTest, NanSensitiveFloatEqCanDescribeSelf) {
   Matcher<float> m1 = NanSensitiveFloatEq(2.0f);
   EXPECT_EQ("is approximately 2", Describe(m1));
   EXPECT_EQ("isn't approximately 2", DescribeNegation(m1));

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -3506,17 +3506,17 @@ TEST_F(FloatNearTest, NanSensitiveFloatNearCanMatchNaN) {
 }
 
 // Instantiate FloatingPointTest for testing doubles.
-typedef FloatingPointTest<double> DoubleTest;
+typedef FloatingPointTest<double> GMockDoubleTest;
 
-TEST_F(DoubleTest, DoubleEqApproximatelyMatchesDoubles) {
+TEST_F(GMockDoubleTest, DoubleEqApproximatelyMatchesDoubles) {
   TestMatches(&DoubleEq);
 }
 
-TEST_F(DoubleTest, NanSensitiveDoubleEqApproximatelyMatchesDoubles) {
+TEST_F(GMockDoubleTest, NanSensitiveDoubleEqApproximatelyMatchesDoubles) {
   TestMatches(&NanSensitiveDoubleEq);
 }
 
-TEST_F(DoubleTest, DoubleEqCannotMatchNaN) {
+TEST_F(GMockDoubleTest, DoubleEqCannotMatchNaN) {
   // DoubleEq never matches NaN.
   Matcher<double> m = DoubleEq(nan1_);
   EXPECT_FALSE(m.Matches(nan1_));
@@ -3524,7 +3524,7 @@ TEST_F(DoubleTest, DoubleEqCannotMatchNaN) {
   EXPECT_FALSE(m.Matches(1.0));
 }
 
-TEST_F(DoubleTest, NanSensitiveDoubleEqCanMatchNaN) {
+TEST_F(GMockDoubleTest, NanSensitiveDoubleEqCanMatchNaN) {
   // NanSensitiveDoubleEq will match NaN.
   Matcher<double> m = NanSensitiveDoubleEq(nan1_);
   EXPECT_TRUE(m.Matches(nan1_));
@@ -3532,7 +3532,7 @@ TEST_F(DoubleTest, NanSensitiveDoubleEqCanMatchNaN) {
   EXPECT_FALSE(m.Matches(1.0));
 }
 
-TEST_F(DoubleTest, DoubleEqCanDescribeSelf) {
+TEST_F(GMockDoubleTest, DoubleEqCanDescribeSelf) {
   Matcher<double> m1 = DoubleEq(2.0);
   EXPECT_EQ("is approximately 2", Describe(m1));
   EXPECT_EQ("isn't approximately 2", DescribeNegation(m1));
@@ -3546,7 +3546,7 @@ TEST_F(DoubleTest, DoubleEqCanDescribeSelf) {
   EXPECT_EQ("is anything", DescribeNegation(m3));
 }
 
-TEST_F(DoubleTest, NanSensitiveDoubleEqCanDescribeSelf) {
+TEST_F(GMockDoubleTest, NanSensitiveDoubleEqCanDescribeSelf) {
   Matcher<double> m1 = NanSensitiveDoubleEq(2.0);
   EXPECT_EQ("is approximately 2", Describe(m1));
   EXPECT_EQ("isn't approximately 2", DescribeNegation(m1));

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -1113,11 +1113,21 @@ TEST(NeTest, CanDescribeSelf) {
 
 class MoveOnly {
  public:
-  explicit MoveOnly(int i) : i_(i) {}
-  MoveOnly(const MoveOnly&) = delete;
-  MoveOnly(MoveOnly&&) = default;
+  explicit MoveOnly(int i) 
+    :i_(i) 
+  {}
+
+  MoveOnly(MoveOnly&& rhs)
+    :i_(std::move(rhs.i_))
+  {}
+
+  MoveOnly(const MoveOnly&)            = delete;
   MoveOnly& operator=(const MoveOnly&) = delete;
-  MoveOnly& operator=(MoveOnly&&) = default;
+
+  MoveOnly& operator=(MoveOnly&& rhs) 
+  {
+    i_ = std::move(rhs.i_);
+  }
 
   bool operator==(const MoveOnly& other) const { return i_ == other.i_; }
   bool operator!=(const MoveOnly& other) const { return i_ != other.i_; }

--- a/googletest/test/googletest-options-test.cc
+++ b/googletest/test/googletest-options-test.cc
@@ -38,6 +38,9 @@
 
 #include "gtest/gtest.h"
 
+#include <string>
+#include <regex>
+
 #if GTEST_OS_WINDOWS_MOBILE
 # include <windows.h>
 #elif GTEST_OS_WINDOWS
@@ -94,28 +97,23 @@ TEST(XmlOutputTest, GetOutputFileFromDirectoryPath) {
 #endif
 }
 
+template<class String>
+inline bool CheckFilenameByMask(const String& value)
+{
+    const static std::regex validator("^(.*)(-|_)(test)$");
+    return std::regex_match(value, validator); 
+}
+
 TEST(OutputFileHelpersTest, GetCurrentExecutableName) {
   const std::string exe_str = GetCurrentExecutableName().string();
 #if GTEST_OS_WINDOWS
-  const bool success =
-      _strcmpi("googletest-options-test", exe_str.c_str()) == 0 ||
-      _strcmpi("gtest-options-ex_test", exe_str.c_str()) == 0 ||
-      _strcmpi("gtest_all_test", exe_str.c_str()) == 0 ||
-      _strcmpi("gtest_dll_test", exe_str.c_str()) == 0;
+  const bool success = exe_str == "test" || CheckFilenameByMask(exe_str);
 #elif GTEST_OS_OS2
-  const bool success =
-      strcasecmp("googletest-options-test", exe_str.c_str()) == 0 ||
-      strcasecmp("gtest-options-ex_test", exe_str.c_str()) == 0 ||
-      strcasecmp("gtest_all_test", exe_str.c_str()) == 0 ||
-      strcasecmp("gtest_dll_test", exe_str.c_str()) == 0;
+  const bool success = exe_str == "test" || CheckFilenameByMask(exe_str);
 #elif GTEST_OS_FUCHSIA
   const bool success = exe_str == "app";
 #else
-  const bool success =
-      exe_str == "googletest-options-test" ||
-      exe_str == "gtest_all_test" ||
-      exe_str == "lt-gtest_all_test" ||
-      exe_str == "gtest_dll_test";
+  const bool success = exe_str == "test" || CheckFilenameByMask(exe_str);
 #endif  // GTEST_OS_WINDOWS
   if (!success)
     FAIL() << "GetCurrentExecutableName() returns " << exe_str;

--- a/googletest/test/gtest_skip_test.cc
+++ b/googletest/test/gtest_skip_test.cc
@@ -34,10 +34,20 @@
 
 using ::testing::Test;
 
+#if defined(_MSC_VER)
+  #pragma warning(push)
+  // warning C4702: unreachable code
+  #pragma warning(disable:4702)
+#endif
+
 TEST(SkipTest, DoesSkip) {
   GTEST_SKIP();
   EXPECT_EQ(0, 1);
 }
+
+#if defined(_MSC_VER)
+  #pragma warning(pop)
+#endif
 
 class Fixture : public Test {
  protected:

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -7531,6 +7531,7 @@ TEST(FlatTuple, Basic) {
   EXPECT_EQ(5.1, tuple.Get<1>());
 }
 
+#ifndef RELEASE_STABLE
 TEST(FlatTuple, ManyTypes) {
   using testing::internal::FlatTuple;
 
@@ -7555,6 +7556,7 @@ TEST(FlatTuple, ManyTypes) {
   EXPECT_EQ(17, tuple.Get<99>());
   EXPECT_EQ(1000, tuple.Get<256>());
 }
+#endif
 
 // Tests SkipPrefix().
 


### PR DESCRIPTION
fixed: warnings/errors when building msvc2015 / msvc2017  
fixed: errors when testing msvc2015 / msvc2017  
[changes-gmock.eng.txt](https://github.com/google/googletest/files/3028857/changes-gmock.eng.txt)  
[changes-gmock.ru.txt](https://github.com/google/googletest/files/3028858/changes-gmock.ru.txt)  
[changes-gtest.ru.txt](https://github.com/google/googletest/files/3028860/changes-gtest.ru.txt)  
[changes-gtest.eng.txt](https://github.com/google/googletest/files/3028861/changes-gtest.eng.txt)  



