### PR TITLE
Prepare for Bazel incompatible changes

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -30,6 +30,8 @@
 #
 #   Bazel Build for Google C++ Testing Framework(Google Test)
 
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
@@ -81,6 +83,10 @@ cc_library(
         ":has_absl": ["GTEST_HAS_ABSL=1"],
         "//conditions:default": [],
     }),
+    features = select({
+        ":windows": ["windows_export_all_symbols"],
+        "//conditions:default": [],
+    }),
     includes = [
         "googlemock",
         "googlemock/include",
@@ -102,20 +108,16 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
-    features = select({
-        ":windows": ["windows_export_all_symbols"],
-        "//conditions:default": [],
-    })
 )
 
 cc_library(
     name = "gtest_main",
     srcs = ["googlemock/src/gmock_main.cc"],
-    deps = [":gtest"],
     features = select({
         ":windows": ["windows_export_all_symbols"],
         "//conditions:default": [],
-    })
+    }),
+    deps = [":gtest"],
 )
 
 # The following rules build samples of how to use gTest.
@@ -136,7 +138,7 @@ cc_library(
     features = select({
         ":windows": ["windows_export_all_symbols"],
         "//conditions:default": [],
-    })
+    }),
 )
 
 cc_test(
@@ -155,11 +157,11 @@ cc_test(
         "googletest/samples/sample7_unittest.cc",
         "googletest/samples/sample8_unittest.cc",
     ],
+    linkstatic = 0,
     deps = [
         "gtest_sample_lib",
         ":gtest_main",
     ],
-    linkstatic = 0,
 )
 
 cc_test(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,7 +4,19 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # Abseil
 http_archive(
-     name = "com_google_absl",
-     urls = ["https://github.com/abseil/abseil-cpp/archive/master.zip"],
-     strip_prefix = "abseil-cpp-master",
+    name = "com_google_absl",
+    strip_prefix = "abseil-cpp-master",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/master.zip"],
+)
+
+http_archive(
+    name = "rules_cc",
+    strip_prefix = "rules_cc-master",
+    urls = ["https://github.com/bazelbuild/rules_cc/archive/master.zip"],
+)
+
+http_archive(
+    name = "rules_python",
+    strip_prefix = "rules_python-master",
+    urls = ["https://github.com/bazelbuild/rules_python/archive/master.zip"],
 )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,7 +58,7 @@ install:
 
     # install Bazel
     if ($env:build_system -eq "bazel") {
-        appveyor DownloadFile https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel-0.21.0-windows-x86_64.exe -FileName bazel.exe
+        appveyor DownloadFile https://github.com/bazelbuild/bazel/releases/download/0.28.1/bazel-0.28.1-windows-x86_64.exe -FileName bazel.exe
     }
 
     if ($env:build_system -eq "cmake") {

--- a/googlemock/test/BUILD.bazel
+++ b/googlemock/test/BUILD.bazel
@@ -32,6 +32,9 @@
 #
 #   Bazel Build for Google C++ Testing Framework(Google Test)-googlemock
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+
 licenses(["notice"])
 
 # Tests for GMock itself

--- a/googletest/test/BUILD.bazel
+++ b/googletest/test/BUILD.bazel
@@ -32,6 +32,9 @@
 #
 # Bazel BUILD for The Google C++ Testing Framework (Google Test)
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+
 licenses(["notice"])
 
 #on windows exclude gtest-tuple.h


### PR DESCRIPTION
Fixes googletest for upcoming `--incompatible_load_cc_rules_from_bzl` (https://github.com/bazelbuild/bazel/issues/8743) and `--incompatible_load_python_rules_from_bzl` (https://github.com/bazelbuild/bazel/issues/9006).

This change was automatically generated with
`buildifier -lint=fix -warnings=all $(find . -name "BUILD" -o -name "BUILD.bazel" -o -name "*.bzl")`.