### PR TITLE
Extend gtest-port and stubs for ESP_PLATFORM

### DIFF
--- a/googletest/src/gtest-filepath.cc
+++ b/googletest/src/gtest-filepath.cc
@@ -93,8 +93,8 @@ static bool IsPathSeparator(char c) {
 // Returns the current working directory, or "" if unsuccessful.
 FilePath FilePath::GetCurrentDir() {
 #if GTEST_OS_WINDOWS_MOBILE || GTEST_OS_WINDOWS_PHONE || \
-    GTEST_OS_WINDOWS_RT || ARDUINO
-  // Windows CE and Arduino don't have a current directory, so we just return
+    GTEST_OS_WINDOWS_RT || ARDUINO || ESP_PLATFORM
+  // These platforms do not have a current directory so we just return
   // something reasonable.
   return FilePath(kCurrentDirectoryString);
 #elif GTEST_OS_WINDOWS

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -3044,7 +3044,7 @@ void ColoredPrintf(GTestColor color, const char* fmt, ...) {
   va_start(args, fmt);
 
 #if GTEST_OS_WINDOWS_MOBILE || GTEST_OS_ZOS || GTEST_OS_IOS || \
-    GTEST_OS_WINDOWS_PHONE || GTEST_OS_WINDOWS_RT
+    GTEST_OS_WINDOWS_PHONE || GTEST_OS_WINDOWS_RT || ESP_PLATFORM
   const bool use_color = AlwaysFalse();
 #else
   static const bool in_color_mode =


### PR DESCRIPTION
ESP_PLATFORM is the macro used to indicate compilation for the ESP32
using the esp-idf library. This isn't a fully posix compatible system so
various features of google test need to be stubbed out in order for
it to work. It's oddly similar to the GTEST_OS_WINDOWS_PHONE setup.