### PR TITLE
Fix C++ includes in preparation for #2364

### DIFF
--- a/googletest/src/gtest-death-test.cc
+++ b/googletest/src/gtest-death-test.cc
@@ -82,7 +82,7 @@
 
 #include "gtest/gtest-message.h"
 #include "gtest/internal/gtest-string.h"
-#include "src/gtest-internal-inl.h"
+#include "gtest-internal-inl.h"
 
 namespace testing {
 

--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -83,7 +83,7 @@
 #include "gtest/gtest-message.h"
 #include "gtest/internal/gtest-internal.h"
 #include "gtest/internal/gtest-string.h"
-#include "src/gtest-internal-inl.h"
+#include "gtest-internal-inl.h"
 
 namespace testing {
 namespace internal {

--- a/googletest/src/gtest-printers.cc
+++ b/googletest/src/gtest-printers.cc
@@ -48,7 +48,7 @@
 #include <ostream>  // NOLINT
 #include <string>
 #include "gtest/internal/gtest-port.h"
-#include "src/gtest-internal-inl.h"
+#include "gtest-internal-inl.h"
 
 namespace testing {
 

--- a/googletest/src/gtest-test-part.cc
+++ b/googletest/src/gtest-test-part.cc
@@ -31,7 +31,7 @@
 // The Google C++ Testing and Mocking Framework (Google Test)
 
 #include "gtest/gtest-test-part.h"
-#include "src/gtest-internal-inl.h"
+#include "gtest-internal-inl.h"
 
 namespace testing {
 

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -119,7 +119,7 @@
 # include <sys/types.h>  // NOLINT
 #endif
 
-#include "src/gtest-internal-inl.h"
+#include "gtest-internal-inl.h"
 
 #if GTEST_OS_WINDOWS
 # define vsnprintf _vsnprintf

--- a/googletest/test/googletest-test2_test.cc
+++ b/googletest/test/googletest-test2_test.cc
@@ -32,7 +32,7 @@
 // Google Test work.
 
 #include "gtest/gtest.h"
-#include "googletest-param-test-test.h"
+#include "test/googletest-param-test-test.h"
 
 using ::testing::Values;
 using ::testing::internal::ParamGenerator;


### PR DESCRIPTION
#2364 will make the Bazel build more hermetic, e.g. we no longer leak `src/gtest-internal-inl.h` to tests.

@gennadiycivil Can you take a look whether this breaks your import?