### PR TITLE
Update pre-C++11 paragraphs

### DIFF
--- a/googlemock/include/gmock/gmock-generated-actions.h
+++ b/googlemock/include/gmock/gmock-generated-actions.h
@@ -259,11 +259,10 @@ class ActionHelper {
 //
 // CAVEAT:
 //
-// ACTION*() can only be used in a namespace scope.  The reason is
-// that C++ doesn't yet allow function-local types to be used to
-// instantiate templates.  The up-coming C++0x standard will fix this.
-// Once that's done, we'll consider supporting using ACTION*() inside
-// a function.
+// ACTION*() can only be used in a namespace scope as templates cannot be
+// declared inside of a local class.
+// Users can, however, define any local functors (e.g. a lambda) that
+// can be used as actions.
 //
 // MORE INFORMATION:
 //

--- a/googlemock/include/gmock/gmock-generated-actions.h.pump
+++ b/googlemock/include/gmock/gmock-generated-actions.h.pump
@@ -182,11 +182,10 @@ $template
 //
 // CAVEAT:
 //
-// ACTION*() can only be used in a namespace scope.  The reason is
-// that C++ doesn't yet allow function-local types to be used to
-// instantiate templates.  The up-coming C++0x standard will fix this.
-// Once that's done, we'll consider supporting using ACTION*() inside
-// a function.
+// ACTION*() can only be used in a namespace scope as templates cannot be
+// declared inside of a local class.
+// Users can, however, define any local functors (e.g. a lambda) that
+// can be used as actions.
 //
 // MORE INFORMATION:
 //

--- a/googlemock/include/gmock/gmock-generated-matchers.h
+++ b/googlemock/include/gmock/gmock-generated-matchers.h
@@ -250,11 +250,8 @@
 // overloading matchers based on parameter types (as opposed to just
 // based on the number of parameters).
 //
-// MATCHER*() can only be used in a namespace scope.  The reason is
-// that C++ doesn't yet allow function-local types to be used to
-// instantiate templates.  The up-coming C++0x standard will fix this.
-// Once that's done, we'll consider supporting using MATCHER*() inside
-// a function.
+// MATCHER*() can only be used in a namespace scope as templates cannot be
+// declared inside of a local class.
 //
 // More Information
 // ================

--- a/googlemock/include/gmock/gmock-generated-matchers.h.pump
+++ b/googlemock/include/gmock/gmock-generated-matchers.h.pump
@@ -252,11 +252,8 @@ $$ }} This line fixes auto-indentation of the following code in Emacs.
 // overloading matchers based on parameter types (as opposed to just
 // based on the number of parameters).
 //
-// MATCHER*() can only be used in a namespace scope.  The reason is
-// that C++ doesn't yet allow function-local types to be used to
-// instantiate templates.  The up-coming C++0x standard will fix this.
-// Once that's done, we'll consider supporting using MATCHER*() inside
-// a function.
+// MATCHER*() can only be used in a namespace scope as templates cannot be
+// declared inside of a local class.
 //
 // More Information
 // ================


### PR DESCRIPTION
As requested in #2344.

This removes the TODO-ish comments of:
> we'll consider supporting using ACTION*() inside a function.

and

> we'll consider supporting using MATCHER*() inside a function.

My reasoning is:
* Actions can be easily changed to lambdas (or even generic ones if someone uses C++14) so no need to put effort into legacy functionality
* Matchers have also alternatives, e.g. Truly(). Perhaps I should add something like:
> Users are free to provide their local functors and invoke Truly() on them

What do you think (especially about the latter)?