### PR TITLE
Fix -Wsign-conversion error on Android by using the right function

### DIFF
--- a/googletest/src/gtest-printers.cc
+++ b/googletest/src/gtest-printers.cc
@@ -237,7 +237,7 @@ void PrintCharAndCodeTo(Char c, ostream* os) {
   if (format == kHexEscape || (1 <= c && c <= 9)) {
     // Do nothing.
   } else {
-    *os << ", 0x" << String::FormatHexInt(static_cast<UnsignedChar>(c));
+    *os << ", 0x" << String::FormatHexInt(static_cast<int>(c));
   }
   *os << ")";
 }


### PR DESCRIPTION
Google Test build is broken on Android by the following error:

```
~/googletest/googletest/src/gtest-printers.cc:240:43: error:
      implicit conversion changes signedness: 'wchar_t' to 'int' [-Werror,-Wsign-conversion]
    *os << ", 0x" << String::FormatHexInt(static_cast<UnsignedChar>(c));
                     ~~~~~~               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
~/googletest/googletest/src/gtest-printers.cc:255:3: note: in
      instantiation of function template specialization 'testing::internal::PrintCharAndCodeTo<wchar_t,
      wchar_t>' requested here
  PrintCharAndCodeTo<wchar_t>(wc, os);
  ^
1 error generated.
```

I fixed it by using `FormatHexUInt32` instead of `FormatHexInt`. After all, UnsignedChar is intended to be an unsigned type.