### PR TITLE
Print C++17 types (any, optional, string_view and variant) and absl::any

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -103,6 +103,7 @@ cc_library(
             "@com_google_absl//absl/debugging:stacktrace",
             "@com_google_absl//absl/debugging:symbolize",
             "@com_google_absl//absl/strings",
+            "@com_google_absl//absl/types:any",
             "@com_google_absl//absl/types:optional",
             "@com_google_absl//absl/types:variant",
         ],

--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -659,16 +659,15 @@ class StrEqualityMatcher {
   StrEqualityMatcher(const StringType& str, bool expect_eq,
                      bool case_sensitive)
       : string_(str), expect_eq_(expect_eq), case_sensitive_(case_sensitive) {}
-
-#if GTEST_HAS_ABSL
-  bool MatchAndExplain(const absl::string_view& s,
+#if GTEST_HAS_CPP17_TYPES
+  bool MatchAndExplain(const string_view& s,
                        MatchResultListener* listener) const {
-    // This should fail to compile if absl::string_view is used with wide
-    // strings.
+    // This should fail to compile if std::string_view / absl::string_view
+    // is used with wide strings.
     const StringType& str = std::string(s);
     return MatchAndExplain(str, listener);
   }
-#endif  // GTEST_HAS_ABSL
+#endif  // GTEST_HAS_CPP17_TYPES
 
   // Accepts pointer types, particularly:
   //   const char*
@@ -685,8 +684,9 @@ class StrEqualityMatcher {
 
   // Matches anything that can convert to StringType.
   //
-  // This is a template, not just a plain function with const StringType&,
-  // because absl::string_view has some interfering non-explicit constructors.
+  // This is a template, not just a plain function with const std::string&,
+  // because std::string_view and absl::string_view have some interfering
+  // non-explicit constructors.
   template <typename MatcheeStringType>
   bool MatchAndExplain(const MatcheeStringType& s,
                        MatchResultListener* /* listener */) const {
@@ -730,15 +730,15 @@ class HasSubstrMatcher {
   explicit HasSubstrMatcher(const StringType& substring)
       : substring_(substring) {}
 
-#if GTEST_HAS_ABSL
-  bool MatchAndExplain(const absl::string_view& s,
+#if GTEST_HAS_CPP17_TYPES
+  bool MatchAndExplain(const string_view& s,
                        MatchResultListener* listener) const {
-    // This should fail to compile if absl::string_view is used with wide
-    // strings.
+    // This should fail to compile if std::string_view / absl::string_view
+    // is used with wide strings.
     const StringType& str = std::string(s);
     return MatchAndExplain(str, listener);
   }
-#endif  // GTEST_HAS_ABSL
+#endif  // GTEST_HAS_CPP17_TYPES
 
   // Accepts pointer types, particularly:
   //   const char*
@@ -752,8 +752,9 @@ class HasSubstrMatcher {
 
   // Matches anything that can convert to StringType.
   //
-  // This is a template, not just a plain function with const StringType&,
-  // because absl::string_view has some interfering non-explicit constructors.
+  // This is a template, not just a plain function with const std::string&,
+  // because std::string_view and absl::string_view have some interfering
+  // non-explicit constructors.
   template <typename MatcheeStringType>
   bool MatchAndExplain(const MatcheeStringType& s,
                        MatchResultListener* /* listener */) const {
@@ -787,15 +788,15 @@ class StartsWithMatcher {
   explicit StartsWithMatcher(const StringType& prefix) : prefix_(prefix) {
   }
 
-#if GTEST_HAS_ABSL
-  bool MatchAndExplain(const absl::string_view& s,
+#if GTEST_HAS_CPP17_TYPES
+  bool MatchAndExplain(const string_view& s,
                        MatchResultListener* listener) const {
-    // This should fail to compile if absl::string_view is used with wide
-    // strings.
+    // This should fail to compile if std::string_view / absl::string_view
+    // is used with wide strings.
     const StringType& str = std::string(s);
     return MatchAndExplain(str, listener);
   }
-#endif  // GTEST_HAS_ABSL
+#endif  // GTEST_HAS_CPP17_TYPES
 
   // Accepts pointer types, particularly:
   //   const char*
@@ -809,8 +810,9 @@ class StartsWithMatcher {
 
   // Matches anything that can convert to StringType.
   //
-  // This is a template, not just a plain function with const StringType&,
-  // because absl::string_view has some interfering non-explicit constructors.
+  // This is a template, not just a plain function with const std::string&,
+  // because std::string_view and absl::string_view have some interfering
+  // non-explicit constructors.
   template <typename MatcheeStringType>
   bool MatchAndExplain(const MatcheeStringType& s,
                        MatchResultListener* /* listener */) const {
@@ -843,15 +845,15 @@ class EndsWithMatcher {
  public:
   explicit EndsWithMatcher(const StringType& suffix) : suffix_(suffix) {}
 
-#if GTEST_HAS_ABSL
-  bool MatchAndExplain(const absl::string_view& s,
+#if GTEST_HAS_CPP17_TYPES
+  bool MatchAndExplain(const string_view& s,
                        MatchResultListener* listener) const {
-    // This should fail to compile if absl::string_view is used with wide
-    // strings.
+    // This should fail to compile if std::string_view / absl::string_view
+    // is used with wide strings.
     const StringType& str = std::string(s);
     return MatchAndExplain(str, listener);
   }
-#endif  // GTEST_HAS_ABSL
+#endif  // GTEST_HAS_CPP17_TYPES
 
   // Accepts pointer types, particularly:
   //   const char*
@@ -865,8 +867,9 @@ class EndsWithMatcher {
 
   // Matches anything that can convert to StringType.
   //
-  // This is a template, not just a plain function with const StringType&,
-  // because absl::string_view has some interfering non-explicit constructors.
+  // This is a template, not just a plain function with const std::string&,
+  // because std::string_view and absl::string_view have some interfering
+  // non-explicit constructors.
   template <typename MatcheeStringType>
   bool MatchAndExplain(const MatcheeStringType& s,
                        MatchResultListener* /* listener */) const {

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -347,43 +347,49 @@ TEST(StringMatcherTest, CanBeImplicitlyConstructedFromString) {
   EXPECT_FALSE(m2.Matches("hello"));
 }
 
-#if GTEST_HAS_ABSL
+#if GTEST_HAS_CPP17_TYPES
 // Tests that a C-string literal can be implicitly converted to a
-// Matcher<absl::string_view> or Matcher<const absl::string_view&>.
+// Matcher<std::string_view / absl::string_view> or
+// Matcher<const std::string_view& / const absl::string_view&>.
 TEST(StringViewMatcherTest, CanBeImplicitlyConstructedFromCStringLiteral) {
-  Matcher<absl::string_view> m1 = "cats";
+  using ::testing::internal::string_view;
+  Matcher<string_view> m1 = "cats";
   EXPECT_TRUE(m1.Matches("cats"));
   EXPECT_FALSE(m1.Matches("dogs"));
 
-  Matcher<const absl::string_view&> m2 = "cats";
+  Matcher<const string_view&> m2 = "cats";
   EXPECT_TRUE(m2.Matches("cats"));
   EXPECT_FALSE(m2.Matches("dogs"));
 }
 
 // Tests that a std::string object can be implicitly converted to a
-// Matcher<absl::string_view> or Matcher<const absl::string_view&>.
+// Matcher<std::string_view / absl::string_view> or
+// Matcher<const std::string_view& / const absl::string_view&>.
 TEST(StringViewMatcherTest, CanBeImplicitlyConstructedFromString) {
-  Matcher<absl::string_view> m1 = std::string("cats");
+  using ::testing::internal::string_view;
+  Matcher<string_view> m1 = std::string("cats");
   EXPECT_TRUE(m1.Matches("cats"));
   EXPECT_FALSE(m1.Matches("dogs"));
 
-  Matcher<const absl::string_view&> m2 = std::string("cats");
+  Matcher<const string_view&> m2 = std::string("cats");
   EXPECT_TRUE(m2.Matches("cats"));
   EXPECT_FALSE(m2.Matches("dogs"));
 }
 
-// Tests that a absl::string_view object can be implicitly converted to a
-// Matcher<absl::string_view> or Matcher<const absl::string_view&>.
+// Tests that a std::string_view / absl::string_view object can be
+// implicitly converted to a Matcher<std::string_view / absl::string_view>
+// or Matcher<const std::string_view& / const absl::string_view&>.
 TEST(StringViewMatcherTest, CanBeImplicitlyConstructedFromStringView) {
-  Matcher<absl::string_view> m1 = absl::string_view("cats");
+  using ::testing::internal::string_view;
+  Matcher<string_view> m1 = string_view("cats");
   EXPECT_TRUE(m1.Matches("cats"));
   EXPECT_FALSE(m1.Matches("dogs"));
 
-  Matcher<const absl::string_view&> m2 = absl::string_view("cats");
+  Matcher<const string_view&> m2 = string_view("cats");
   EXPECT_TRUE(m2.Matches("cats"));
   EXPECT_FALSE(m2.Matches("dogs"));
 }
-#endif  // GTEST_HAS_ABSL
+#endif  // GTEST_HAS_CPP17_TYPES
 
 // Tests that a std::reference_wrapper<std::string> object can be implicitly
 // converted to a Matcher<std::string> or Matcher<const std::string&> via Eq().
@@ -1232,17 +1238,18 @@ TEST(StrEqTest, MatchesEqualString) {
   EXPECT_TRUE(m2.Matches("Hello"));
   EXPECT_FALSE(m2.Matches("Hi"));
 
-#if GTEST_HAS_ABSL
-  Matcher<const absl::string_view&> m3 = StrEq("Hello");
-  EXPECT_TRUE(m3.Matches(absl::string_view("Hello")));
-  EXPECT_FALSE(m3.Matches(absl::string_view("hello")));
-  EXPECT_FALSE(m3.Matches(absl::string_view()));
+#if GTEST_HAS_CPP17_TYPES
+  using ::testing::internal::string_view;
+  Matcher<const string_view&> m3 = StrEq("Hello");
+  EXPECT_TRUE(m3.Matches(string_view("Hello")));
+  EXPECT_FALSE(m3.Matches(string_view("hello")));
+  EXPECT_FALSE(m3.Matches(string_view()));
 
-  Matcher<const absl::string_view&> m_empty = StrEq("");
-  EXPECT_TRUE(m_empty.Matches(absl::string_view("")));
-  EXPECT_TRUE(m_empty.Matches(absl::string_view()));
-  EXPECT_FALSE(m_empty.Matches(absl::string_view("hello")));
-#endif  // GTEST_HAS_ABSL
+  Matcher<const string_view&> m_empty = StrEq("");
+  EXPECT_TRUE(m_empty.Matches(string_view("")));
+  EXPECT_TRUE(m_empty.Matches(string_view()));
+  EXPECT_FALSE(m_empty.Matches(string_view("hello")));
+#endif  // GTEST_HAS_CPP17_TYPES
 }
 
 TEST(StrEqTest, CanDescribeSelf) {
@@ -1269,12 +1276,13 @@ TEST(StrNeTest, MatchesUnequalString) {
   EXPECT_TRUE(m2.Matches("hello"));
   EXPECT_FALSE(m2.Matches("Hello"));
 
-#if GTEST_HAS_ABSL
-  Matcher<const absl::string_view> m3 = StrNe("Hello");
-  EXPECT_TRUE(m3.Matches(absl::string_view("")));
-  EXPECT_TRUE(m3.Matches(absl::string_view()));
-  EXPECT_FALSE(m3.Matches(absl::string_view("Hello")));
-#endif  // GTEST_HAS_ABSL
+#if GTEST_HAS_CPP17_TYPES
+  using ::testing::internal::string_view;
+  Matcher<string_view> m3 = StrNe("Hello");
+  EXPECT_TRUE(m3.Matches(string_view("")));
+  EXPECT_TRUE(m3.Matches(string_view()));
+  EXPECT_FALSE(m3.Matches(string_view("Hello")));
+#endif  // GTEST_HAS_CPP17_TYPES
 }
 
 TEST(StrNeTest, CanDescribeSelf) {
@@ -1293,13 +1301,14 @@ TEST(StrCaseEqTest, MatchesEqualStringIgnoringCase) {
   EXPECT_TRUE(m2.Matches("hello"));
   EXPECT_FALSE(m2.Matches("Hi"));
 
-#if GTEST_HAS_ABSL
-  Matcher<const absl::string_view&> m3 = StrCaseEq(std::string("Hello"));
-  EXPECT_TRUE(m3.Matches(absl::string_view("Hello")));
-  EXPECT_TRUE(m3.Matches(absl::string_view("hello")));
-  EXPECT_FALSE(m3.Matches(absl::string_view("Hi")));
-  EXPECT_FALSE(m3.Matches(absl::string_view()));
-#endif  // GTEST_HAS_ABSL
+#if GTEST_HAS_CPP17_TYPES
+  using ::testing::internal::string_view;
+  Matcher<const string_view&> m3 = StrCaseEq(std::string("Hello"));
+  EXPECT_TRUE(m3.Matches(string_view("Hello")));
+  EXPECT_TRUE(m3.Matches(string_view("hello")));
+  EXPECT_FALSE(m3.Matches(string_view("Hi")));
+  EXPECT_FALSE(m3.Matches(string_view()));
+#endif  // GTEST_HAS_CPP17_TYPES
 }
 
 TEST(StrCaseEqTest, MatchesEqualStringWith0IgnoringCase) {
@@ -1343,13 +1352,14 @@ TEST(StrCaseNeTest, MatchesUnequalStringIgnoringCase) {
   EXPECT_TRUE(m2.Matches(""));
   EXPECT_FALSE(m2.Matches("Hello"));
 
-#if GTEST_HAS_ABSL
-  Matcher<const absl::string_view> m3 = StrCaseNe("Hello");
-  EXPECT_TRUE(m3.Matches(absl::string_view("Hi")));
-  EXPECT_TRUE(m3.Matches(absl::string_view()));
-  EXPECT_FALSE(m3.Matches(absl::string_view("Hello")));
-  EXPECT_FALSE(m3.Matches(absl::string_view("hello")));
-#endif  // GTEST_HAS_ABSL
+#if GTEST_HAS_CPP17_TYPES
+  using ::testing::internal::string_view;
+  Matcher<string_view> m3 = StrCaseNe("Hello");
+  EXPECT_TRUE(m3.Matches(string_view("Hi")));
+  EXPECT_TRUE(m3.Matches(string_view()));
+  EXPECT_FALSE(m3.Matches(string_view("Hello")));
+  EXPECT_FALSE(m3.Matches(string_view("hello")));
+#endif  // GTEST_HAS_CPP17_TYPES
 }
 
 TEST(StrCaseNeTest, CanDescribeSelf) {
@@ -1390,25 +1400,27 @@ TEST(HasSubstrTest, WorksForCStrings) {
   EXPECT_FALSE(m_empty.Matches(nullptr));
 }
 
-#if GTEST_HAS_ABSL
-// Tests that HasSubstr() works for matching absl::string_view-typed values.
+#if GTEST_HAS_CPP17_TYPES
+// Tests that HasSubstr() works for matching
+// std::string_view / absl::string_view -typed values.
 TEST(HasSubstrTest, WorksForStringViewClasses) {
-  const Matcher<absl::string_view> m1 = HasSubstr("foo");
-  EXPECT_TRUE(m1.Matches(absl::string_view("I love food.")));
-  EXPECT_FALSE(m1.Matches(absl::string_view("tofo")));
-  EXPECT_FALSE(m1.Matches(absl::string_view()));
+  using ::testing::internal::string_view;
+  const Matcher<string_view> m1 = HasSubstr("foo");
+  EXPECT_TRUE(m1.Matches(string_view("I love food.")));
+  EXPECT_FALSE(m1.Matches(string_view("tofo")));
+  EXPECT_FALSE(m1.Matches(string_view()));
 
-  const Matcher<const absl::string_view&> m2 = HasSubstr("foo");
-  EXPECT_TRUE(m2.Matches(absl::string_view("I love food.")));
-  EXPECT_FALSE(m2.Matches(absl::string_view("tofo")));
-  EXPECT_FALSE(m2.Matches(absl::string_view()));
+  const Matcher<const string_view&> m2 = HasSubstr("foo");
+  EXPECT_TRUE(m2.Matches(string_view("I love food.")));
+  EXPECT_FALSE(m2.Matches(string_view("tofo")));
+  EXPECT_FALSE(m2.Matches(string_view()));
 
-  const Matcher<const absl::string_view&> m3 = HasSubstr("");
-  EXPECT_TRUE(m3.Matches(absl::string_view("foo")));
-  EXPECT_TRUE(m3.Matches(absl::string_view("")));
-  EXPECT_TRUE(m3.Matches(absl::string_view()));
+  const Matcher<const string_view&> m3 = HasSubstr("");
+  EXPECT_TRUE(m3.Matches(string_view("foo")));
+  EXPECT_TRUE(m3.Matches(string_view("")));
+  EXPECT_TRUE(m3.Matches(string_view()));
 }
-#endif  // GTEST_HAS_ABSL
+#endif  // GTEST_HAS_CPP17_TYPES
 
 // Tests that HasSubstr(s) describes itself properly.
 TEST(HasSubstrTest, CanDescribeSelf) {
@@ -1645,12 +1657,13 @@ TEST(StartsWithTest, MatchesStringWithGivenPrefix) {
   EXPECT_FALSE(m2.Matches("H"));
   EXPECT_FALSE(m2.Matches(" Hi"));
 
-#if GTEST_HAS_ABSL
-  const Matcher<absl::string_view> m_empty = StartsWith("");
-  EXPECT_TRUE(m_empty.Matches(absl::string_view()));
-  EXPECT_TRUE(m_empty.Matches(absl::string_view("")));
-  EXPECT_TRUE(m_empty.Matches(absl::string_view("not empty")));
-#endif  // GTEST_HAS_ABSL
+#if GTEST_HAS_CPP17_TYPES
+  using ::testing::internal::string_view;
+  const Matcher<string_view> m_empty = StartsWith("");
+  EXPECT_TRUE(m_empty.Matches(string_view()));
+  EXPECT_TRUE(m_empty.Matches(string_view("")));
+  EXPECT_TRUE(m_empty.Matches(string_view("not empty")));
+#endif  // GTEST_HAS_CPP17_TYPES
 }
 
 TEST(StartsWithTest, CanDescribeSelf) {
@@ -1673,13 +1686,14 @@ TEST(EndsWithTest, MatchesStringWithGivenSuffix) {
   EXPECT_FALSE(m2.Matches("i"));
   EXPECT_FALSE(m2.Matches("Hi "));
 
-#if GTEST_HAS_ABSL
-  const Matcher<const absl::string_view&> m4 = EndsWith("");
+#if GTEST_HAS_CPP17_TYPES
+  using ::testing::internal::string_view;
+  const Matcher<const string_view&> m4 = EndsWith("");
   EXPECT_TRUE(m4.Matches("Hi"));
   EXPECT_TRUE(m4.Matches(""));
-  EXPECT_TRUE(m4.Matches(absl::string_view()));
-  EXPECT_TRUE(m4.Matches(absl::string_view("")));
-#endif  // GTEST_HAS_ABSL
+  EXPECT_TRUE(m4.Matches(string_view()));
+  EXPECT_TRUE(m4.Matches(string_view("")));
+#endif  // GTEST_HAS_CPP17_TYPES
 }
 
 TEST(EndsWithTest, CanDescribeSelf) {
@@ -1700,16 +1714,17 @@ TEST(MatchesRegexTest, MatchesStringMatchingGivenRegex) {
   EXPECT_FALSE(m2.Matches("az1"));
   EXPECT_FALSE(m2.Matches("1az"));
 
-#if GTEST_HAS_ABSL
-  const Matcher<const absl::string_view&> m3 = MatchesRegex("a.*z");
-  EXPECT_TRUE(m3.Matches(absl::string_view("az")));
-  EXPECT_TRUE(m3.Matches(absl::string_view("abcz")));
-  EXPECT_FALSE(m3.Matches(absl::string_view("1az")));
-  EXPECT_FALSE(m3.Matches(absl::string_view()));
-  const Matcher<const absl::string_view&> m4 = MatchesRegex("");
-  EXPECT_TRUE(m4.Matches(absl::string_view("")));
-  EXPECT_TRUE(m4.Matches(absl::string_view()));
-#endif  // GTEST_HAS_ABSL
+#if GTEST_HAS_CPP17_TYPES
+  using ::testing::internal::string_view;
+  const Matcher<const string_view&> m3 = MatchesRegex("a.*z");
+  EXPECT_TRUE(m3.Matches(string_view("az")));
+  EXPECT_TRUE(m3.Matches(string_view("abcz")));
+  EXPECT_FALSE(m3.Matches(string_view("1az")));
+  EXPECT_FALSE(m3.Matches(string_view()));
+  const Matcher<const string_view&> m4 = MatchesRegex("");
+  EXPECT_TRUE(m4.Matches(string_view("")));
+  EXPECT_TRUE(m4.Matches(string_view()));
+#endif  // GTEST_HAS_CPP17_TYPES
 }
 
 TEST(MatchesRegexTest, CanDescribeSelf) {
@@ -1719,10 +1734,11 @@ TEST(MatchesRegexTest, CanDescribeSelf) {
   Matcher<const char*> m2 = MatchesRegex(new RE("a.*"));
   EXPECT_EQ("matches regular expression \"a.*\"", Describe(m2));
 
-#if GTEST_HAS_ABSL
-  Matcher<const absl::string_view> m3 = MatchesRegex(new RE("0.*"));
+#if GTEST_HAS_CPP17_TYPES
+  Matcher<const ::testing::internal::string_view> m3 =
+      MatchesRegex(new RE("0.*"));
   EXPECT_EQ("matches regular expression \"0.*\"", Describe(m3));
-#endif  // GTEST_HAS_ABSL
+#endif  // GTEST_HAS_CPP17_TYPES
 }
 
 // Tests ContainsRegex().
@@ -1738,16 +1754,17 @@ TEST(ContainsRegexTest, MatchesStringContainingGivenRegex) {
   EXPECT_TRUE(m2.Matches("az1"));
   EXPECT_FALSE(m2.Matches("1a"));
 
-#if GTEST_HAS_ABSL
-  const Matcher<const absl::string_view&> m3 = ContainsRegex(new RE("a.*z"));
-  EXPECT_TRUE(m3.Matches(absl::string_view("azbz")));
-  EXPECT_TRUE(m3.Matches(absl::string_view("az1")));
-  EXPECT_FALSE(m3.Matches(absl::string_view("1a")));
-  EXPECT_FALSE(m3.Matches(absl::string_view()));
-  const Matcher<const absl::string_view&> m4 = ContainsRegex("");
-  EXPECT_TRUE(m4.Matches(absl::string_view("")));
-  EXPECT_TRUE(m4.Matches(absl::string_view()));
-#endif  // GTEST_HAS_ABSL
+#if GTEST_HAS_CPP17_TYPES
+  using ::testing::internal::string_view;
+  const Matcher<const string_view&> m3 = ContainsRegex(new RE("a.*z"));
+  EXPECT_TRUE(m3.Matches(string_view("azbz")));
+  EXPECT_TRUE(m3.Matches(string_view("az1")));
+  EXPECT_FALSE(m3.Matches(string_view("1a")));
+  EXPECT_FALSE(m3.Matches(string_view()));
+  const Matcher<const string_view&> m4 = ContainsRegex("");
+  EXPECT_TRUE(m4.Matches(string_view("")));
+  EXPECT_TRUE(m4.Matches(string_view()));
+#endif  // GTEST_HAS_CPP17_TYPES
 }
 
 TEST(ContainsRegexTest, CanDescribeSelf) {
@@ -1757,10 +1774,11 @@ TEST(ContainsRegexTest, CanDescribeSelf) {
   Matcher<const char*> m2 = ContainsRegex(new RE("a.*"));
   EXPECT_EQ("contains regular expression \"a.*\"", Describe(m2));
 
-#if GTEST_HAS_ABSL
-  Matcher<const absl::string_view> m3 = ContainsRegex(new RE("0.*"));
+#if GTEST_HAS_CPP17_TYPES
+  Matcher<const ::testing::internal::string_view> m3 =
+      ContainsRegex(new RE("0.*"));
   EXPECT_EQ("contains regular expression \"0.*\"", Describe(m3));
-#endif  // GTEST_HAS_ABSL
+#endif  // GTEST_HAS_CPP17_TYPES
 }
 
 // Tests for wide strings.

--- a/googletest/include/gtest/gtest-matchers.h
+++ b/googletest/include/gtest/gtest-matchers.h
@@ -384,18 +384,18 @@ class GTEST_API_ Matcher<std::string>
   Matcher(const char* s);  // NOLINT
 };
 
-#if GTEST_HAS_ABSL
+#if GTEST_HAS_CPP17_TYPES
 // The following two specializations allow the user to write str
-// instead of Eq(str) and "foo" instead of Eq("foo") when a absl::string_view
-// matcher is expected.
+// instead of Eq(str) and "foo" instead of Eq("foo") when a std::string_view /
+// absl::string_view matcher is expected.
 template <>
-class GTEST_API_ Matcher<const absl::string_view&>
-    : public internal::MatcherBase<const absl::string_view&> {
+class GTEST_API_ Matcher<const internal::string_view&>
+    : public internal::MatcherBase<const internal::string_view&> {
  public:
   Matcher() {}
 
-  explicit Matcher(const MatcherInterface<const absl::string_view&>* impl)
-      : internal::MatcherBase<const absl::string_view&>(impl) {}
+  explicit Matcher(const MatcherInterface<const internal::string_view&>* impl)
+      : internal::MatcherBase<const internal::string_view&>(impl) {}
 
   // Allows the user to write str instead of Eq(str) sometimes, where
   // str is a std::string object.
@@ -404,20 +404,20 @@ class GTEST_API_ Matcher<const absl::string_view&>
   // Allows the user to write "foo" instead of Eq("foo") sometimes.
   Matcher(const char* s);  // NOLINT
 
-  // Allows the user to pass absl::string_views directly.
-  Matcher(absl::string_view s);  // NOLINT
+  // Allows the user to pass a std::string_view / absl::string_view directly.
+  Matcher(internal::string_view s);  // NOLINT
 };
 
 template <>
-class GTEST_API_ Matcher<absl::string_view>
-    : public internal::MatcherBase<absl::string_view> {
+class GTEST_API_ Matcher<internal::string_view>
+    : public internal::MatcherBase<internal::string_view> {
  public:
   Matcher() {}
 
-  explicit Matcher(const MatcherInterface<const absl::string_view&>* impl)
-      : internal::MatcherBase<absl::string_view>(impl) {}
-  explicit Matcher(const MatcherInterface<absl::string_view>* impl)
-      : internal::MatcherBase<absl::string_view>(impl) {}
+  explicit Matcher(const MatcherInterface<const internal::string_view&>* impl)
+      : internal::MatcherBase<internal::string_view>(impl) {}
+  explicit Matcher(const MatcherInterface<internal::string_view>* impl)
+      : internal::MatcherBase<internal::string_view>(impl) {}
 
   // Allows the user to write str instead of Eq(str) sometimes, where
   // str is a std::string object.
@@ -426,10 +426,10 @@ class GTEST_API_ Matcher<absl::string_view>
   // Allows the user to write "foo" instead of Eq("foo") sometimes.
   Matcher(const char* s);  // NOLINT
 
-  // Allows the user to pass absl::string_views directly.
-  Matcher(absl::string_view s);  // NOLINT
+  // Allows the user to pass a std::string_view / absl::string_view directly.
+  Matcher(internal::string_view s);  // NOLINT
 };
-#endif  // GTEST_HAS_ABSL
+#endif  // GTEST_HAS_CPP17_TYPES
 
 // Prints a matcher in a human-readable format.
 template <typename T>
@@ -620,12 +620,12 @@ class MatchesRegexMatcher {
   MatchesRegexMatcher(const RE* regex, bool full_match)
       : regex_(regex), full_match_(full_match) {}
 
-#if GTEST_HAS_ABSL
-  bool MatchAndExplain(const absl::string_view& s,
+#if GTEST_HAS_CPP17_TYPES
+  bool MatchAndExplain(const internal::string_view& s,
                        MatchResultListener* listener) const {
     return MatchAndExplain(std::string(s), listener);
   }
-#endif  // GTEST_HAS_ABSL
+#endif  // GTEST_HAS_CPP17_TYPES
 
   // Accepts pointer types, particularly:
   //   const char*
@@ -640,7 +640,8 @@ class MatchesRegexMatcher {
   // Matches anything that can convert to std::string.
   //
   // This is a template, not just a plain function with const std::string&,
-  // because absl::string_view has some interfering non-explicit constructors.
+  // because std::string_view and absl::string_view have some interfering
+  // non-explicit constructors.
   template <class MatcheeStringType>
   bool MatchAndExplain(const MatcheeStringType& s,
                        MatchResultListener* /* listener */) const {

--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -122,6 +122,12 @@
 #include "absl/types/variant.h"
 #endif  // __cplusplus >= 201703L
 
+#ifdef GTEST_HAS_CPP17_TYPES
+#error GTEST_HAS_CPP17_TYPES cannot be directly set
+#elif GTEST_HAS_ABSL || __cplusplus >= 201703L
+#define GTEST_HAS_CPP17_TYPES 1
+#endif  // GTEST_HAS_CPP17_TYPES
+
 namespace testing {
 
 // Definitions in the 'internal' and 'internal2' name spaces are
@@ -687,7 +693,7 @@ class UniversalPrinter {
   GTEST_DISABLE_MSC_WARNINGS_POP_()
 };
 
-#if GTEST_HAS_ABSL || __cplusplus >= 201703L
+#if GTEST_HAS_CPP17_TYPES
 
 using any =
 #if __cplusplus >= 201703L
@@ -771,7 +777,7 @@ class UniversalPrinter<variant<T...>> {
   };
 };
 
-#endif  // GTEST_HAS_ABSL || __cplusplus >= 201703L
+#endif  // GTEST_HAS_CPP17_TYPES
 
 // UniversalPrintArray(begin, len, os) prints an array of 'len'
 // elements, starting at address 'begin'.

--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -112,10 +112,12 @@
 #include "gtest/internal/gtest-port.h"
 
 #if __cplusplus >= 201703L
+#include <any>
 #include <optional>
 #include <variant>
 #elif GTEST_HAS_ABSL
 #include "absl/strings/string_view.h"
+#include "absl/types/any.h"
 #include "absl/types/optional.h"
 #include "absl/types/variant.h"
 #endif  // __cplusplus >= 201703L
@@ -687,6 +689,13 @@ class UniversalPrinter {
 
 #if GTEST_HAS_ABSL || __cplusplus >= 201703L
 
+using any =
+#if __cplusplus >= 201703L
+    std::any;
+#elif GTEST_HAS_ABSL
+    absl::any;
+#endif  // __cplusplus >= 201703L
+
 template <typename T>
 using optional =
 #if __cplusplus >= 201703L
@@ -702,6 +711,23 @@ using variant =
 #elif GTEST_HAS_ABSL
     absl::variant<Ts...>;
 #endif  // __cplusplus >= 201703L
+
+// Printer for std::any / absl::any
+
+template <>
+class UniversalPrinter<any> {
+ public:
+  static void Print(const any& value, ::std::ostream* os) {
+#if __cplusplus >= 201703L
+    *os << "std::any";
+#elif GTEST_HAS_ABSL
+    *os << "absl::any";
+#endif  // __cplusplus >= 201703L
+#if GTEST_HAS_RTTI
+    *os << " (" << GetTypeName(value.type()) << ')';
+#endif  // GTEST_HAS_RTTI
+  }
+};
 
 // Printer for std::optional / absl::optional
 

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -66,6 +66,17 @@
 #include "gtest/internal/gtest-string.h"
 #include "gtest/internal/gtest-type-util.h"
 
+#if __cplusplus >= 201703L
+#include <any>
+#include <optional>
+#include <variant>
+#elif GTEST_HAS_ABSL
+#include "absl/strings/string_view.h"
+#include "absl/types/any.h"
+#include "absl/types/optional.h"
+#include "absl/types/variant.h"
+#endif  // __cplusplus >= 201703L
+
 // Due to C++ preprocessor weirdness, we need double indirection to
 // concatenate two tokens when one of them is __LINE__.  Writing
 //
@@ -1252,6 +1263,46 @@ GTEST_INTERNAL_DEPRECATED(
     "INSTANTIATE_TYPED_TEST_CASE_P is deprecated, please use "
     "INSTANTIATE_TYPED_TEST_SUITE_P")
 constexpr bool InstantiateTypedTestCase_P_IsDeprecated() { return true; }
+
+#ifdef GTEST_HAS_CPP17_TYPES
+#error GTEST_HAS_CPP17_TYPES cannot be directly set
+#elif GTEST_HAS_ABSL || __cplusplus >= 201703L
+#define GTEST_HAS_CPP17_TYPES 1
+#endif  // GTEST_HAS_CPP17_TYPES
+
+#if GTEST_HAS_CPP17_TYPES
+
+using any =
+#if __cplusplus >= 201703L
+    std::any;
+#elif GTEST_HAS_ABSL
+    absl::any;
+#endif  // __cplusplus >= 201703L
+
+template <typename T>
+using optional =
+#if __cplusplus >= 201703L
+    std::optional<T>;
+#elif GTEST_HAS_ABSL
+    absl::optional<T>;
+#endif  // __cplusplus >= 201703L
+
+using string_view =
+#if __cplusplus >= 201703L
+    std::string_view;
+#elif GTEST_HAS_ABSL
+    absl::string_view;
+#endif  // __cplusplus >= 201703L
+
+template <typename... Ts>
+using variant =
+#if __cplusplus >= 201703L
+    std::variant<Ts...>;
+#elif GTEST_HAS_ABSL
+    absl::variant<Ts...>;
+#endif  // __cplusplus >= 201703L
+
+#endif  // GTEST_HAS_CPP17_TYPES
 
 }  // namespace internal
 }  // namespace testing

--- a/googletest/include/gtest/internal/gtest-type-util.h
+++ b/googletest/include/gtest/internal/gtest-type-util.h
@@ -73,34 +73,40 @@ inline std::string CanonicalizeForStdLibVersioning(std::string s) {
   return s;
 }
 
-// GetTypeName<T>() returns a human-readable name of type T.
+#if GTEST_HAS_RTTI
+// GetTypeName(const std::type_info&) returns a human-readable name of type T.
 // NB: This function is also used in Google Mock, so don't move it inside of
 // the typed-test-only section below.
-template <typename T>
-std::string GetTypeName() {
-# if GTEST_HAS_RTTI
-
-  const char* const name = typeid(T).name();
-#  if GTEST_HAS_CXXABI_H_ || defined(__HP_aCC)
+inline std::string GetTypeName(const std::type_info& type) {
+  const char* const name = type.name();
+#if GTEST_HAS_CXXABI_H_ || defined(__HP_aCC)
   int status = 0;
   // gcc's implementation of typeid(T).name() mangles the type name,
   // so we have to demangle it.
-#   if GTEST_HAS_CXXABI_H_
+#if GTEST_HAS_CXXABI_H_
   using abi::__cxa_demangle;
-#   endif  // GTEST_HAS_CXXABI_H_
+#endif  // GTEST_HAS_CXXABI_H_
   char* const readable_name = __cxa_demangle(name, nullptr, nullptr, &status);
   const std::string name_str(status == 0 ? readable_name : name);
   free(readable_name);
   return CanonicalizeForStdLibVersioning(name_str);
-#  else
+#else
   return name;
-#  endif  // GTEST_HAS_CXXABI_H_ || __HP_aCC
+#endif  // GTEST_HAS_CXXABI_H_ || __HP_aCC
+}
+#endif  // GTEST_HAS_RTTI
 
-# else
-
+// GetTypeName<T>() returns a human-readable name of type T if and only if
+// RTTI is enabled, otherwise it returns a dummy type name.
+// NB: This function is also used in Google Mock, so don't move it inside of
+// the typed-test-only section below.
+template <typename T>
+std::string GetTypeName() {
+#if GTEST_HAS_RTTI
+  return GetTypeName(typeid(T));
+#else
   return "<type>";
-
-# endif  // GTEST_HAS_RTTI
+#endif  // GTEST_HAS_RTTI
 }
 
 #if GTEST_HAS_TYPED_TEST || GTEST_HAS_TYPED_TEST_P

--- a/googletest/include/gtest/internal/gtest-type-util.h.pump
+++ b/googletest/include/gtest/internal/gtest-type-util.h.pump
@@ -72,34 +72,40 @@ inline std::string CanonicalizeForStdLibVersioning(std::string s) {
   return s;
 }
 
-// GetTypeName<T>() returns a human-readable name of type T.
+#if GTEST_HAS_RTTI
+// GetTypeName(const std::type_info&) returns a human-readable name of type T.
 // NB: This function is also used in Google Mock, so don't move it inside of
 // the typed-test-only section below.
-template <typename T>
-std::string GetTypeName() {
-# if GTEST_HAS_RTTI
-
-  const char* const name = typeid(T).name();
-#  if GTEST_HAS_CXXABI_H_ || defined(__HP_aCC)
+inline std::string GetTypeName(const std::type_info& type) {
+  const char* const name = type.name();
+#if GTEST_HAS_CXXABI_H_ || defined(__HP_aCC)
   int status = 0;
   // gcc's implementation of typeid(T).name() mangles the type name,
   // so we have to demangle it.
-#   if GTEST_HAS_CXXABI_H_
+#if GTEST_HAS_CXXABI_H_
   using abi::__cxa_demangle;
-#   endif  // GTEST_HAS_CXXABI_H_
+#endif  // GTEST_HAS_CXXABI_H_
   char* const readable_name = __cxa_demangle(name, nullptr, nullptr, &status);
   const std::string name_str(status == 0 ? readable_name : name);
   free(readable_name);
   return CanonicalizeForStdLibVersioning(name_str);
-#  else
+#else
   return name;
-#  endif  // GTEST_HAS_CXXABI_H_ || __HP_aCC
+#endif  // GTEST_HAS_CXXABI_H_ || __HP_aCC
+}
+#endif  // GTEST_HAS_RTTI
 
-# else
-
+// GetTypeName<T>() returns a human-readable name of type T if and only if
+// RTTI is enabled, otherwise it returns a dummy type name.
+// NB: This function is also used in Google Mock, so don't move it inside of
+// the typed-test-only section below.
+template <typename T>
+std::string GetTypeName() {
+#if GTEST_HAS_RTTI
+  return GetTypeName(typeid(T));
+#else
   return "<type>";
-
-# endif  // GTEST_HAS_RTTI
+#endif  // GTEST_HAS_RTTI
 }
 
 #if GTEST_HAS_TYPED_TEST || GTEST_HAS_TYPED_TEST_P

--- a/googletest/src/gtest-matchers.cc
+++ b/googletest/src/gtest-matchers.cc
@@ -58,40 +58,40 @@ Matcher<std::string>::Matcher(const std::string& s) { *this = Eq(s); }
 // s.
 Matcher<std::string>::Matcher(const char* s) { *this = Eq(std::string(s)); }
 
-#if GTEST_HAS_ABSL
-// Constructs a matcher that matches a const absl::string_view& whose value is
-// equal to s.
-Matcher<const absl::string_view&>::Matcher(const std::string& s) {
+#if GTEST_HAS_CPP17_TYPES
+// Constructs a matcher that matches a const std::string_view /
+// const absl::string_view& whose value is equal to s.
+Matcher<const internal::string_view&>::Matcher(const std::string& s) {
   *this = Eq(s);
 }
 
-// Constructs a matcher that matches a const absl::string_view& whose value is
-// equal to s.
-Matcher<const absl::string_view&>::Matcher(const char* s) {
+// Constructs a matcher that matches a const std::string_view /
+// const absl::string_view& whose value is equal to s.
+Matcher<const internal::string_view&>::Matcher(const char* s) {
   *this = Eq(std::string(s));
 }
 
-// Constructs a matcher that matches a const absl::string_view& whose value is
-// equal to s.
-Matcher<const absl::string_view&>::Matcher(absl::string_view s) {
+// Constructs a matcher that matches a const std::string_view& /
+// const absl::string_view& whose value is equal to s.
+Matcher<const internal::string_view&>::Matcher(internal::string_view s) {
   *this = Eq(std::string(s));
 }
 
-// Constructs a matcher that matches a absl::string_view whose value is equal to
-// s.
-Matcher<absl::string_view>::Matcher(const std::string& s) { *this = Eq(s); }
+// Constructs a matcher that matches a std::string_view / absl::string_view
+// whose value is equal to s.
+Matcher<internal::string_view>::Matcher(const std::string& s) { *this = Eq(s); }
 
-// Constructs a matcher that matches a absl::string_view whose value is equal to
-// s.
-Matcher<absl::string_view>::Matcher(const char* s) {
+// Constructs a matcher that matches a std::string_view / absl::string_view
+// whose value is equal to s.
+Matcher<internal::string_view>::Matcher(const char* s) {
   *this = Eq(std::string(s));
 }
 
-// Constructs a matcher that matches a absl::string_view whose value is equal to
-// s.
-Matcher<absl::string_view>::Matcher(absl::string_view s) {
+// Constructs a matcher that matches a std::string_view / absl::string_view
+// whose value is equal to s.
+Matcher<internal::string_view>::Matcher(internal::string_view s) {
   *this = Eq(std::string(s));
 }
-#endif  // GTEST_HAS_ABSL
+#endif  // GTEST_HAS_CPP17_TYPES
 
 }  // namespace testing

--- a/googletest/test/googletest-printers-test.cc
+++ b/googletest/test/googletest-printers-test.cc
@@ -758,22 +758,22 @@ TEST(PrintTypeWithGenericStreamingTest, TypeImplicitlyConvertible) {
   EXPECT_EQ("AllowsGenericStreamingAndImplicitConversionTemplate", Print(a));
 }
 
-#if GTEST_HAS_ABSL
+#if GTEST_HAS_CPP17_TYPES
 
-// Tests printing ::absl::string_view.
+// Tests printing a std::string_view / absl::string_view.
 
 TEST(PrintStringViewTest, SimpleStringView) {
-  const ::absl::string_view sp = "Hello";
+  const ::testing::internal::string_view sp = "Hello";
   EXPECT_EQ("\"Hello\"", Print(sp));
 }
 
 TEST(PrintStringViewTest, UnprintableCharacters) {
   const char str[] = "NUL (\0) and \r\t";
-  const ::absl::string_view sp(str, sizeof(str) - 1);
+  const ::testing::internal::string_view sp(str, sizeof(str) - 1);
   EXPECT_EQ("\"NUL (\\0) and \\r\\t\"", Print(sp));
 }
 
-#endif  // GTEST_HAS_ABSL
+#endif  // GTEST_HAS_CPP17_TYPES
 
 // Tests printing STL containers.
 

--- a/googletest/test/googletest-printers-test.cc
+++ b/googletest/test/googletest-printers-test.cc
@@ -1530,15 +1530,16 @@ TEST(UniversalTersePrintTupleFieldsToStringsTestWithStd, PrintsTersely) {
   EXPECT_EQ("\"a\"", result[1]);
 }
 
-#if GTEST_HAS_ABSL
+#if GTEST_HAS_ABSL || __cplusplus >= 201703L
 
 TEST(PrintOptionalTest, Basic) {
-  absl::optional<int> value;
+  using ::testing::internal::optional;
+  optional<int> value;
   EXPECT_EQ("(nullopt)", PrintToString(value));
   value = {7};
   EXPECT_EQ("(7)", PrintToString(value));
-  EXPECT_EQ("(1.1)", PrintToString(absl::optional<double>{1.1}));
-  EXPECT_EQ("(\"A\")", PrintToString(absl::optional<std::string>{"A"}));
+  EXPECT_EQ("(1.1)", PrintToString(optional<double>{1.1}));
+  EXPECT_EQ("(\"A\")", PrintToString(optional<std::string>{"A"}));
 }
 
 struct NonPrintable {
@@ -1546,7 +1547,8 @@ struct NonPrintable {
 };
 
 TEST(PrintOneofTest, Basic) {
-  using Type = absl::variant<int, StreamableInGlobal, NonPrintable>;
+  using Type =
+      ::testing::internal::variant<int, StreamableInGlobal, NonPrintable>;
   EXPECT_EQ("('int' with value 7)", PrintToString(Type(7)));
   EXPECT_EQ("('StreamableInGlobal' with value StreamableInGlobal)",
             PrintToString(Type(StreamableInGlobal{})));
@@ -1555,7 +1557,7 @@ TEST(PrintOneofTest, Basic) {
       "<11>)",
       PrintToString(Type(NonPrintable{})));
 }
-#endif  // GTEST_HAS_ABSL
+#endif  // GTEST_HAS_ABSL || __cplusplus >= 201703L
 namespace {
 class string_ref;
 

--- a/googletest/test/googletest-printers-test.cc
+++ b/googletest/test/googletest-printers-test.cc
@@ -1530,7 +1530,7 @@ TEST(UniversalTersePrintTupleFieldsToStringsTestWithStd, PrintsTersely) {
   EXPECT_EQ("\"a\"", result[1]);
 }
 
-#if GTEST_HAS_ABSL || __cplusplus >= 201703L
+#if GTEST_HAS_CPP17_TYPES
 
 class PrintAnyTest : public ::testing::Test {
  protected:
@@ -1599,7 +1599,7 @@ TEST(PrintOneofTest, Basic) {
       "<11>)",
       PrintToString(Type(NonPrintable{})));
 }
-#endif  // GTEST_HAS_ABSL || __cplusplus >= 201703L
+#endif  // GTEST_HAS_CPP17_TYPES
 namespace {
 class string_ref;
 

--- a/googletest/test/googletest-printers-test.cc
+++ b/googletest/test/googletest-printers-test.cc
@@ -1532,6 +1532,48 @@ TEST(UniversalTersePrintTupleFieldsToStringsTestWithStd, PrintsTersely) {
 
 #if GTEST_HAS_ABSL || __cplusplus >= 201703L
 
+class PrintAnyTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+#if __cplusplus >= 201703L
+    any_prefix = "std::any";
+#elif GTEST_HAS_ABSL
+    any_prefix = "absl::any";
+#endif  // __cplusplus >= 201703L
+  }
+  std::string ExpectedTypeName(std::string s) const {
+#if GTEST_HAS_RTTI
+    return any_prefix + " (" + s + ')';
+#else
+    static_cast<void>(s);
+    return any_prefix;
+#endif  // GTEST_HAS_RTTI
+  }
+
+  ::testing::internal::any any;
+  std::string any_prefix;
+};
+
+TEST_F(PrintAnyTest, Empty) {
+  EXPECT_EQ(ExpectedTypeName(::testing::internal::GetTypeName<void>()),
+            PrintToString(any));
+}
+
+TEST_F(PrintAnyTest, NonEmpty) {
+  constexpr int val1 = 10;
+  const std::string val2 = "content";
+
+  any = val1;
+  EXPECT_EQ(
+      ExpectedTypeName(::testing::internal::GetTypeName<decltype(val1)>()),
+      PrintToString(any));
+
+  any = val2;
+  EXPECT_EQ(
+      ExpectedTypeName(::testing::internal::GetTypeName<decltype(val2)>()),
+      PrintToString(any));
+}
+
 TEST(PrintOptionalTest, Basic) {
   using ::testing::internal::optional;
   optional<int> value;


### PR DESCRIPTION
Resolves #2437.

Future work:
Matchers could now support wide string_views. This is something new; Abseil doesn't support this one.