### PR TITLE
Remove google internal links from documentation on github

### DIFF
--- a/googletest/docs/advanced.md
+++ b/googletest/docs/advanced.md
@@ -1398,7 +1398,7 @@ namespace:
 
 For more details, see the comments at the definitions of these functions.
 
-NOTE: The `INSTANTIATE_TEST_SUITE_P` keyword is recommended (addressing http://go/gh/google/googletest/issues/1085)  For 1.8.1 and previous releases the keyword is `INSTANTIATE_TEST_CASE_P`. which has been deprecated in favor of INSTANTIATE_TEST_SUITE_P.
+NOTE: The `INSTANTIATE_TEST_SUITE_P` keyword is recommended (addressing https://github.com/google/googletest/issues/1085)  For 1.8.1 and previous releases the keyword is `INSTANTIATE_TEST_CASE_P`. which has been deprecated in favor of INSTANTIATE_TEST_SUITE_P.
 
 The following statement will instantiate tests from the `FooTest` test suite each
 with parameter values `"meeny"`, `"miny"`, and `"moe"`.

--- a/googletest/docs/faq.md
+++ b/googletest/docs/faq.md
@@ -682,7 +682,7 @@ there is an `std::ostream& operator<<(std::ostream&, const FooType&)` function
 defined such that we can print a value of `FooType`.
 
 In addition, if `FooType` is declared in a name space, the `<<` operator also
-needs to be defined in the *same* name space. See go/totw/49 for details.
+needs to be defined in the *same* name space. See  https://abseil.io/tips/49 for details.
 
 ## How do I suppress the memory leak messages on Windows?
 


### PR DESCRIPTION
Replace go links with externally accessible urls.