### PR TITLE
Let tables use the same syntax and fix some typos in docs

### DIFF
--- a/googlemock/docs/cheat_sheet.md
+++ b/googlemock/docs/cheat_sheet.md
@@ -235,10 +235,10 @@ several categories:
 
 #### Wildcard
 
-Matcher                     | Description
-:-------------------------- | :-----------------------------------------------
-`_`                         | `argument` can be any value of the correct type.
-`A<type>()` or `An<type>()` | `argument` can be any value of type `type`.
+| Matcher                     | Description                                      |
+| :-------------------------- | :----------------------------------------------- |
+| `_`                         | `argument` can be any value of the correct type. |
+| `A<type>()` or `An<type>()` | `argument` can be any value of type `type`.      |
 
 #### Generic Comparison
 
@@ -406,14 +406,14 @@ Technically, all matchers match a *single* value. A "multi-argument" matcher is
 just one that matches a *tuple*. The following matchers can be used to match a
 tuple `(x, y)`:
 
-Matcher | Description
-:------ | :----------
-`Eq()`  | `x == y`
-`Ge()`  | `x >= y`
-`Gt()`  | `x > y`
-`Le()`  | `x <= y`
-`Lt()`  | `x < y`
-`Ne()`  | `x != y`
+| Matcher | Description |
+| :------ | :---------- |
+| `Eq()`  | `x == y`    |
+| `Ge()`  | `x >= y`    |
+| `Gt()`  | `x > y`     |
+| `Le()`  | `x <= y`    |
+| `Lt()`  | `x < y`     |
+| `Ne()`  | `x != y`    |
 
 You can use the following selectors to pick a subset of the arguments (or
 reorder them) to participate in the matching:
@@ -490,12 +490,12 @@ which must be a permanent callback.
 #### Returning a Value
 
 <!-- mdformat off(no multiline tables) -->
-|                             |                                               |
+| Action                      | Description                                   |
 | :-------------------------- | :-------------------------------------------- |
 | `Return()`                  | Return from a `void` mock function.           |
-| `Return(value)`             | Return `value`. If the type of `value` is     different to the mock function's return type, `value` is converted to the latter type <i>at the time the expectation is set</i>, not when the action is executed. |
+| `Return(value)`             | Return `value`. If the type of `value` is different to the mock function's return type, `value` is converted to the latter type *at the time the expectation is set*, not when the action is executed. |
 | `ReturnArg<N>()`            | Return the `N`-th (0-based) argument.         |
-| `ReturnNew<T>(a1, ..., ak)` | Return `new T(a1, ..., ak)`; a different      object is created each time. |
+| `ReturnNew<T>(a1, ..., ak)` | Return `new T(a1, ..., ak)`; a different object is created each time. |
 | `ReturnNull()`              | Return a null pointer.                        |
 | `ReturnPointee(ptr)`        | Return the value pointed to by `ptr`.         |
 | `ReturnRef(variable)`       | Return a reference to `variable`.             |
@@ -505,18 +505,18 @@ which must be a permanent callback.
 #### Side Effects
 
 <!-- mdformat off(no multiline tables) -->
-|                                    |                                         |
+| Action                             | Description                             |
 | :--------------------------------- | :-------------------------------------- |
