### PR TITLE
Fix CI break

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       install: ./ci/install-platformio.sh
       script: ./ci/build-platformio.sh      
     - os: linux
-      compiler: gcc4.9
+      compiler: gcc
       sudo : true
       install: ./ci/install-linux.sh && ./ci/log-config.sh
       script: ./ci/build-linux-bazel.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       install: ./ci/install-platformio.sh
       script: ./ci/build-platformio.sh      
     - os: linux
-      compiler: gcc
+      compiler: gcc4.9
       sudo : true
       install: ./ci/install-linux.sh && ./ci/log-config.sh
       script: ./ci/build-linux-bazel.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,8 @@ language: cpp
 matrix:
   include:
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
-      group: deprecated-2017Q3
       before_install: chmod -R +x ./ci/*platformio.sh 
       install: ./ci/install-platformio.sh
       script: ./ci/build-platformio.sh      
@@ -28,11 +27,9 @@ matrix:
       install: ./ci/install-linux.sh && ./ci/log-config.sh
       script: ./ci/build-linux-bazel.sh
     - os: linux
-      group: deprecated-2017Q4
       compiler: gcc
       env: BUILD_TYPE=Debug VERBOSE=1 CXX_FLAGS=-std=c++11 
     - os: linux
-      group: deprecated-2017Q4
       compiler: clang
       env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11 -Wgnu-zero-variadic-macro-arguments
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,18 @@ language: cpp
 matrix:
   include:
     - os: linux
-      dist: xenial
       sudo: required
       before_install: chmod -R +x ./ci/*platformio.sh 
       install: ./ci/install-platformio.sh
       script: ./ci/build-platformio.sh      
     - os: linux
+      dist: xenial
       compiler: gcc
       sudo : true
       install: ./ci/install-linux.sh && ./ci/log-config.sh
       script: ./ci/build-linux-bazel.sh
     - os: linux
+      dist: xenial
       compiler: clang
       sudo : true
       install: ./ci/install-linux.sh && ./ci/log-config.sh

--- a/ci/install-linux.sh
+++ b/ci/install-linux.sh
@@ -41,11 +41,7 @@ if [ "${TRAVIS_SUDO}" = "true" ]; then
     echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | \
         sudo tee /etc/apt/sources.list.d/bazel.list
     curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
-    sudo apt-get update && sudo apt-get install -y gcc-4.9 g++-4.9 clang-3.9
-    sudo wget https://github.com/bazelbuild/bazel/releases/download/0.26.1/bazel-0.26.1-installer-linux-x86_64.sh
-    sudo chmod +x bazel-0.26.1-installer-linux-x86_64.sh
-    sudo ./bazel-0.26.1-installer-linux-x86_64.sh 
-
+    sudo apt-get update && sudo apt-get install -y bazel gcc-4.9 g++-4.9 clang-3.9
   elif [ "${CXX}" = "clang++" ]; then
     # Use ccache, assuming $HOME/bin is in the path, which is true in the Travis build environment.
     ln -sf /usr/bin/ccache $HOME/bin/${CXX};

--- a/ci/install-linux.sh
+++ b/ci/install-linux.sh
@@ -42,7 +42,7 @@ if [ "${TRAVIS_SUDO}" = "true" ]; then
         sudo tee /etc/apt/sources.list.d/bazel.list
     curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
     sudo apt-get update && sudo apt-get install -y bazel gcc-4.9 g++-4.9 clang-3.9
-elif[ "${CXX}" = "clang++" ]; then
+elif [ "${CXX}" = "clang++" ]; then
     # Use ccache, assuming $HOME/bin is in the path, which is true in the Travis build environment.
     ln -sf /usr/bin/ccache $HOME/bin/${CXX};
     ln -sf /usr/bin/ccache $HOME/bin/${CC};

--- a/ci/install-linux.sh
+++ b/ci/install-linux.sh
@@ -42,7 +42,7 @@ if [ "${TRAVIS_SUDO}" = "true" ]; then
         sudo tee /etc/apt/sources.list.d/bazel.list
     curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
     sudo apt-get update && sudo apt-get install -y gcc-4.9 g++-4.9 clang-3.9
-    sudo apt-get install bazel 0.26.1
+    sudo apt-get install bazel-0.26.1
 elif [ "${CXX}" = "clang++" ]; then
     # Use ccache, assuming $HOME/bin is in the path, which is true in the Travis build environment.
     ln -sf /usr/bin/ccache $HOME/bin/${CXX};

--- a/ci/install-linux.sh
+++ b/ci/install-linux.sh
@@ -41,7 +41,8 @@ if [ "${TRAVIS_SUDO}" = "true" ]; then
     echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | \
         sudo tee /etc/apt/sources.list.d/bazel.list
     curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
-    sudo apt-get update && sudo apt-get install -y bazel gcc-4.9 g++-4.9 clang-3.9
+    sudo apt-get update && sudo apt-get install -y gcc-4.9 g++-4.9 clang-3.9
+    sudo apt-get install bazel 0.26.1
 elif [ "${CXX}" = "clang++" ]; then
     # Use ccache, assuming $HOME/bin is in the path, which is true in the Travis build environment.
     ln -sf /usr/bin/ccache $HOME/bin/${CXX};

--- a/ci/install-linux.sh
+++ b/ci/install-linux.sh
@@ -42,9 +42,9 @@ if [ "${TRAVIS_SUDO}" = "true" ]; then
         sudo tee /etc/apt/sources.list.d/bazel.list
     curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
     sudo apt-get update && sudo apt-get install -y gcc-4.9 g++-4.9 clang-3.9
-    wget https://github.com/bazelbuild/bazel/releases/download/0.26.1/bazel-0.26.1-installer-linux-x86_64.sh
-    chmod +x bazel-0.26.1-installer-linux-x86_64.sh
-    ./bazel-0.26.1-installer-linux-x86_64.sh 
+    sudo wget https://github.com/bazelbuild/bazel/releases/download/0.26.1/bazel-0.26.1-installer-linux-x86_64.sh
+    sudo chmod +x bazel-0.26.1-installer-linux-x86_64.sh
+    sudo ./bazel-0.26.1-installer-linux-x86_64.sh 
 
   elif [ "${CXX}" = "clang++" ]; then
     # Use ccache, assuming $HOME/bin is in the path, which is true in the Travis build environment.

--- a/ci/install-linux.sh
+++ b/ci/install-linux.sh
@@ -42,7 +42,7 @@ if [ "${TRAVIS_SUDO}" = "true" ]; then
         sudo tee /etc/apt/sources.list.d/bazel.list
     curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
     sudo apt-get update && sudo apt-get install -y bazel gcc-4.9 g++-4.9 clang-3.9
-  elif [ "${CXX}" = "clang++" ]; then
+  elif[ "${CXX}" = "clang++" ]; then
     # Use ccache, assuming $HOME/bin is in the path, which is true in the Travis build environment.
     ln -sf /usr/bin/ccache $HOME/bin/${CXX};
     ln -sf /usr/bin/ccache $HOME/bin/${CC};

--- a/ci/install-linux.sh
+++ b/ci/install-linux.sh
@@ -42,7 +42,7 @@ if [ "${TRAVIS_SUDO}" = "true" ]; then
         sudo tee /etc/apt/sources.list.d/bazel.list
     curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
     sudo apt-get update && sudo apt-get install -y bazel gcc-4.9 g++-4.9 clang-3.9
-  elif[ "${CXX}" = "clang++" ]; then
+elif[ "${CXX}" = "clang++" ]; then
     # Use ccache, assuming $HOME/bin is in the path, which is true in the Travis build environment.
     ln -sf /usr/bin/ccache $HOME/bin/${CXX};
     ln -sf /usr/bin/ccache $HOME/bin/${CC};

--- a/ci/install-linux.sh
+++ b/ci/install-linux.sh
@@ -42,8 +42,11 @@ if [ "${TRAVIS_SUDO}" = "true" ]; then
         sudo tee /etc/apt/sources.list.d/bazel.list
     curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
     sudo apt-get update && sudo apt-get install -y gcc-4.9 g++-4.9 clang-3.9
-    sudo apt-get install bazel-0.26.1
-elif [ "${CXX}" = "clang++" ]; then
+    wget https://github.com/bazelbuild/bazel/releases/download/0.26.1/bazel-0.26.1-installer-linux-x86_64.sh
+    chmod +x bazel-0.26.1-installer-linux-x86_64.sh
+    ./bazel-0.26.1-installer-linux-x86_64.sh 
+
+  elif [ "${CXX}" = "clang++" ]; then
     # Use ccache, assuming $HOME/bin is in the path, which is true in the Travis build environment.
     ln -sf /usr/bin/ccache $HOME/bin/${CXX};
     ln -sf /usr/bin/ccache $HOME/bin/${CC};


### PR DESCRIPTION
Bazel 0.21.0 stopped supporting trusty. Changing bazel builds to xenial
See https://github.com/bazelbuild/bazel/issues/8652#issuecomment-502834523