### PR TITLE
Add missing <functional> include

### DIFF
--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -61,6 +61,7 @@
 #ifndef GMOCK_INCLUDE_GMOCK_GMOCK_SPEC_BUILDERS_H_
 #define GMOCK_INCLUDE_GMOCK_GMOCK_SPEC_BUILDERS_H_
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <set>


### PR DESCRIPTION
gmock-spec-builders.h uses std::function (in MockFunction) but did not include <functional> to provide it. Apparently, it worked since the header must have been included by something else but better be safe than sorry.

Note that this PR comes from #2319.