### PR TITLE
MSVC C5046 warning is unavailable in MSVC 2015.

### DIFF
--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -58,9 +58,16 @@
 #include "gmock/internal/gmock-port.h"
 #include "gtest/gtest.h"
 
+// MSVC warning C5046 is new as of VS2017 version 15.8.
+#if defined(_MSC_VER) && _MSC_VER >= 1915
+#define GMOCK_MAYBE_5046_ 5046
+#else
+#define GMOCK_MAYBE_5046_
+#endif
+
 GTEST_DISABLE_MSC_WARNINGS_PUSH_(
-    4251 5046 /* class A needs to have dll-interface to be used by clients of
-                 class B */
+    4251 GMOCK_MAYBE_5046_ /* class A needs to have dll-interface to be used by
+                              clients of class B */
     /* Symbol involving type with internal linkage not defined */)
 
 namespace testing {

--- a/googletest/include/gtest/gtest-matchers.h
+++ b/googletest/include/gtest/gtest-matchers.h
@@ -47,9 +47,16 @@
 #include "gtest/internal/gtest-internal.h"
 #include "gtest/internal/gtest-port.h"
 
+// MSVC warning C5046 is new as of VS2017 version 15.8.
+#if defined(_MSC_VER) && _MSC_VER >= 1915
+#define GTEST_MAYBE_5046_ 5046
+#else
+#define GTEST_MAYBE_5046_
+#endif
+
 GTEST_DISABLE_MSC_WARNINGS_PUSH_(
-    4251 5046 /* class A needs to have dll-interface to be used by clients of
-                 class B */
+    4251 GTEST_MAYBE_5046_ /* class A needs to have dll-interface to be used by
+                              clients of class B */
     /* Symbol involving type with internal linkage not defined */)
 
 namespace testing {


### PR DESCRIPTION
Per the MSVC documentation, the warning is new as of Visual Studio 2017, version 15.8.
https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5046?view=vs-2019

GTest users building on MSVC 2015 or older versions of 2017 will, when C4616 is enabled, see a warning like:

[...]gtest-matchers.h(53): error C2220: warning treated as error - no 'object' file generated
[...]gtest-matchers.h(53): warning C4619: #pragma warning: there is no warning number '5046'

Guard the mention of 5046 by an _MSC_VER check. VS2017 15.8 corresponds to an _MSC_VER of 1915.
https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019

VS2017 15.7 is not very old (15.7 was released August 2018 and 15.8 was released November 2018), and I believe VS2015 is still covered under Abseil's support guarantees. (BoringSSL have some consumers who sadly still support VS2015, so we have to apply this patch to update googletest.)