### PR TITLE
Move bool_constant from gtest-port.h to gtest-internal.h

### DIFF
--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -860,6 +860,9 @@ struct CompileAssertTypesEqual<T, T> {
 #define GTEST_REMOVE_REFERENCE_AND_CONST_(T) \
   typename std::remove_const<typename std::remove_reference<T>::type>::type
 
+template <bool B>
+using bool_constant = std::integral_constant<bool, B>;
+
 // IsAProtocolMessage<T>::value is a compile-time bool constant that's
 // true if T is type proto2::Message or a subclass of it.
 template <typename T>

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -249,7 +249,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <memory>
-#include <type_traits>
 
 #ifndef _WIN32_WCE
 # include <sys/types.h>
@@ -1892,9 +1891,6 @@ class GTEST_API_ ThreadLocal {
 // Returns the number of threads running in the process, or 0 to indicate that
 // we cannot detect it.
 GTEST_API_ size_t GetThreadCount();
-
-template <bool B>
-using bool_constant = std::integral_constant<bool, B>;
 
 #if GTEST_OS_WINDOWS
 # define GTEST_PATH_SEP_ "\\"


### PR DESCRIPTION
Because `bool_constant` is portable, it should not belong to *gtest-port.h*.