### PR TITLE
Fix a broken link

### DIFF
--- a/googlemock/docs/cook_book.md
+++ b/googlemock/docs/cook_book.md
@@ -229,7 +229,7 @@ If a mock method has no `EXPECT_CALL` spec but is called, Google Mock
 will print a warning about the "uninteresting call". The rationale is:
 
   * New methods may be added to an interface after a test is written. We shouldn't fail a test just because a method it doesn't know about is called.
-  * However, this may also mean there's a bug in the test, so Google Mock shouldn't be silent either. (Note that the user should [*not* add an `EXPECT_CALL()`](https://github.com/google/googletest/blob/master/googlemock/docs/CookBook.md#knowing-when-to-expect) to suppress the warning, even if they think the call is harmless).
+  * However, this may also mean there's a bug in the test, so Google Mock shouldn't be silent either. (Note that the user should [*not* add an `EXPECT_CALL()`](https://github.com/google/googletest/blob/master/googlemock/docs/cook_book.md#knowing-when-to-expect) to suppress the warning, even if they think the call is harmless).
 
 However, sometimes you may want to suppress all "uninteresting call"
 warnings, while sometimes you may want the opposite, i.e. to treat all


### PR DESCRIPTION
ee3aa831172090fd5442820f215cb04ab6062756 added a broken link
which results in 404. The broken part is reference to a
nonexistent file "CheatSheet.md" instead of "cheet_sheet.md".

In addition, since the aforementioned link references the same file,
it is sufficient to provide a relative reference to itself rather than
forcing a user to connect to github.com.