-| `Assign(&variable, value)` | Assign `value` to variable. |
-| `DeleteArg<N>()` | Delete the `N`-th (0-based) argument, which must be a pointer. |
-| `SaveArg<N>(pointer)` | Save the `N`-th (0-based) argument to `*pointer`. |
-| `SaveArgPointee<N>(pointer)` | Save the value pointed to by the `N`-th (0-based) argument to `*pointer`. |
-| `SetArgReferee<N>(value)` | Assign value to the variable referenced by the `N`-th (0-based) argument. |
-| `SetArgPointee<N>(value)` | Assign `value` to the variable pointed by the `N`-th (0-based) argument. |
-| `SetArgumentPointee<N>(value)` | Same as `SetArgPointee<N>(value)`. Deprecated. Will be removed in v1.7.0. |
+| `Assign(&variable, value)`         | Assign `value` to variable. |
+| `DeleteArg<N>()`                   | Delete the `N`-th (0-based) argument, which must be a pointer. |
+| `SaveArg<N>(pointer)`              | Save the `N`-th (0-based) argument to `*pointer`. |
+| `SaveArgPointee<N>(pointer)`       | Save the value pointed to by the `N`-th (0-based) argument to `*pointer`. |
+| `SetArgReferee<N>(value)`          | Assign value to the variable referenced by the `N`-th (0-based) argument. |
+| `SetArgPointee<N>(value)`          | Assign `value` to the variable pointed by the `N`-th (0-based) argument. |
+| `SetArgumentPointee<N>(value)`     | Same as `SetArgPointee<N>(value)`. Deprecated. Will be removed in v1.7.0. |
 | `SetArrayArgument<N>(first, last)` | Copies the elements in source range [`first`, `last`) to the array pointed to by the `N`-th (0-based) argument, which can be either a pointer or an iterator. The action does not take ownership of the elements in the source range. |
-| `SetErrnoAndReturn(error, value)` | Set `errno` to `error` and return `value`. |
-| `Throw(exception)` | Throws the given exception, which can be any copyable value. Available since v1.1.0. |
+| `SetErrnoAndReturn(error, value)`  | Set `errno` to `error` and return `value`. |
+| `Throw(exception)`                 | Throws the given exception, which can be any copyable value. Available since v1.1.0. |
 <!-- mdformat on -->
 
 #### Using a Function, Functor, or Lambda as an Action
@@ -525,14 +525,14 @@ In the following, by "callable" we mean a free function, `std::function`,
 functor, or lambda.
 
 <!-- mdformat off(no multiline tables) -->
-|                                     |                                        |
-| :---------------------------------- | :------------------------------------- |
+| Action                                              | Description                     |
+| :-------------------------------------------------- | :------------------------------ |
 | `f` | Invoke f with the arguments passed to the mock function, where f is a callable. |
-| `Invoke(f)` | Invoke `f` with the arguments passed to the mock function, where `f` can be a global/static function or a functor. |
-| `Invoke(object_pointer, &class::method)` | Invoke the method on the object with the arguments passed to the mock function. |
-| `InvokeWithoutArgs(f)` | Invoke `f`, which can be a global/static function or a functor. `f` must take no arguments. |
+| `Invoke(f)`                                         | Invoke `f` with the arguments passed to the mock function, where `f` can be a global/static function or a functor. |
+| `Invoke(object_pointer, &class::method)`            | Invoke the method on the object with the arguments passed to the mock function. |
+| `InvokeWithoutArgs(f)`                              | Invoke `f`, which can be a global/static function or a functor. `f` must take no arguments. |
 | `InvokeWithoutArgs(object_pointer, &class::method)` | Invoke the method on the object, which takes no arguments. |
-| `InvokeArgument<N>(arg1, arg2, ..., argk)` | Invoke the mock function's `N`-th (0-based) argument, which must be a function or a functor, with the `k` arguments. |
+| `InvokeArgument<N>(arg1, arg2, ..., argk)`          | Invoke the mock function's `N`-th (0-based) argument, which must be a function or a functor, with the `k` arguments. |
 <!-- mdformat on -->
 
 The return value of the invoked function is used as the return value of the
@@ -576,8 +576,8 @@ value, and `foo` by reference.
 #### Default Action
 
 <!-- mdformat off(no multiline tables) -->
-| Matcher       | Description                                            |
-| :------------ | :----------------------------------------------------- |
+| Action        | Description                                                           |
+| :------------ | :-------------------------------------------------------------------- |
 | `DoDefault()` | Do the default action (specified by `ON_CALL()` or the built-in one). |
 <!-- mdformat on -->
 
