### PR TITLE
Remove GTEST_HAS_STD_STRING

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -439,15 +439,6 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 # endif  // defined(_MSC_VER) || defined(__BORLANDC__)
 #endif  // GTEST_HAS_EXCEPTIONS
 
-#if !defined(GTEST_HAS_STD_STRING)
-// Even though we don't use this macro any longer, we keep it in case
-// some clients still depend on it.
-# define GTEST_HAS_STD_STRING 1
-#elif !GTEST_HAS_STD_STRING
-// The user told us that ::std::string isn't available.
-# error "::std::string isn't available."
-#endif  // !defined(GTEST_HAS_STD_STRING)
-
 #ifndef GTEST_HAS_STD_WSTRING
 // The user didn't tell us whether ::std::wstring is available, so we need
 // to figure it out.


### PR DESCRIPTION
1st commit removes GTEST_HAS_STD_STRING. I think we can drop it, after all it's 2019 :)
2nd commit simply removes usings from the header, which is how all guidelines say

Both changes are backward incompatible. I would merge them though because README.md says the following about [post 1.8.x releases](https://github.com/google/googletest#post-18x):
> On-going work to improve/cleanup/pay technical debt

and we don't quite need it, right?