### PR TITLE
Remove BiggestInt

### DIFF
--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -133,7 +133,7 @@ GTEST_API_ void PrintBytesInObjectTo(const unsigned char* obj_bytes,
 // nor PrintTo().
 enum TypeKind {
   kProtobuf,              // a protobuf type
-  kConvertibleToInteger,  // a type implicitly convertible to BiggestInt
+  kConvertibleToInteger,  // a type implicitly convertible to std::intmax_t
                           // (e.g. a named or unnamed enum type)
 #if GTEST_HAS_ABSL
   kConvertibleToStringView,  // a type implicitly convertible to
@@ -179,14 +179,14 @@ template <typename T>
 class TypeWithoutFormatter<T, kConvertibleToInteger> {
  public:
   // Since T has no << operator or PrintTo() but can be implicitly
-  // converted to BiggestInt, we print it as a BiggestInt.
+  // converted to the maximum width integer, we print it as a std::intmax_t.
   //
   // Most likely T is an enum type (either named or unnamed), in which
-  // case printing it as an integer is the desired behavior.  In case
+  // case printing it as an integer is the desired behavior. In case
   // T is not an enum, printing it as an integer is the best we can do
   // given that it has no user-defined printer.
   static void PrintValue(const T& value, ::std::ostream* os) {
-    const internal::BiggestInt kBigInt = value;
+    const std::intmax_t kBigInt = value;
     *os << kBigInt;
   }
 };
@@ -204,10 +204,10 @@ class TypeWithoutFormatter<T, kConvertibleToStringView> {
 };
 #endif
 
-// Prints the given value to the given ostream.  If the value is a
+// Prints the given value to the given ostream. If the value is a
 // protocol message, its debug string is printed; if it's an enum or
-// of a type implicitly convertible to BiggestInt, it's printed as an
-// integer; otherwise the bytes in the value are printed.  This is
+// of a type implicitly convertible to std::intmax_t, it's printed as an
+// integer; otherwise the bytes in the value are printed. This is
 // what UniversalPrinter<T>::Print() does when it knows nothing about
 // type T and T has neither << operator nor PrintTo().
 //
@@ -234,7 +234,7 @@ template <typename Char, typename CharTraits, typename T>
   TypeWithoutFormatter<T, (internal::IsAProtocolMessage<T>::value
                                ? kProtobuf
                                : std::is_convertible<
-                                     const T&, internal::BiggestInt>::value
+                                     const T&, std::intmax_t>::value
                                      ? kConvertibleToInteger
                                      :
 #if GTEST_HAS_ABSL

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1530,13 +1530,12 @@ AssertionResult CmpHelperEQ(const char* lhs_expression,
   return CmpHelperEQFailure(lhs_expression, rhs_expression, lhs, rhs);
 }
 
-// With this overloaded version, we allow anonymous enums to be used
-// in {ASSERT|EXPECT}_EQ when compiled with gcc 4, as anonymous enums
-// can be implicitly cast to BiggestInt.
+// With this overloaded version, we allow anonymous enums to be used in
+// {ASSERT|EXPECT}_EQ as anonymous enums can be implicitly cast to integers.
 GTEST_API_ AssertionResult CmpHelperEQ(const char* lhs_expression,
                                        const char* rhs_expression,
-                                       BiggestInt lhs,
-                                       BiggestInt rhs);
+                                       std::intmax_t lhs,
+                                       std::intmax_t rhs);
 
 class EqHelper {
  public:
@@ -1553,16 +1552,15 @@ class EqHelper {
     return CmpHelperEQ(lhs_expression, rhs_expression, lhs, rhs);
   }
 
-  // With this overloaded version, we allow anonymous enums to be used
-  // in {ASSERT|EXPECT}_EQ when compiled with gcc 4, as anonymous
-  // enums can be implicitly cast to BiggestInt.
+  // With this overloaded version, we allow anonymous enums to be used in
+  // {ASSERT|EXPECT}_EQ as anonymous enums can be implicitly cast to integers.
   //
   // Even though its body looks the same as the above version, we
   // cannot merge the two, as it will make anonymous enums unhappy.
   static AssertionResult Compare(const char* lhs_expression,
                                  const char* rhs_expression,
-                                 BiggestInt lhs,
-                                 BiggestInt rhs) {
+                                 std::intmax_t lhs,
+                                 std::intmax_t rhs) {
     return CmpHelperEQ(lhs_expression, rhs_expression, lhs, rhs);
   }
 
@@ -1595,9 +1593,8 @@ AssertionResult CmpHelperOpFailure(const char* expr1, const char* expr2,
 // of similar code.
 //
 // For each templatized helper function, we also define an overloaded
-// version for BiggestInt in order to reduce code bloat and allow
-// anonymous enums to be used with {ASSERT|EXPECT}_?? when compiled
-// with gcc 4.
+// version for std::intmax_t in order to reduce code bloat and allow
+// anonymous enums to be used with {ASSERT|EXPECT}_??.
 //
 // INTERNAL IMPLEMENTATION - DO NOT USE IN A USER PROGRAM.
 
@@ -1612,7 +1609,7 @@ AssertionResult CmpHelper##op_name(const char* expr1, const char* expr2, \
   }\
 }\
 GTEST_API_ AssertionResult CmpHelper##op_name(\
-    const char* expr1, const char* expr2, BiggestInt val1, BiggestInt val2)
+    const char* expr1, const char* expr2, std::intmax_t val1, std::intmax_t val2)
 
 // INTERNAL IMPLEMENTATION - DO NOT USE IN A USER PROGRAM.
 

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -225,7 +225,6 @@
 //   TypeWithSize   - maps an integer to a int type.
 //   Int32, UInt32, Int64, UInt64, TimeInMillis
 //                  - integers of known sizes.
