### PR TITLE
Fix conflict with <complex.h> `I` macro

### DIFF
--- a/googlemock/include/gmock/gmock-actions.h
+++ b/googlemock/include/gmock/gmock-actions.h
@@ -877,7 +877,7 @@ class IgnoreResultAction {
   GTEST_DISALLOW_ASSIGN_(IgnoreResultAction);
 };
 
-template <typename InnerAction, size_t... I>
+template <typename InnerAction, size_t... N>
 struct WithArgsAction {
   InnerAction action;
 
@@ -885,12 +885,12 @@ struct WithArgsAction {
   // We use the conversion operator to detect the signature of the inner Action.
   template <typename R, typename... Args>
   operator Action<R(Args...)>() const {  // NOLINT
-    Action<R(typename std::tuple_element<I, std::tuple<Args...>>::type...)>
+    Action<R(typename std::tuple_element<N, std::tuple<Args...>>::type...)>
         converted(action);
 
     return [converted](Args... args) -> R {
       return converted.Perform(std::forward_as_tuple(
-        std::get<I>(std::forward_as_tuple(std::forward<Args>(args)...))...));
+        std::get<N>(std::forward_as_tuple(std::forward<Args>(args)...))...));
     };
   }
 };
@@ -898,9 +898,9 @@ struct WithArgsAction {
 template <typename... Actions>
 struct DoAllAction {
  private:
-  template <typename... Args, size_t... I>
-  std::vector<Action<void(Args...)>> Convert(IndexSequence<I...>) const {
-    return {std::get<I>(actions)...};
+  template <typename... Args, size_t... N>
+  std::vector<Action<void(Args...)>> Convert(IndexSequence<N...>) const {
+    return {std::get<N>(actions)...};
   }
 
  public:

--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -1095,11 +1095,11 @@ class VariadicMatcher {
   }
 
  private:
-  template <typename T, size_t I>
+  template <typename T, size_t N>
   void CreateVariadicMatcher(std::vector<Matcher<T> >* values,
-                             std::integral_constant<size_t, I>) const {
-    values->push_back(SafeMatcherCast<T>(std::get<I>(matchers_)));
-    CreateVariadicMatcher<T>(values, std::integral_constant<size_t, I + 1>());
+                             std::integral_constant<size_t, N>) const {
+    values->push_back(SafeMatcherCast<T>(std::get<N>(matchers_)));
+    CreateVariadicMatcher<T>(values, std::integral_constant<size_t, N + 1>());
   }
 
   template <typename T>

--- a/googlemock/include/gmock/internal/gmock-internal-utils.h
+++ b/googlemock/include/gmock/internal/gmock-internal-utils.h
@@ -509,9 +509,9 @@ GTEST_API_ void IllegalDoDefault(const char* file, int line);
 // Helper types for Apply() below.
 template <size_t... Is> struct int_pack { typedef int_pack type; };
 
-template <class Pack, size_t I> struct append;
-template <size_t... Is, size_t I>
-struct append<int_pack<Is...>, I> : int_pack<Is..., I> {};
+template <class Pack, size_t N> struct append;
+template <size_t... Is, size_t N>
+struct append<int_pack<Is...>, N> : int_pack<Is..., N> {};
 
 template <size_t C>
 struct make_int_pack : append<typename make_int_pack<C - 1>::type, C - 1> {};
@@ -552,8 +552,8 @@ template <typename R, typename... Args>
 struct Function<R(Args...)> {
   using Result = R;
   static constexpr size_t ArgumentCount = sizeof...(Args);
-  template <size_t I>
-  using Arg = ElemFromList<I, typename MakeIndexSequence<sizeof...(Args)>::type,
+  template <size_t N>
+  using Arg = ElemFromList<N, typename MakeIndexSequence<sizeof...(Args)>::type,
                            Args...>;
   using ArgumentTuple = std::tuple<Args...>;
   using ArgumentMatcherTuple = std::tuple<Matcher<Args>...>;

--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -623,17 +623,17 @@ template <typename T>
 void PrintTupleTo(const T&, std::integral_constant<size_t, 0>,
                   ::std::ostream*) {}
 
-template <typename T, size_t I>
-void PrintTupleTo(const T& t, std::integral_constant<size_t, I>,
+template <typename T, size_t N>
+void PrintTupleTo(const T& t, std::integral_constant<size_t, N>,
                   ::std::ostream* os) {
-  PrintTupleTo(t, std::integral_constant<size_t, I - 1>(), os);
+  PrintTupleTo(t, std::integral_constant<size_t, N - 1>(), os);
   GTEST_INTENTIONAL_CONST_COND_PUSH_()
-  if (I > 1) {
+  if (N > 1) {
     GTEST_INTENTIONAL_CONST_COND_POP_()
     *os << ", ";
   }
-  UniversalPrinter<typename std::tuple_element<I - 1, T>::type>::Print(
-      std::get<I - 1>(t), os);
+  UniversalPrinter<typename std::tuple_element<N - 1, T>::type>::Print(
+      std::get<N - 1>(t), os);
 }
 
 template <typename... Types>
@@ -876,14 +876,14 @@ typedef ::std::vector< ::std::string> Strings;
 template <typename Tuple>
 void TersePrintPrefixToStrings(const Tuple&, std::integral_constant<size_t, 0>,
                                Strings*) {}
-template <typename Tuple, size_t I>
+template <typename Tuple, size_t N>
 void TersePrintPrefixToStrings(const Tuple& t,
-                               std::integral_constant<size_t, I>,
+                               std::integral_constant<size_t, N>,
                                Strings* strings) {
-  TersePrintPrefixToStrings(t, std::integral_constant<size_t, I - 1>(),
+  TersePrintPrefixToStrings(t, std::integral_constant<size_t, N - 1>(),
                             strings);
   ::std::stringstream ss;
-  UniversalTersePrint(std::get<I - 1>(t), &ss);
+  UniversalTersePrint(std::get<N - 1>(t), &ss);
   strings->push_back(ss.str());
 }
 

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1157,13 +1157,13 @@ struct IndexSequence {
 // Double the IndexSequence, and one if plus_one is true.
 template <bool plus_one, typename T, size_t sizeofT>
 struct DoubleSequence;
-template <size_t... I, size_t sizeofT>
-struct DoubleSequence<true, IndexSequence<I...>, sizeofT> {
-  using type = IndexSequence<I..., (sizeofT + I)..., 2 * sizeofT>;
+template <size_t... N, size_t sizeofT>
+struct DoubleSequence<true, IndexSequence<N...>, sizeofT> {
+  using type = IndexSequence<N..., (sizeofT + N)..., 2 * sizeofT>;
 };
-template <size_t... I, size_t sizeofT>
-struct DoubleSequence<false, IndexSequence<I...>, sizeofT> {
-  using type = IndexSequence<I..., (sizeofT + I)...>;
+template <size_t... N, size_t sizeofT>
+struct DoubleSequence<false, IndexSequence<N...>, sizeofT> {
+  using type = IndexSequence<N..., (sizeofT + N)...>;
 };
 
 // Backport of std::make_index_sequence.
@@ -1182,30 +1182,30 @@ struct MakeIndexSequence<0> : IndexSequence<> {};
 template <typename T, size_t, size_t>
 struct ElemFromListImpl {};
 
-template <typename T, size_t I>
-struct ElemFromListImpl<T, I, I> {
+template <typename T, size_t N>
+struct ElemFromListImpl<T, N, N> {
   using type = T;
 };
 
 // Get the Nth element from T...
 // It uses O(1) instantiation depth.
-template <size_t N, typename I, typename... T>
+template <size_t N, typename M, typename... T>
 struct ElemFromList;
 
-template <size_t N, size_t... I, typename... T>
-struct ElemFromList<N, IndexSequence<I...>, T...>
-    : ElemFromListImpl<T, N, I>... {};
+template <size_t N, size_t... M, typename... T>
+struct ElemFromList<N, IndexSequence<M...>, T...>
+    : ElemFromListImpl<T, N, M>... {};
 
 template <typename... T>
 class FlatTuple;
 
-template <typename Derived, size_t I>
+template <typename Derived, size_t N>
 struct FlatTupleElemBase;
 
-template <typename... T, size_t I>
-struct FlatTupleElemBase<FlatTuple<T...>, I> {
+template <typename... T, size_t N>
+struct FlatTupleElemBase<FlatTuple<T...>, N> {
   using value_type =
-      typename ElemFromList<I, typename MakeIndexSequence<sizeof...(T)>::type,
+      typename ElemFromList<N, typename MakeIndexSequence<sizeof...(T)>::type,
                             T...>::type;
   FlatTupleElemBase() = default;
   explicit FlatTupleElemBase(value_type t) : value(std::move(t)) {}
@@ -1243,14 +1243,14 @@ class FlatTuple
   FlatTuple() = default;
   explicit FlatTuple(T... t) : FlatTuple::FlatTupleBase(std::move(t)...) {}
 
-  template <size_t I>
-  const typename ElemFromList<I, Indices, T...>::type& Get() const {
-    return static_cast<const FlatTupleElemBase<FlatTuple, I>*>(this)->value;
+  template <size_t N>
+  const typename ElemFromList<N, Indices, T...>::type& Get() const {
+    return static_cast<const FlatTupleElemBase<FlatTuple, N>*>(this)->value;
   }
 
-  template <size_t I>
-  typename ElemFromList<I, Indices, T...>::type& Get() {
-    return static_cast<FlatTupleElemBase<FlatTuple, I>*>(this)->value;
+  template <size_t N>
+  typename ElemFromList<N, Indices, T...>::type& Get() {
+    return static_cast<FlatTupleElemBase<FlatTuple, N>*>(this)->value;
   }
 };
 

--- a/googletest/include/gtest/internal/gtest-param-util.h
+++ b/googletest/include/gtest/internal/gtest-param-util.h
@@ -736,9 +736,9 @@ class ValueArray {
   }
 
  private:
-  template <typename T, size_t... I>
-  std::vector<T> MakeVector(IndexSequence<I...>) const {
-    return std::vector<T>{static_cast<T>(v_.template Get<I>())...};
+  template <typename T, size_t... N>
+  std::vector<T> MakeVector(IndexSequence<N...>) const {
+    return std::vector<T>{static_cast<T>(v_.template Get<N>())...};
   }
 
   FlatTuple<Ts...> v_;
@@ -762,17 +762,17 @@ class CartesianProductGenerator
   }
 
  private:
-  template <class I>
+  template <class N>
   class IteratorImpl;
-  template <size_t... I>
-  class IteratorImpl<IndexSequence<I...>>
+  template <size_t... N>
+  class IteratorImpl<IndexSequence<N...>>
       : public ParamIteratorInterface<ParamType> {
    public:
     IteratorImpl(const ParamGeneratorInterface<ParamType>* base,
              const std::tuple<ParamGenerator<T>...>& generators, bool is_end)
         : base_(base),
-          begin_(std::get<I>(generators).begin()...),
-          end_(std::get<I>(generators).end()...),
+          begin_(std::get<N>(generators).begin()...),
+          end_(std::get<N>(generators).end()...),
           current_(is_end ? end_ : begin_) {
       ComputeCurrentValue();
     }
@@ -813,8 +813,8 @@ class CartesianProductGenerator
 
       bool same = true;
       bool dummy[] = {
-          (same = same && std::get<I>(current_) ==
-                              std::get<I>(typed_other->current_))...};
+          (same = same && std::get<N>(current_) ==
+                              std::get<N>(typed_other->current_))...};
       (void)dummy;
       return same;
     }
@@ -838,12 +838,12 @@ class CartesianProductGenerator
 
     void ComputeCurrentValue() {
       if (!AtEnd())
-        current_value_ = std::make_shared<ParamType>(*std::get<I>(current_)...);
+        current_value_ = std::make_shared<ParamType>(*std::get<N>(current_)...);
     }
     bool AtEnd() const {
       bool at_end = false;
       bool dummy[] = {
-          (at_end = at_end || std::get<I>(current_) == std::get<I>(end_))...};
+          (at_end = at_end || std::get<N>(current_) == std::get<N>(end_))...};
       (void)dummy;
       return at_end;
     }


### PR DESCRIPTION
As mentioned in the now-closed issue #1391, the use of `I` in various header files causes a conflict with `<complex.h>`, which uses `I` as a macro for the imaginary number. This PR identifies and replaces (hopefully) all instances of `I` with `N` or, in one case, `M`.