### PR TITLE
TYPED_TEST_SUITE - outdated documentation

### DIFF
--- a/googletest/docs/advanced.md
+++ b/googletest/docs/advanced.md
@@ -1531,10 +1531,10 @@ each type in the list:
 
 ```c++
 using MyTypes = ::testing::Types<char, int, unsigned int>;
-TYPED_TEST_SUITE(FooTest, MyTypes);
+TYPED_TEST_CASE(FooTest, MyTypes);
 ```
 
-The type alias (`using` or `typedef`) is necessary for the `TYPED_TEST_SUITE`
+The type alias (`using` or `typedef`) is necessary for the `TYPED_TEST_CASE`
 macro to parse correctly. Otherwise the compiler will think that each comma in
 the type list introduces a new macro argument.
 


### PR DESCRIPTION
The sample6_unittest.cc differs from the documentation here. The documentation has 'TYPED_TEST_SUITE' (which fails to build in my own projects) where the sample unit test has 'TYPED_TEST_CASE' (and this builds and runs fine for me).

I'm not sure if this is a legacy thing or not but I always forget this every time I come to the documentation, and then wonder why unit test doesn't compile.