### PR TITLE
Fix typed- and type-parameterized test clang warnings

### DIFF
--- a/googletest/test/googletest-output-test_.cc
+++ b/googletest/test/googletest-output-test_.cc
@@ -815,7 +815,8 @@ class TypedTestNames {
   }
 };
 
-TYPED_TEST_SUITE(TypedTestWithNames, TypesForTestWithNames, TypedTestNames);
+TYPED_TEST_SUITE_CUSTOM_NAME_GENERATOR(TypedTestWithNames,
+                                       TypesForTestWithNames, TypedTestNames);
 
 TYPED_TEST(TypedTestWithNames, Success) {}
 
@@ -858,8 +859,9 @@ class TypedTestPNames {
   }
 };
 
-INSTANTIATE_TYPED_TEST_SUITE_P(UnsignedCustomName, TypedTestP, UnsignedTypes,
-                              TypedTestPNames);
+INSTANTIATE_TYPED_TEST_SUITE_CUSTOM_NAME_GENERATOR_P(UnsignedCustomName,
+                                                     TypedTestP, UnsignedTypes,
+                                                     TypedTestPNames);
 
 #endif  // GTEST_HAS_TYPED_TEST_P
 

--- a/googletest/test/gtest-typed-test_test.cc
+++ b/googletest/test/gtest-typed-test_test.cc
@@ -186,7 +186,8 @@ class TypedTestNames {
   }
 };
 
-TYPED_TEST_SUITE(TypedTestWithNames, TwoTypes, TypedTestNames);
+TYPED_TEST_SUITE_CUSTOM_NAME_GENERATOR(TypedTestWithNames, TwoTypes,
+                                       TypedTestNames);
 
 TYPED_TEST(TypedTestWithNames, TestSuiteName) {
   if (testing::internal::IsSame<TypeParam, char>::value) {
@@ -340,8 +341,9 @@ class TypeParametrizedTestNames {
   }
 };
 
-INSTANTIATE_TYPED_TEST_SUITE_P(CustomName, TypeParametrizedTestWithNames,
-                              TwoTypes, TypeParametrizedTestNames);
+INSTANTIATE_TYPED_TEST_SUITE_CUSTOM_NAME_GENERATOR_P(
+    CustomName, TypeParametrizedTestWithNames, TwoTypes,
+    TypeParametrizedTestNames);
 
 // Tests that multiple TYPED_TEST_SUITE_P's can be defined in the same
 // translation unit.


### PR DESCRIPTION
This refers to [issue #2271](https://github.com/google/googletest/issues/2271)