### PR TITLE
Added googletest/generated/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ googlemock/gtest
 /CMakeCache.txt
 /ALL_BUILD.vcxproj.filters
 /ALL_BUILD.vcxproj
+
+googletest/generated/


### PR DESCRIPTION
We don't want git submodules to googletest as changed the project is built.