### PR TITLE
Fix to Check, at compile time, that ReturnRef action is not operating on

### DIFF
--- a/googlemock/include/gmock/gmock-actions.h
+++ b/googlemock/include/gmock/gmock-actions.h
@@ -1022,6 +1022,10 @@ inline internal::ReturnRefAction<R> ReturnRef(R& x) {  // NOLINT
   return internal::ReturnRefAction<R>(x);
 }
 
+// Prevent creates an action that returns the reference to a variable to operate on temporaries
+template <typename R>
+internal::ReturnRefAction<R> ReturnRef(R&& x) = delete;
+
 // Creates an action that returns the reference to a copy of the
 // argument.  The copy is created when the action is constructed and
 // lives as long as the action.


### PR DESCRIPTION
temporaries #2471

Added deleted overload to ::testing::ReturnRef that prevents this
funtion from operating on temporaries (T&&)