### PR TITLE
Add MAP_GROWSDOWN flag for call to mmap in Linux for stack auto-resizing

### DIFF
--- a/googletest/src/gtest-death-test.cc
+++ b/googletest/src/gtest-death-test.cc
@@ -1357,6 +1357,10 @@ static pid_t ExecDeathTestSpawnChild(char* const* argv, int close_fd) {
     const auto stack_size = static_cast<size_t>(getpagesize());
     // MMAP_ANONYMOUS is not defined on Mac, so we use MAP_ANON instead.
     void* const stack = mmap(nullptr, stack_size, PROT_READ | PROT_WRITE,
+    // Include the MAP_GROWSDOWN flag in linux for stack auto-resizing
+#    if GTEST_OS_LINUX
+                             (stack_grows_down ? MAP_GROWSDOWN : 0) |
+#    endif
                              MAP_ANON | MAP_PRIVATE, -1, 0);
     GTEST_DEATH_TEST_CHECK_(stack != MAP_FAILED);
 


### PR DESCRIPTION
https://github.com/google/googletest/pull/1274 was, I believe, closed prematurely.  The downstream bug was closed as it is being patched but I'm hoping that you would consider applying the necessary change upstream.  Currently, only one page of memory is allocated to` clone()` in `ExecDeathTestSpawnChild()`. On my system, a page is 4 KB.  Examples I've seen show 1MB as a reasonable stack size for clone().  In this PR, I have chosen `getpagesize() * 8` since 8 is the first multiple of 2 that, when multiplied by the page size, provides enough stack space to prevent a stack overflow in a sandboxed environment.