### PR TITLE
Remove an excessive mutable type specifier

### DIFF
--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -1870,7 +1870,7 @@ class MockFunction<R(Args...)> {
   }
 
  private:
-  mutable internal::FunctionMocker<R(Args...)> mock_;
+  internal::FunctionMocker<R(Args...)> mock_;
 };
 
 // The style guide prohibits "using" statements in a namespace scope


### PR DESCRIPTION
The private mutable member of MockFunction cannot be reached from outside and all its
non-static member functions are not const. Alternatively, we could add const to every function of MockFunction, though it's a much worse idea I believe.

@adambadura - watch out, this will conflict with your #2350 if this gets merged first.