### PR TITLE
Fix typo introduced in 63be3dcc245 (maintaners -> maintainers)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Note: CMake support is community-based. The maintaners do not use CMake
+# Note: CMake support is community-based. The maintainers do not use CMake
 # internally.
 
 cmake_minimum_required(VERSION 2.8.8)

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-# Note: automake support is community-based. The maintaners do not use automake
+# Note: automake support is community-based. The maintainers do not use automake
 # internally.
 
 ## Process this file with automake to produce Makefile.in

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-# Note: automake support is community-based. The maintaners do not use automake
+# Note: automake support is community-based. The maintainers do not use automake
 # internally.
 
 AC_INIT([Google C++ Mocking and Testing Frameworks],

--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -1,5 +1,5 @@
 ########################################################################
-# Note: CMake support is community-based. The maintaners do not use CMake
+# Note: CMake support is community-based. The maintainers do not use CMake
 # internally.
 #
 # CMake build script for Google Mock.

--- a/googlemock/Makefile.am
+++ b/googlemock/Makefile.am
@@ -1,4 +1,4 @@
-# Note: automake support is community-based. The maintaners do not use automake
+# Note: automake support is community-based. The maintainers do not use automake
 # internally.
 
 # Automake file

--- a/googlemock/configure.ac
+++ b/googlemock/configure.ac
@@ -1,4 +1,4 @@
-# Note: automake support is community-based. The maintaners do not use automake
+# Note: automake support is community-based. The maintainers do not use automake
 # internally.
 
 m4_include(../googletest/m4/acx_pthread.m4)

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -1,5 +1,5 @@
 ########################################################################
-# Note: CMake support is community-based. The maintaners do not use CMake
+# Note: CMake support is community-based. The maintainers do not use CMake
 # internally.
 #
 # CMake build script for Google Test.

--- a/googletest/Makefile.am
+++ b/googletest/Makefile.am
@@ -1,4 +1,4 @@
-# Note: automake support is community-based. The maintaners do not use automake
+# Note: automake support is community-based. The maintainers do not use automake
 # internally.
 
 # Automake file

--- a/googletest/configure.ac
+++ b/googletest/configure.ac
@@ -1,4 +1,4 @@
-# Note: automake support is community-based. The maintaners do not use automake
+# Note: automake support is community-based. The maintainers do not use automake
 # internally.
 
 m4_include(m4/acx_pthread.m4)


### PR DESCRIPTION
Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>