### PR TITLE
Add more override keywords

### DIFF
--- a/googlemock/include/gmock/gmock-generated-actions.h
+++ b/googlemock/include/gmock/gmock-generated-actions.h
@@ -663,7 +663,7 @@ class ActionHelper {
       typedef typename ::testing::internal::Function<F>::ArgumentTuple\
           args_type;\
       explicit gmock_Impl GMOCK_INTERNAL_INIT_##value_params {}\
-      virtual return_type Perform(const args_type& args) {\
+      return_type Perform(const args_type& args) override {\
         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
             Perform(this, args);\
       }\
@@ -726,7 +726,7 @@ class ActionHelper {
       typedef typename ::testing::internal::Function<F>::ArgumentTuple\
           args_type;\
       gmock_Impl() {}\
-      virtual return_type Perform(const args_type& args) {\
+      return_type Perform(const args_type& args) override {\
         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
             Perform(this, args);\
       }\
@@ -776,7 +776,7 @@ class ActionHelper {
           args_type;\
       explicit gmock_Impl(p0##_type gmock_p0) : \
           p0(::std::forward<p0##_type>(gmock_p0)) {}\
-      virtual return_type Perform(const args_type& args) {\
+      return_type Perform(const args_type& args) override {\
         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
             Perform(this, args);\
       }\
@@ -832,7 +832,7 @@ class ActionHelper {
       gmock_Impl(p0##_type gmock_p0, \
           p1##_type gmock_p1) : p0(::std::forward<p0##_type>(gmock_p0)), \
           p1(::std::forward<p1##_type>(gmock_p1)) {}\
-      virtual return_type Perform(const args_type& args) {\
+      return_type Perform(const args_type& args) override {\
         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
             Perform(this, args);\
       }\
@@ -893,7 +893,7 @@ class ActionHelper {
           p2##_type gmock_p2) : p0(::std::forward<p0##_type>(gmock_p0)), \
           p1(::std::forward<p1##_type>(gmock_p1)), \
           p2(::std::forward<p2##_type>(gmock_p2)) {}\
-      virtual return_type Perform(const args_type& args) {\
+      return_type Perform(const args_type& args) override {\
         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
             Perform(this, args);\
       }\
@@ -961,7 +961,7 @@ class ActionHelper {
           p1(::std::forward<p1##_type>(gmock_p1)), \
           p2(::std::forward<p2##_type>(gmock_p2)), \
           p3(::std::forward<p3##_type>(gmock_p3)) {}\
-      virtual return_type Perform(const args_type& args) {\
+      return_type Perform(const args_type& args) override {\
         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
             Perform(this, args);\
       }\
@@ -1038,7 +1038,7 @@ class ActionHelper {
           p2(::std::forward<p2##_type>(gmock_p2)), \
           p3(::std::forward<p3##_type>(gmock_p3)), \
           p4(::std::forward<p4##_type>(gmock_p4)) {}\
-      virtual return_type Perform(const args_type& args) {\
+      return_type Perform(const args_type& args) override {\
         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
             Perform(this, args);\
       }\
@@ -1119,7 +1119,7 @@ class ActionHelper {
           p3(::std::forward<p3##_type>(gmock_p3)), \
           p4(::std::forward<p4##_type>(gmock_p4)), \
           p5(::std::forward<p5##_type>(gmock_p5)) {}\
-      virtual return_type Perform(const args_type& args) {\
+      return_type Perform(const args_type& args) override {\
         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
             Perform(this, args);\
       }\
@@ -1206,7 +1206,7 @@ class ActionHelper {
           p4(::std::forward<p4##_type>(gmock_p4)), \
           p5(::std::forward<p5##_type>(gmock_p5)), \
           p6(::std::forward<p6##_type>(gmock_p6)) {}\
-      virtual return_type Perform(const args_type& args) {\
+      return_type Perform(const args_type& args) override {\
         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
             Perform(this, args);\
       }\
@@ -1302,7 +1302,7 @@ class ActionHelper {
           p5(::std::forward<p5##_type>(gmock_p5)), \
           p6(::std::forward<p6##_type>(gmock_p6)), \
           p7(::std::forward<p7##_type>(gmock_p7)) {}\
-      virtual return_type Perform(const args_type& args) {\
+      return_type Perform(const args_type& args) override {\
         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
             Perform(this, args);\
       }\
@@ -1404,7 +1404,7 @@ class ActionHelper {
           p6(::std::forward<p6##_type>(gmock_p6)), \
           p7(::std::forward<p7##_type>(gmock_p7)), \
           p8(::std::forward<p8##_type>(gmock_p8)) {}\
-      virtual return_type Perform(const args_type& args) {\
+      return_type Perform(const args_type& args) override {\
         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
             Perform(this, args);\
       }\
@@ -1513,7 +1513,7 @@ class ActionHelper {
           p7(::std::forward<p7##_type>(gmock_p7)), \
           p8(::std::forward<p8##_type>(gmock_p8)), \
           p9(::std::forward<p9##_type>(gmock_p9)) {}\
-      virtual return_type Perform(const args_type& args) {\
+      return_type Perform(const args_type& args) override {\
         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
             Perform(this, args);\
       }\

--- a/googlemock/include/gmock/gmock-generated-actions.h.pump
+++ b/googlemock/include/gmock/gmock-generated-actions.h.pump
@@ -395,7 +395,7 @@ $range k 0..n-1
       typedef typename ::testing::internal::Function<F>::ArgumentTuple\
           args_type;\
       explicit gmock_Impl GMOCK_INTERNAL_INIT_##value_params {}\
-      virtual return_type Perform(const args_type& args) {\
+      return_type Perform(const args_type& args) override {\
         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
             Perform(this, args);\
       }\
@@ -482,7 +482,7 @@ $var macro_name = [[$if i==0 [[ACTION]] $elif i==1 [[ACTION_P]]
       typedef typename ::testing::internal::Function<F>::ArgumentTuple\
           args_type;\
       [[$if i==1 [[explicit ]]]]gmock_Impl($ctor_param_list)$inits {}\
-      virtual return_type Perform(const args_type& args) {\
+      return_type Perform(const args_type& args) override {\
         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
             Perform(this, args);\
       }\

--- a/googlemock/include/gmock/gmock-generated-matchers.h
+++ b/googlemock/include/gmock/gmock-generated-matchers.h
@@ -269,13 +269,13 @@
      public:\
       gmock_Impl()\
            {}\
-      virtual bool MatchAndExplain(\
+      bool MatchAndExplain(\
           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
-          ::testing::MatchResultListener* result_listener) const;\
-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
+          ::testing::MatchResultListener* result_listener) const override;\
+      void DescribeTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(false);\
       }\
-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
+      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(true);\
       }\
      private:\
@@ -318,13 +318,13 @@
      public:\
       explicit gmock_Impl(p0##_type gmock_p0)\
            : p0(::std::move(gmock_p0)) {}\
-      virtual bool MatchAndExplain(\
+      bool MatchAndExplain(\
           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
-          ::testing::MatchResultListener* result_listener) const;\
-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
+          ::testing::MatchResultListener* result_listener) const override;\
+      void DescribeTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(false);\
       }\
-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
+      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(true);\
       }\
       p0##_type const p0;\
@@ -371,13 +371,13 @@
      public:\
       gmock_Impl(p0##_type gmock_p0, p1##_type gmock_p1)\
            : p0(::std::move(gmock_p0)), p1(::std::move(gmock_p1)) {}\
-      virtual bool MatchAndExplain(\
+      bool MatchAndExplain(\
           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
-          ::testing::MatchResultListener* result_listener) const;\
-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
+          ::testing::MatchResultListener* result_listener) const override;\
+      void DescribeTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(false);\
       }\
-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
+      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(true);\
       }\
       p0##_type const p0;\
@@ -431,13 +431,13 @@
       gmock_Impl(p0##_type gmock_p0, p1##_type gmock_p1, p2##_type gmock_p2)\
            : p0(::std::move(gmock_p0)), p1(::std::move(gmock_p1)), \
                p2(::std::move(gmock_p2)) {}\
-      virtual bool MatchAndExplain(\
+      bool MatchAndExplain(\
           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
-          ::testing::MatchResultListener* result_listener) const;\
-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
+          ::testing::MatchResultListener* result_listener) const override;\
+      void DescribeTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(false);\
       }\
-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
+      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(true);\
       }\
       p0##_type const p0;\
@@ -495,13 +495,13 @@
           p3##_type gmock_p3)\
            : p0(::std::move(gmock_p0)), p1(::std::move(gmock_p1)), \
                p2(::std::move(gmock_p2)), p3(::std::move(gmock_p3)) {}\
-      virtual bool MatchAndExplain(\
+      bool MatchAndExplain(\
           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
-          ::testing::MatchResultListener* result_listener) const;\
-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
+          ::testing::MatchResultListener* result_listener) const override;\
+      void DescribeTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(false);\
       }\
-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
+      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(true);\
       }\
       p0##_type const p0;\
@@ -568,13 +568,13 @@
            : p0(::std::move(gmock_p0)), p1(::std::move(gmock_p1)), \
                p2(::std::move(gmock_p2)), p3(::std::move(gmock_p3)), \
                p4(::std::move(gmock_p4)) {}\
-      virtual bool MatchAndExplain(\
+      bool MatchAndExplain(\
           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
-          ::testing::MatchResultListener* result_listener) const;\
-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
+          ::testing::MatchResultListener* result_listener) const override;\
+      void DescribeTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(false);\
       }\
-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
+      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(true);\
       }\
       p0##_type const p0;\
@@ -644,13 +644,13 @@
            : p0(::std::move(gmock_p0)), p1(::std::move(gmock_p1)), \
                p2(::std::move(gmock_p2)), p3(::std::move(gmock_p3)), \
                p4(::std::move(gmock_p4)), p5(::std::move(gmock_p5)) {}\
-      virtual bool MatchAndExplain(\
+      bool MatchAndExplain(\
           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
-          ::testing::MatchResultListener* result_listener) const;\
-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
+          ::testing::MatchResultListener* result_listener) const override;\
+      void DescribeTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(false);\
       }\
-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
+      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(true);\
       }\
       p0##_type const p0;\
@@ -726,13 +726,13 @@
                p2(::std::move(gmock_p2)), p3(::std::move(gmock_p3)), \
                p4(::std::move(gmock_p4)), p5(::std::move(gmock_p5)), \
                p6(::std::move(gmock_p6)) {}\
-      virtual bool MatchAndExplain(\
+      bool MatchAndExplain(\
           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
-          ::testing::MatchResultListener* result_listener) const;\
-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
+          ::testing::MatchResultListener* result_listener) const override;\
+      void DescribeTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(false);\
       }\
-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
+      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(true);\
       }\
       p0##_type const p0;\
@@ -814,13 +814,13 @@
                p2(::std::move(gmock_p2)), p3(::std::move(gmock_p3)), \
                p4(::std::move(gmock_p4)), p5(::std::move(gmock_p5)), \
                p6(::std::move(gmock_p6)), p7(::std::move(gmock_p7)) {}\
-      virtual bool MatchAndExplain(\
+      bool MatchAndExplain(\
           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
-          ::testing::MatchResultListener* result_listener) const;\
-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
+          ::testing::MatchResultListener* result_listener) const override;\
+      void DescribeTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(false);\
       }\
-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
+      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(true);\
       }\
       p0##_type const p0;\
@@ -909,13 +909,13 @@
                p4(::std::move(gmock_p4)), p5(::std::move(gmock_p5)), \
                p6(::std::move(gmock_p6)), p7(::std::move(gmock_p7)), \
                p8(::std::move(gmock_p8)) {}\
-      virtual bool MatchAndExplain(\
+      bool MatchAndExplain(\
           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
-          ::testing::MatchResultListener* result_listener) const;\
-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
+          ::testing::MatchResultListener* result_listener) const override;\
+      void DescribeTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(false);\
       }\
-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
+      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(true);\
       }\
       p0##_type const p0;\
@@ -1009,13 +1009,13 @@
                p4(::std::move(gmock_p4)), p5(::std::move(gmock_p5)), \
                p6(::std::move(gmock_p6)), p7(::std::move(gmock_p7)), \
                p8(::std::move(gmock_p8)), p9(::std::move(gmock_p9)) {}\
-      virtual bool MatchAndExplain(\
+      bool MatchAndExplain(\
           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
-          ::testing::MatchResultListener* result_listener) const;\
-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
+          ::testing::MatchResultListener* result_listener) const override;\
+      void DescribeTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(false);\
       }\
-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
+      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(true);\
       }\
       p0##_type const p0;\

--- a/googlemock/include/gmock/gmock-generated-matchers.h.pump
+++ b/googlemock/include/gmock/gmock-generated-matchers.h.pump
@@ -302,13 +302,13 @@ $var param_field_decls2 = [[$for j
      public:\
       [[$if i==1 [[explicit ]]]]gmock_Impl($impl_ctor_param_list)\
           $impl_inits {}\
-      virtual bool MatchAndExplain(\
+      bool MatchAndExplain(\
           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
-          ::testing::MatchResultListener* result_listener) const;\
-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
+          ::testing::MatchResultListener* result_listener) const override;\
+      void DescribeTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(false);\
       }\
-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
+      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
         *gmock_os << FormatDescription(true);\
       }\$param_field_decls
      private:\

--- a/googletest/include/gtest/gtest-typed-test.h
+++ b/googletest/include/gtest/gtest-typed-test.h
@@ -201,7 +201,7 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
    private:                                                                   \
     typedef CaseName<gtest_TypeParam_> TestFixture;                           \
     typedef gtest_TypeParam_ TypeParam;                                       \
-    virtual void TestBody();                                                  \
+    void TestBody() override;                                                 \
   };                                                                          \
   static bool gtest_##CaseName##_##TestName##_registered_                     \
         GTEST_ATTRIBUTE_UNUSED_ =                                             \
@@ -276,7 +276,7 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
      private:                                                         \
       typedef SuiteName<gtest_TypeParam_> TestFixture;                \
       typedef gtest_TypeParam_ TypeParam;                             \
-      virtual void TestBody();                                        \
+      void TestBody() override;                                       \
     };                                                                \
     static bool gtest_##TestName##_defined_ GTEST_ATTRIBUTE_UNUSED_ = \
         GTEST_TYPED_TEST_SUITE_P_STATE_(SuiteName).AddTestName(       \

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -1590,7 +1590,7 @@ class ThreadLocal : public ThreadLocalBase {
   class DefaultValueHolderFactory : public ValueHolderFactory {
    public:
     DefaultValueHolderFactory() {}
-    virtual ValueHolder* MakeNewHolder() const { return new ValueHolder(); }
+    ValueHolder* MakeNewHolder() const override { return new ValueHolder(); }
 
    private:
     GTEST_DISALLOW_COPY_AND_ASSIGN_(DefaultValueHolderFactory);
@@ -1599,7 +1599,7 @@ class ThreadLocal : public ThreadLocalBase {
   class InstanceValueHolderFactory : public ValueHolderFactory {
    public:
     explicit InstanceValueHolderFactory(const T& value) : value_(value) {}
-    virtual ValueHolder* MakeNewHolder() const {
+    ValueHolder* MakeNewHolder() const override {
       return new ValueHolder(value_);
     }
 

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -6170,7 +6170,7 @@ TEST_F(ParseFlagsTest, WideStrings) {
 #if GTEST_USE_OWN_FLAGFILE_FLAG_
 class FlagfileTest : public ParseFlagsTest {
  public:
-  virtual void SetUp() {
+  void SetUp() override {
     ParseFlagsTest::SetUp();
 
     testdata_path_.Set(internal::FilePath(
@@ -6180,7 +6180,7 @@ class FlagfileTest : public ParseFlagsTest {
     EXPECT_TRUE(testdata_path_.CreateFolder());
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     testing::internal::posix::RmDir(testdata_path_.c_str());
     ParseFlagsTest::TearDown();
   }


### PR DESCRIPTION
Mark more functions with "override" keyword, just like
it was done in commit 2460f97152c.

This should prevent compiler from complaining while compiling both
user code, and the googletest code itself with the -Wsuggest-override
option turned on; with the exception of:
 * calls to new MOCK_METHOD() in test/gmock-function-mocker_test.cc
 * calls to old MOCK_METHODx()/MOCK_CONST_METHODx() in other
   unit test files.

Closes #2493