-//   BiggestInt     - the biggest signed integer type.
 //
 // Command-line utilities:
 //   GTEST_DECLARE_*()  - declares a flag.
@@ -1899,12 +1898,9 @@ using bool_constant = std::integral_constant<bool, B>;
 #if GTEST_OS_WINDOWS
 # define GTEST_PATH_SEP_ "\\"
 # define GTEST_HAS_ALT_PATH_SEP_ 1
-// The biggest signed integer type the compiler supports.
-typedef __int64 BiggestInt;
 #else
 # define GTEST_PATH_SEP_ "/"
 # define GTEST_HAS_ALT_PATH_SEP_ 0
-typedef long long BiggestInt;  // NOLINT
 #endif  // GTEST_OS_WINDOWS
 
 // Utilities for char.
@@ -2093,16 +2089,6 @@ GTEST_DISABLE_MSC_DEPRECATED_POP_()
 #else
 # define GTEST_SNPRINTF_ snprintf
 #endif
-
-// The maximum number a BiggestInt can represent.  This definition
-// works no matter BiggestInt is represented in one's complement or
-// two's complement.
-//
-// We cannot rely on numeric_limits in STL, as __int64 and long long
-// are not part of standard C++ and numeric_limits doesn't need to be
-// defined for them.
-const BiggestInt kMaxBiggestInt =
-    ~(static_cast<BiggestInt>(1) << (8*sizeof(BiggestInt) - 1));
 
 // This template class serves as a compile-time function from size to
 // type.  It maps a size in bytes to a primitive type with that

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -1449,8 +1449,8 @@ namespace internal {
 // arguments.
 AssertionResult CmpHelperEQ(const char* lhs_expression,
                             const char* rhs_expression,
-                            BiggestInt lhs,
-                            BiggestInt rhs) {
+                            std::intmax_t lhs,
+                            std::intmax_t rhs) {
   if (lhs == rhs) {
     return AssertionSuccess();
   }
@@ -1463,11 +1463,11 @@ AssertionResult CmpHelperEQ(const char* lhs_expression,
 }
 
 // A macro for implementing the helper functions needed to implement
-// ASSERT_?? and EXPECT_?? with integer or enum arguments.  It is here
+// ASSERT_?? and EXPECT_?? with integer or enum arguments. It is here
 // just to avoid copy-and-paste of similar code.
 #define GTEST_IMPL_CMP_HELPER_(op_name, op)\
 AssertionResult CmpHelper##op_name(const char* expr1, const char* expr2, \
-                                   BiggestInt val1, BiggestInt val2) {\
+                                   std::intmax_t val1, std::intmax_t val2) {\
   if (val1 op val2) {\
     return AssertionSuccess();\
   } else {\

--- a/googletest/test/googletest-printers-test.cc
+++ b/googletest/test/googletest-printers-test.cc
@@ -83,10 +83,10 @@ void PrintTo(EnumWithPrintTo e, std::ostream* os) {
   *os << (e == kEWPT1 ? "kEWPT1" : "invalid");
 }
 
-// A class implicitly convertible to BiggestInt.
-class BiggestIntConvertible {
+// A class implicitly convertible to std::intmax_t.
+class IntMaxConvertible {
  public:
-  operator ::testing::internal::BiggestInt() const { return 42; }
+  constexpr operator std::intmax_t() const { return 42; }
 };
 
 // A user-defined unprintable class template in the global namespace.
@@ -268,10 +268,10 @@ TEST(PrintEnumTest, EnumWithPrintTo) {
   EXPECT_EQ("invalid", Print(static_cast<EnumWithPrintTo>(0)));
 }
 
-// Tests printing a class implicitly convertible to BiggestInt.
+// Tests printing a class implicitly convertible to std::intmax_t.
 
-TEST(PrintClassTest, BiggestIntConvertible) {
-  EXPECT_EQ("42", Print(BiggestIntConvertible()));
+TEST(PrintClassTest, IntMaxConvertible) {
+  EXPECT_EQ("42", Print(IntMaxConvertible()));
 }
 
 // Tests printing various char types.
@@ -528,7 +528,7 @@ TEST(PrintPointerTest, NonMemberFunctionPointer) {
   // this limitation.
   EXPECT_EQ(
       PrintPointer(reinterpret_cast<const void*>(
-          reinterpret_cast<internal::BiggestInt>(&MyFunction))),
+          reinterpret_cast<std::intptr_t>(&MyFunction))),
       Print(&MyFunction));
   int (*p)(bool) = NULL;  // NOLINT
   EXPECT_EQ("NULL", Print(p));
@@ -1122,7 +1122,7 @@ TEST(PrintReferenceTest, HandlesFunctionPointer) {
   // pointers to objects, and some compilers (e.g. GCC 3.4) enforce
   // this limitation.
   const std::string fp_string = PrintPointer(reinterpret_cast<const void*>(
-      reinterpret_cast<internal::BiggestInt>(fp)));
+      reinterpret_cast<std::intptr_t>(fp)));
   EXPECT_EQ("@" + fp_pointer_string + " " + fp_string,
             PrintByRef(fp));
 }

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -55,11 +55,11 @@ TEST(CommandLineFlagsTest, CanBeAccessedInCodeOnceGTestHIsIncluded) {
   EXPECT_TRUE(dummy || !dummy);  // Suppresses warning that dummy is unused.
 }
 
-#include <limits.h>  // For INT_MAX.
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
 
+#include <limits>
 #include <map>
 #include <ostream>
 #include <type_traits>
@@ -3953,11 +3953,11 @@ enum {
   // On Linux, kCaseB and kCaseA have the same value when truncated to
   // int size.  We want to test whether this will confuse the
   // assertions.
-  kCaseB = testing::internal::kMaxBiggestInt,
+  kCaseB = std::numeric_limits<std::intmax_t>::max(),
 
 # else
 
-  kCaseB = INT_MAX,
+  kCaseB = std::numeric_limits<int>::max(),
 
 # endif  // GTEST_OS_LINUX
 


### PR DESCRIPTION
Resolves #2451.

Additionally I've moved it to gtest-internal.h because it requires no porting to specific platforms (long long int is a part of C++11).