### PR TITLE
Correct CMake to cover Cygwin

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -142,7 +142,7 @@ if (gmock_build_tests)
 "$project_bin = \"${CMAKE_BINARY_DIR}/bin/$<CONFIG>\"
 $env:Path = \"$project_bin;$env:Path\"
 & $args")
-  elseif (MINGW)
+  elseif (MINGW OR CYGWIN)
     file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/RunTest.ps1"
          CONTENT
 "$project_bin = (cygpath --windows ${CMAKE_BINARY_DIR}/bin)
@@ -162,7 +162,7 @@ $env:Path = \"$project_bin;$env:Path\"
   cxx_test(gmock-generated-matchers_test gmock_main)
   cxx_test(gmock-internal-utils_test gmock_main)
   cxx_test(gmock-matchers_test gmock_main)
-  if (MINGW)
+  if (MINGW OR CYGWIN)
     target_compile_options(gmock-matchers_test PRIVATE "-Wa,-mbig-obj")
   endif()
   cxx_test(gmock-more-actions_test gmock_main)

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -188,7 +188,7 @@ if (gtest_build_tests)
 "$project_bin = \"${CMAKE_BINARY_DIR}/bin/$<CONFIG>\"
 $env:Path = \"$project_bin;$env:Path\"
 & $args")
-  elseif (MINGW)
+  elseif (MINGW OR CYGWIN)
     file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/RunTest.ps1"
          CONTENT
 "$project_bin = (cygpath --windows ${CMAKE_BINARY_DIR}/bin)


### PR DESCRIPTION
Building the project on Cygwin fails due to a too large object file. Cygwin is not considered MinGW even if it shares ]options. Along with that two other cases where only MinGW was checked were updated as well.

Note that this PR comes from #2319.