### PR TITLE
Suppress CMake policy warning (CMP0048)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@
 
 cmake_minimum_required(VERSION 2.8.8)
 
+if (POLICY CMP0048)
+  cmake_policy(SET CMP0048 NEW)
+endif (POLICY CMP0048)
+
 project(googletest-distribution)
 set(GOOGLETEST_VERSION 1.9.0)
 
@@ -15,10 +19,6 @@ else()
     set(CMAKE_CXX_EXTENSIONS OFF)
   endif()
 endif()
-
-if (POLICY CMP0048)
-  cmake_policy(SET CMP0048 NEW)
-endif (POLICY CMP0048)
 
 enable_testing()
 


### PR DESCRIPTION
As suggested in #2150.

This moves the `cmake_policy` command before the project definition, where it used to be until: https://github.com/google/googletest/commit/67265e07067758f51db6fd9296de02c16b1f9873. It was introduced with https://github.com/google/googletest/pull/782. 

This suppresses the following policy warning:

```
CMake Warning (dev) at CMakeLists.txt:6 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    CMAKE_PROJECT_VERSION
    CMAKE_PROJECT_VERSION_MAJOR
    CMAKE_PROJECT_VERSION_MINOR
    CMAKE_PROJECT_VERSION_PATCH
This warning is for project developers.  Use -Wno-dev to suppress it.
```