### PR TITLE
Make gtest_main testonly in Bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -112,6 +112,7 @@ cc_library(
     name = "gtest_main",
     srcs = ["googlemock/src/gmock_main.cc"],
     deps = [":gtest"],
+    testonly = True,
     features = select({
         ":windows": ["windows_export_all_symbols"],
         "//conditions:default": [],


### PR DESCRIPTION
`gtest_main` should not be a non-test dependency of anyone. Even though googletest is just a library I feel like that's reasonable to enforce on customers.

Also it prevents non-testonly libraries from erroneously pulling it in and using the wrong main or causing link errors.