### PR TITLE
Feature: Add support for google unit tests to register tests dynamically

### DIFF
--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -437,7 +437,7 @@ GTEST_API_ TypeId GetTestTypeId();
 
 // Defines the abstract factory interface that creates instances
 // of a Test object.
-class TestFactoryBase {
+class GTEST_API_ TestFactoryBase {
  public:
   virtual ~TestFactoryBase() {}
 

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -5555,10 +5555,12 @@ void UnitTestImpl::ListTestsMatchingFilter() {
 
         int line = test_info->location_.line;
 
+#ifdef _CPPRTTI
         if (dynamic_cast<const DynamicTestInfo*>(test_info) == nullptr)
             // +1 => Here we just pick up next line after where test was declared - GTA is extracting
             // line information in same manner. Not necessarily correct, but best guess
             line++;
+#endif
 
         printf("  <loc>%s(%d)\n", test_info->location_.file.c_str(), line);
 

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -2574,8 +2574,8 @@ TestInfo::TestInfo(const std::string& a_test_suite_name,
 DynamicTestInfo::DynamicTestInfo(
     const std::string& suite, const std::string& testName, 
     functionTestBody _testBody,
-    const char* file, int line ) :
-    TestInfo(suite, testName, nullptr, nullptr, internal::CodeLocation(file, line), nullptr, this),
+    const char* _file, int _line ) :
+    TestInfo(suite, testName, nullptr, nullptr, internal::CodeLocation(_file, _line), nullptr, this),
     testBody(_testBody)
 {
     ownFactory_ = false;

--- a/googletest/test/googletest-list-tests-unittest.py
+++ b/googletest/test/googletest-list-tests-unittest.py
@@ -51,60 +51,96 @@ EXE_PATH = gtest_test_utils.GetTestExecutablePath('googletest-list-tests-unittes
 # The expected output when running googletest-list-tests-unittest_ with
 # --gtest_list_tests
 EXPECTED_OUTPUT_NO_FILTER_RE = re.compile(r"""FooDeathTest\.
+  <loc>.*googletest-list-tests-unittest.*
   Test1
 Foo\.
+  <loc>.*googletest-list-tests-unittest.*
   Bar1
+  <loc>.*googletest-list-tests-unittest.*
   Bar2
+  <loc>.*googletest-list-tests-unittest.*
   DISABLED_Bar3
 Abc\.
+  <loc>.*googletest-list-tests-unittest.*
   Xyz
+  <loc>.*googletest-list-tests-unittest.*
   Def
 FooBar\.
+  <loc>.*googletest-list-tests-unittest.*
   Baz
 FooTest\.
+  <loc>.*googletest-list-tests-unittest.*
   Test1
+  <loc>.*googletest-list-tests-unittest.*
   DISABLED_Test2
+  <loc>.*googletest-list-tests-unittest.*
   Test3
 TypedTest/0\.  # TypeParam = (VeryLo{245}|class VeryLo{239})\.\.\.
+  <loc>.*googletest-list-tests-unittest.*
   TestA
+  <loc>.*googletest-list-tests-unittest.*
   TestB
 TypedTest/1\.  # TypeParam = int\s*\*( __ptr64)?
+  <loc>.*googletest-list-tests-unittest.*
   TestA
+  <loc>.*googletest-list-tests-unittest.*
   TestB
 TypedTest/2\.  # TypeParam = .*MyArray<bool,\s*42>
+  <loc>.*googletest-list-tests-unittest.*
   TestA
+  <loc>.*googletest-list-tests-unittest.*
   TestB
 My/TypeParamTest/0\.  # TypeParam = (VeryLo{245}|class VeryLo{239})\.\.\.
+  <loc>.*googletest-list-tests-unittest.*
   TestA
+  <loc>.*googletest-list-tests-unittest.*
   TestB
 My/TypeParamTest/1\.  # TypeParam = int\s*\*( __ptr64)?
+  <loc>.*googletest-list-tests-unittest.*
   TestA
+  <loc>.*googletest-list-tests-unittest.*
   TestB
 My/TypeParamTest/2\.  # TypeParam = .*MyArray<bool,\s*42>
+  <loc>.*googletest-list-tests-unittest.*
   TestA
+  <loc>.*googletest-list-tests-unittest.*
   TestB
 MyInstantiation/ValueParamTest\.
+  <loc>.*googletest-list-tests-unittest.*
   TestA/0  # GetParam\(\) = one line
+  <loc>.*googletest-list-tests-unittest.*
   TestA/1  # GetParam\(\) = two\\nlines
+  <loc>.*googletest-list-tests-unittest.*
   TestA/2  # GetParam\(\) = a very\\nlo{241}\.\.\.
+  <loc>.*googletest-list-tests-unittest.*
   TestB/0  # GetParam\(\) = one line
+  <loc>.*googletest-list-tests-unittest.*
   TestB/1  # GetParam\(\) = two\\nlines
+  <loc>.*googletest-list-tests-unittest.*
   TestB/2  # GetParam\(\) = a very\\nlo{241}\.\.\.
 """)
 
 # The expected output when running googletest-list-tests-unittest_ with
 # --gtest_list_tests and --gtest_filter=Foo*.
 EXPECTED_OUTPUT_FILTER_FOO_RE = re.compile(r"""FooDeathTest\.
+  <loc>.*googletest-list-tests-unittest.*
   Test1
 Foo\.
+  <loc>.*googletest-list-tests-unittest.*
   Bar1
+  <loc>.*googletest-list-tests-unittest.*
   Bar2
+  <loc>.*googletest-list-tests-unittest.*
   DISABLED_Bar3
 FooBar\.
+  <loc>.*googletest-list-tests-unittest.*
   Baz
 FooTest\.
+  <loc>.*googletest-list-tests-unittest.*
   Test1
+  <loc>.*googletest-list-tests-unittest.*
   DISABLED_Test2
+  <loc>.*googletest-list-tests-unittest.*
   Test3
 """)
 


### PR DESCRIPTION

This change allows simple dynamic test registration for google unit test.

Sample code how it can be used can be found here: 

https://github.com/tapika/cppscriptcore/blob/8d29136f86e3ff874d21cc76014c852f3f1c9fda/SolutionProjectModel/cppexec/cppexec.cpp#L144

This change:

https://github.com/tapika/googletest/blob/ae45849962424c0353cc01d0ea873ccff1dc4163/googletest/src/gtest.cc#L5563

Allows also for test application to provide source code position information back to caller, using special `<loc>` syntax. Currently Google test adapter does not supports it, my own fork does.