@@ -589,8 +589,8 @@ composite action - trying to do so will result in a run-time error.
 #### Composite Actions
 
 <!-- mdformat off(no multiline tables) -->
-|                                |                                             |
-| :----------------------------- | :------------------------------------------ |
+| Action                         | Description                               |
+| :----------------------------- | :---------------------------------------- |
 | `DoAll(a1, a2, ..., an)`       | Do all actions `a1` to `an` and return the result of `an` in each invocation. The first `n - 1` sub-actions must return void. |
 | `IgnoreResult(a)`              | Perform action `a` and ignore its result. `a` must not return void. |
 | `WithArg<N>(a)`                | Pass the `N`-th (0-based) argument of the mock function to action `a` and perform it. |
@@ -614,10 +614,10 @@ composite action - trying to do so will result in a run-time error.
 </table>
 
 <!-- mdformat off(no multiline tables) -->
-|                                    |                                         |
-| :--------------------------------- | :-------------------------------------- |
-| `ACTION(Sum) { return arg0 + arg1; }` | Defines an action `Sum()` to return the sum of the mock function's argument #0 and #1. |
-| `ACTION_P(Plus, n) { return arg0 + n; }` | Defines an action `Plus(n)` to return the sum of the mock function's argument #0 and `n`. |
+| Action                                        | Description                             |
+| :-------------------------------------------- | :-------------------------------------- |
+| `ACTION(Sum) { return arg0 + arg1; }`         | Defines an action `Sum()` to return the sum of the mock function's argument #0 and #1. |
+| `ACTION_P(Plus, n) { return arg0 + n; }`      | Defines an action `Plus(n)` to return the sum of the mock function's argument #0 and `n`. |
 | `ACTION_Pk(Foo, p1, ..., pk) { statements; }` | Defines a parameterized action `Foo(p1, ..., pk)` to execute the given `statements`. |
 <!-- mdformat on -->
 
@@ -629,7 +629,7 @@ These are used in `Times()` to specify how many times a mock function will be
 called:
 
 <!-- mdformat off(no multiline tables) -->
-|                   |                                                        |
+| Cardinality       | Description                                            |
 | :---------------- | :----------------------------------------------------- |
 | `AnyNumber()`     | The function can be called any number of times.        |
 | `AtLeast(n)`      | The call is expected at least `n` times.               |

--- a/googlemock/docs/cook_book.md
+++ b/googlemock/docs/cook_book.md
@@ -3852,12 +3852,14 @@ returns argument #0.
 For more convenience and flexibility, you can also use the following pre-defined
 symbols in the body of `ACTION`:
 
-`argK_type`     | The type of the K-th (0-based) argument of the mock function
-:-------------- | :-----------------------------------------------------------
-`args`          | All arguments of the mock function as a tuple
-`args_type`     | The type of all arguments of the mock function as a tuple
-`return_type`   | The return type of the mock function
-`function_type` | The type of the mock function
+| Pre-defined Symbol | Description                                                   |
+| :----------------- | :------------------------------------------------------------ |
+| `argK`             | The value of the K-th (0-based) argument of the mock function |
+| `argK_type`        | The type of the K-th (0-based) argument of the mock function  |
+| `args`             | The value of all arguments of the mock function as a tuple    |
+| `args_type`        | The type of all arguments of the mock function as a tuple     |
+| `return_type`      | The return type of the mock function                          |
+| `function_type`    | The type of the mock function                                 |
 
 For example, when using an `ACTION` as a stub action for mock function:
 
@@ -3867,16 +3869,16 @@ int DoSomething(bool flag, int* ptr);
 
 we have:
 
