### PR TITLE
Fix 'String Comparison' table

### DIFF
--- a/googletest/docs/primer.md
+++ b/googletest/docs/primer.md
@@ -215,16 +215,10 @@ two `string` objects, use `EXPECT_EQ`, `EXPECT_NE`, and etc instead.
 
 | Fatal assertion         | Nonfatal assertion      | Verifies               |
 | ----------------------- | ----------------------- | ---------------------- |
-| `ASSERT_STREQ(str1,     | `EXPECT_STREQ(str1,     | the two C strings have |
-: str2);`                 : str2);`                 : the same content       :
-| `ASSERT_STRNE(str1,     | `EXPECT_STRNE(str1,     | the two C strings have |
-: str2);`                 : str2);`                 : different contents     :
-| `ASSERT_STRCASEEQ(str1, | `EXPECT_STRCASEEQ(str1, | the two C strings have |
-: str2);`                 : str2);`                 : the same content,      :
-:                         :                         : ignoring case          :
-| `ASSERT_STRCASENE(str1, | `EXPECT_STRCASENE(str1, | the two C strings have |
-: str2);`                 : str2);`                 : different contents,    :
-:                         :                         : ignoring case          :
+| `ASSERT_STREQ(str1, str2);` | `EXPECT_STREQ(str1, str2);`    | the two C strings have<br>the same content |
+| `ASSERT_STRNE(str1, str2);` | `EXPECT_STRNE(str1, str2);`    | the two C strings have<br>different contents |
+| `ASSERT_STRCASEEQ(str1, str2);` | `EXPECT_STRCASEEQ(str1, str2);` | the two C strings have<br>the same content ignoring case  |
+| `ASSERT_STRCASENE(str1, str2);` | `EXPECT_STRCASENE(str1, str2);` | the two C strings have<br>different contents ignoring case |
 
 Note that "CASE" in an assertion name means that case is ignored. A `NULL`
 pointer and an empty string are considered *different*.


### PR DESCRIPTION
In preview some of the code sections had affected the 'String Comparison' table.
This is now fixed, the side effect being it doesn't look as pretty in markdown.