-Pre-defined Symbol | Is Bound To
------------------- | ---------------------------------
-`arg0`             | the value of `flag`
-`arg0_type`        | the type `bool`
-`arg1`             | the value of `ptr`
-`arg1_type`        | the type `int*`
-`args`             | the tuple `(flag, ptr)`
-`args_type`        | the type `std::tuple<bool, int*>`
-`return_type`      | the type `int`
-`function_type`    | the type `int(bool, int*)`
+| Pre-defined Symbol | Is Bound To                       |
+| :----------------- | :-------------------------------- |
+| `arg0`             | the value of `flag`               |
+| `arg0_type`        | the type `bool`                   |
+| `arg1`             | the value of `ptr`                |
+| `arg1_type`        | the type `int*`                   |
+| `args`             | the tuple `(flag, ptr)`           |
+| `args_type`        | the type `std::tuple<bool, int*>` |
+| `return_type`      | the type `int`                    |
+| `function_type`    | the type `int(bool, int*)`        |
 
 ##### Legacy macro-based parameterized Actions
 
@@ -4041,22 +4043,17 @@ If you are writing a function that returns an `ACTION` object, you'll need to
 know its type. The type depends on the macro used to define the action and the
 parameter types. The rule is relatively simple:
 
-| Given Definition              | Expression          | Has Type              |
-| ----------------------------- | ------------------- | --------------------- |
-| `ACTION(Foo)`                 | `Foo()`             | `FooAction`           |
-| `ACTION_TEMPLATE(Foo,`        | `Foo<t1, ...,       | `FooAction<t1, ...,   |
-: `HAS_m_TEMPLATE_PARAMS(...),` : t_m>()`             : t_m>`                 :
-: `AND_0_VALUE_PARAMS())`       :                     :                       :
-| `ACTION_P(Bar, param)`        | `Bar(int_value)`    | `BarActionP<int>`     |
-| `ACTION_TEMPLATE(Bar,`        | `Bar<t1, ..., t_m>` | `FooActionP<t1, ...,  |
-: `HAS_m_TEMPLATE_PARAMS(...),` : `(int_value)`       : t_m, int>`            :
-: `AND_1_VALUE_PARAMS(p1))`     :                     :                       :
-| `ACTION_P2(Baz, p1, p2)`      | `Baz(bool_value,`   | `BazActionP2<bool,    |
-:                               : `int_value)`        : int>`                 :
-| `ACTION_TEMPLATE(Baz,`        | `Baz<t1, ..., t_m>` | `FooActionP2<t1, ..., |
-: `HAS_m_TEMPLATE_PARAMS(...),` : `(bool_value,`      : t_m,` `bool, int>`    :
-: `AND_2_VALUE_PARAMS(p1, p2))` : `int_value)`        :                       :
-| ...                           | ...                 | ...                   |
+<!-- mdformat off(github rendering does not support multiline tables) -->
+| Given Definition                                                               | Expression                                 | Has Type                               |
+| :----------------------------------------------------------------------------- |------------------------------------------- | :------------------------------------- |
+| `ACTION(Foo)`                                                                  | `Foo()`                                    | `FooAction`                            |
+| `ACTION_TEMPLATE(Foo, HAS_m_TEMPLATE_PARAMS(...), AND_0_VALUE_PARAMS())`       | `Foo<t1, ..., t_m>()`                      | `FooAction<t1, ..., t_m>`              |
+| `ACTION_P(Bar, param)`                                                         | `Bar(int_value)`                           | `BarActionP<int>`                      |
+| `ACTION_TEMPLATE(Bar, HAS_m_TEMPLATE_PARAMS(...), AND_1_VALUE_PARAMS(p1))`     | `Bar<t1, ..., t_m>(int_value)`             | `FooActionP<t1, ..., t_m, int>`        |
+| `ACTION_P2(Baz, p1, p2)`                                                       | `Baz(bool_value, int_value)`               | `BazActionP2<bool, int>`               |
+| `ACTION_TEMPLATE(Baz, HAS_m_TEMPLATE_PARAMS(...), AND_2_VALUE_PARAMS(p1, p2))` | `Baz<t1, ..., t_m>(bool_value, int_value)` | `FooActionP2<t1, ..., t_m, bool, int>` |
+| `...`                                                                          | `...`                                      | `...`                                  |
+<!-- mdformat on -->
 
 Note that we have to pick different suffixes (`Action`, `ActionP`, `ActionP2`,
 and etc) for actions with different numbers of value parameters, or the action

--- a/googlemock/docs/for_dummies.md
+++ b/googlemock/docs/for_dummies.md
@@ -213,7 +213,7 @@ specific domain much better than `Foo` does.
 Once you have a mock class, using it is easy. The typical work flow is:
 
 1.  Import the gMock names from the `testing` namespace such that you can use
-    them unqualified (You only have to do it once per file. Remember that
+    them unqualified (You only have to do it once per file). Remember that
     namespaces are a good idea.
 2.  Create some mock objects.
 3.  Specify your expectations on them (How many times will a method be called?

--- a/googletest/docs/advanced.md
+++ b/googletest/docs/advanced.md
@@ -253,7 +253,7 @@ Fatal assertion                                  | Nonfatal assertion           
 ------------------------------------------------ | ------------------------------------------------ | --------
 `ASSERT_PRED_FORMAT1(pred_format1, val1);`       | `EXPECT_PRED_FORMAT1(pred_format1, val1);`       | `pred_format1(val1)` is successful
 `ASSERT_PRED_FORMAT2(pred_format2, val1, val2);` | `EXPECT_PRED_FORMAT2(pred_format2, val1, val2);` | `pred_format2(val1, val2)` is successful
-`...`                                            | `...`                                            | ...
+`...`                                            | `...`                                            | `...`
 
 The difference between this and the previous group of macros is that instead of
 a predicate, `(ASSERT|EXPECT)_PRED_FORMAT*` take a *predicate-formatter*
@@ -645,7 +645,7 @@ Fatal assertion                                  | Nonfatal assertion           
 
 where `statement` is a statement that is expected to cause the process to die,
 `predicate` is a function or function object that evaluates an integer exit
-status, and `matcher` is either a GMock matcher matching a `const std::string&`
+status, and `matcher` is either a gMock matcher matching a `const std::string&`
 or a (Perl) regular expression - either of which is matched against the stderr
 output of `statement`. For legacy reasons, a bare string (i.e. with no matcher)
 is interpreted as `ContainsRegex(str)`, **not** `Eq(str)`. Note that `statement`
@@ -660,7 +660,7 @@ As usual, the `ASSERT` variants abort the current test function, while the
 > has called `exit()` or `_exit()` with a non-zero value, or it may be killed by
 > a signal.
 >
-> This means that if `*statement*` terminates the process with a 0 exit code, it
+> This means that if *`statement`* terminates the process with a 0 exit code, it
 > is *not* considered a crash by `EXPECT_DEATH`. Use `EXPECT_EXIT` instead if
 > this is the case, or if you want to restrict the exit code more precisely.
 
@@ -690,7 +690,7 @@ Note that a death test only cares about three things:
 2.  (in the case of `ASSERT_EXIT` and `EXPECT_EXIT`) does the exit status
     satisfy `predicate`? Or (in the case of `ASSERT_DEATH` and `EXPECT_DEATH`)
     is the exit status non-zero? And
-3.  does the stderr output match `regex`?
+3.  does the stderr output match `matcher`?
 
 In particular, if `statement` generates an `ASSERT_*` or `EXPECT_*` failure, it
 will **not** cause the death test to fail, as googletest assertions don't abort
@@ -1135,7 +1135,7 @@ will output XML like this:
 > *   `RecordProperty()` is a static member of the `Test` class. Therefore it
 >     needs to be prefixed with `::testing::Test::` if used outside of the
 >     `TEST` body and the test fixture class.
-> *   `*key*` must be a valid XML attribute name, and cannot conflict with the
+> *   *`key`* must be a valid XML attribute name, and cannot conflict with the
 >     ones already used by googletest (`name`, `status`, `time`, `classname`,
 >     `type_param`, and `value_param`).
 > *   Calling `RecordProperty()` outside of the lifespan of a test is allowed.
@@ -1906,8 +1906,6 @@ To obtain a `TestInfo` object for the currently running test, call
   // Do NOT delete the returned object - it's managed by the UnitTest class.
   const ::testing::TestInfo* const test_info =
     ::testing::UnitTest::GetInstance()->current_test_info();
-
-
 
   printf("We are in test %s of test suite %s.\n",
          test_info->name(),

--- a/googletest/docs/faq.md
+++ b/googletest/docs/faq.md
@@ -531,8 +531,8 @@ There are several good reasons:
 
 ## What can the statement argument in ASSERT_DEATH() be?
 
-`ASSERT_DEATH(*statement*, *regex*)` (or any death assertion macro) can be used
-wherever `*statement*` is valid. So basically `*statement*` can be any C++
+`ASSERT_DEATH(statement, matcher)` (or any death assertion macro) can be used
+wherever *`statement`* is valid. So basically *`statement`* can be any C++
 statement that makes sense in the current context. In particular, it can
 reference global and/or local variables, and can be:
 

--- a/googletest/docs/pump_manual.md
+++ b/googletest/docs/pump_manual.md
@@ -119,24 +119,20 @@ Func(a1 + a2 + a3);  // If n is 3.
 
 We support the following meta programming constructs:
 
-| `$var id = exp`                  | Defines a named constant value. `$id` is |
-:                                  : valid util the end of the current meta   :
-:                                  : lexical block.                           :
-| :------------------------------- | :--------------------------------------- |
-| `$range id exp..exp`             | Sets the range of an iteration variable, |
-:                                  : which can be reused in multiple loops    :
-:                                  : later.                                   :
-| `$for id sep [[ code ]]`         | Iteration. The range of `id` must have   |
-:                                  : been defined earlier. `$id` is valid in  :
-:                                  : `code`.                                  :
-| `$($)`                           | Generates a single `$` character.        |
-| `$id`                            | Value of the named constant or iteration |
-:                                  : variable.                                :
-| `$(exp)`                         | Value of the expression.                 |
-| `$if exp [[ code ]] else_branch` | Conditional.                             |
-| `[[ code ]]`                     | Meta lexical block.                      |
-| `cpp_code`                       | Raw C++ code.                            |
-| `$$ comment`                     | Meta comment.                            |
+<!-- mdformat off(github rendering does not support multiline tables) -->
+| Construct                        | Description                                                                                    |
+| :------------------------------- | :--------------------------------------------------------------------------------------------- |
+| `$var id = exp`                  | Defines a named constant value. `$id` is valid util the end of the current meta lexical block. |
+| `$range id exp..exp`             | Sets the range of an iteration variable, which can be reused in multiple loops later.          |
+| `$for id sep [[ code ]]`         | Iteration. The range of `id` must have been defined earlier. `$id` is valid in `code`.         |
+| `$($)`                           | Generates a single `$` character.                                                              |
+| `$id`                            | Value of the named constant or iteration variable.                                             |
+| `$(exp)`                         | Value of the expression.                                                                       |
+| `$if exp [[ code ]] else_branch` | Conditional.                                                                                   |
+| `[[ code ]]`                     | Meta lexical block.                                                                            |
+| `cpp_code`                       | Raw C++ code.                                                                                  |
+| `$$ comment`                     | Meta comment.                                                                                  |
+<!-- mdformat on -->
 
 **Note:** To give the user some freedom in formatting the Pump source code, Pump
 ignores a new-line character if it's right after `$for foo` or next to `[[` or


### PR DESCRIPTION
This PR is trying to let tables use the same syntax and fix some typos in documents!

I submit this PR while I'm working on issue https://github.com/google/googletest/issues/2337