### PR TITLE
Remove inclusion of deprecated C++ headers

### DIFF
--- a/googlemock/include/gmock/gmock-actions.h
+++ b/googlemock/include/gmock/gmock-actions.h
@@ -38,7 +38,7 @@
 #define GMOCK_INCLUDE_GMOCK_GMOCK_ACTIONS_H_
 
 #ifndef _WIN32_WCE
-# include <errno.h>
+# include <cerrno>
 #endif
 
 #include <algorithm>

--- a/googlemock/include/gmock/gmock-cardinalities.h
+++ b/googlemock/include/gmock/gmock-cardinalities.h
@@ -39,7 +39,7 @@
 #ifndef GMOCK_INCLUDE_GMOCK_GMOCK_CARDINALITIES_H_
 #define GMOCK_INCLUDE_GMOCK_GMOCK_CARDINALITIES_H_
 
-#include <limits.h>
+#include <climits>
 #include <memory>
 #include <ostream>  // NOLINT
 #include "gmock/internal/gmock-port.h"

--- a/googlemock/include/gmock/internal/gmock-internal-utils.h
+++ b/googlemock/include/gmock/internal/gmock-internal-utils.h
@@ -39,7 +39,7 @@
 #ifndef GMOCK_INCLUDE_GMOCK_INTERNAL_GMOCK_INTERNAL_UTILS_H_
 #define GMOCK_INCLUDE_GMOCK_INTERNAL_GMOCK_INTERNAL_UTILS_H_
 
-#include <stdio.h>
+#include <cstdio>
 #include <ostream>  // NOLINT
 #include <string>
 #include <type_traits>

--- a/googlemock/include/gmock/internal/gmock-port.h
+++ b/googlemock/include/gmock/internal/gmock-port.h
@@ -40,8 +40,8 @@
 #ifndef GMOCK_INCLUDE_GMOCK_INTERNAL_GMOCK_PORT_H_
 #define GMOCK_INCLUDE_GMOCK_INTERNAL_GMOCK_PORT_H_
 
-#include <assert.h>
-#include <stdlib.h>
+#include <cassert>
+#include <cstdlib>
 #include <iostream>
 
 // Most of the utilities needed for porting Google Mock are also

--- a/googlemock/src/gmock-cardinalities.cc
+++ b/googlemock/src/gmock-cardinalities.cc
@@ -34,9 +34,8 @@
 
 #include "gmock/gmock-cardinalities.h"
 
-#include <limits.h>
+#include <climits>
 #include <ostream>  // NOLINT
-#include <sstream>
 #include <string>
 #include "gmock/internal/gmock-internal-utils.h"
 #include "gtest/gtest.h"

--- a/googlemock/src/gmock-internal-utils.cc
+++ b/googlemock/src/gmock-internal-utils.cc
@@ -36,7 +36,6 @@
 
 #include "gmock/internal/gmock-internal-utils.h"
 
-#include <ctype.h>
 #include <ostream>  // NOLINT
 #include <string>
 #include "gmock/gmock.h"

--- a/googlemock/src/gmock-matchers.cc
+++ b/googlemock/src/gmock-matchers.cc
@@ -36,9 +36,7 @@
 #include "gmock/gmock-matchers.h"
 #include "gmock/gmock-generated-matchers.h"
 
-#include <string.h>
 #include <iostream>
-#include <sstream>
 #include <string>
 
 namespace testing {

--- a/googlemock/src/gmock-spec-builders.cc
+++ b/googlemock/src/gmock-spec-builders.cc
@@ -35,8 +35,6 @@
 
 #include "gmock/gmock-spec-builders.h"
 
-#include <stdlib.h>
-
 #include <iostream>  // NOLINT
 #include <map>
 #include <memory>

--- a/googlemock/test/gmock-actions_test.cc
+++ b/googlemock/test/gmock-actions_test.cc
@@ -42,7 +42,6 @@
 #endif
 
 #include "gmock/gmock-actions.h"
-#include <algorithm>
 #include <iterator>
 #include <memory>
 #include <string>

--- a/googlemock/test/gmock-function-mocker_test.cc
+++ b/googlemock/test/gmock-function-mocker_test.cc
@@ -41,7 +41,6 @@
 #endif  // GTEST_OS_WINDOWS
 
 #include <map>
-#include <string>
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/googlemock/test/gmock-generated-function-mockers_test.cc
+++ b/googlemock/test/gmock-generated-function-mockers_test.cc
@@ -42,7 +42,6 @@
 #endif  // GTEST_OS_WINDOWS
 
 #include <map>
-#include <string>
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/googlemock/test/gmock-internal-utils_test.cc
+++ b/googlemock/test/gmock-internal-utils_test.cc
@@ -34,7 +34,7 @@
 
 #include "gmock/internal/gmock-internal-utils.h"
 
-#include <stdlib.h>
+#include <cstdlib>
 
 #include <map>
 #include <memory>

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -42,21 +42,19 @@
 
 #include "gmock/gmock-matchers.h"
 
-#include <string.h>
-#include <time.h>
+#include <cstring>
+#include <ctime>
 
 #include <array>
 #include <deque>
 #include <forward_list>
 #include <functional>
 #include <iostream>
-#include <iterator>
 #include <limits>
 #include <list>
 #include <map>
 #include <memory>
 #include <set>
-#include <sstream>
 #include <string>
 #include <type_traits>
 #include <utility>

--- a/googlemock/test/gmock-more-actions_test.cc
+++ b/googlemock/test/gmock-more-actions_test.cc
@@ -36,7 +36,6 @@
 
 #include <functional>
 #include <memory>
-#include <sstream>
 #include <string>
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/googlemock/test/gmock_link_test.h
+++ b/googlemock/test/gmock_link_test.h
@@ -118,7 +118,7 @@
 #include "gmock/gmock.h"
 
 #if !GTEST_OS_WINDOWS_MOBILE
-# include <errno.h>
+# include <cerrno>
 #endif
 
 #include <iostream>

--- a/googlemock/test/gmock_output_test_.cc
+++ b/googlemock/test/gmock_output_test_.cc
@@ -33,7 +33,6 @@
 
 #include "gmock/gmock.h"
 
-#include <stdio.h>
 #include <string>
 
 #include "gtest/gtest.h"

--- a/googletest/include/gtest/internal/gtest-death-test-internal.h
+++ b/googletest/include/gtest/internal/gtest-death-test-internal.h
@@ -39,7 +39,7 @@
 #include "gtest/gtest-matchers.h"
 #include "gtest/internal/gtest-internal.h"
 
-#include <stdio.h>
+#include <cstdio>
 #include <memory>
 
 namespace testing {

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -40,7 +40,7 @@
 #include "gtest/internal/gtest-port.h"
 
 #if GTEST_OS_LINUX
-# include <stdlib.h>
+# include <cstdlib>
 # include <sys/types.h>
 # include <sys/wait.h>
 # include <unistd.h>
@@ -50,9 +50,9 @@
 # include <stdexcept>
 #endif
 
-#include <ctype.h>
-#include <float.h>
-#include <string.h>
+#include <cctype>
+#include <cfloat>
+#include <cstring>
 #include <iomanip>
 #include <limits>
 #include <map>

--- a/googletest/include/gtest/internal/gtest-param-util.h
+++ b/googletest/include/gtest/internal/gtest-param-util.h
@@ -35,7 +35,7 @@
 #ifndef GTEST_INCLUDE_GTEST_INTERNAL_GTEST_PARAM_UTIL_H_
 #define GTEST_INCLUDE_GTEST_INTERNAL_GTEST_PARAM_UTIL_H_
 
-#include <ctype.h>
+#include <cctype>
 
 #include <cassert>
 #include <iterator>

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -243,11 +243,11 @@
 //                                        deprecated; calling a marked function
 //                                        should generate a compiler warning
 
-#include <ctype.h>   // for isspace, etc
-#include <stddef.h>  // for ptrdiff_t
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cctype>   // for isspace, etc
+#include <cstddef>  // for ptrdiff_t
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <type_traits>
 
 #ifndef _WIN32_WCE

--- a/googletest/include/gtest/internal/gtest-string.h
+++ b/googletest/include/gtest/internal/gtest-string.h
@@ -46,7 +46,7 @@
 # include <mem.h>
 #endif
 
-#include <string.h>
+#include <cstring>
 #include <string>
 
 #include "gtest/internal/gtest-port.h"

--- a/googletest/src/gtest-death-test.cc
+++ b/googletest/src/gtest-death-test.cc
@@ -43,15 +43,8 @@
 #  include <crt_externs.h>
 # endif  // GTEST_OS_MAC
 
-# include <errno.h>
+# include <cerrno>
 # include <fcntl.h>
-# include <limits.h>
-
-# if GTEST_OS_LINUX
-#  include <signal.h>
-# endif  // GTEST_OS_LINUX
-
-# include <stdarg.h>
 
 # if GTEST_OS_WINDOWS
 #  include <windows.h>

--- a/googletest/src/gtest-filepath.cc
+++ b/googletest/src/gtest-filepath.cc
@@ -29,7 +29,7 @@
 
 #include "gtest/internal/gtest-filepath.h"
 
-#include <stdlib.h>
+#include <cstdlib>
 #include "gtest/internal/gtest-port.h"
 #include "gtest/gtest-message.h"
 
@@ -39,8 +39,7 @@
 # include <direct.h>
 # include <io.h>
 #else
-# include <limits.h>
-# include <climits>  // Some Linux distributions define PATH_MAX here.
+# include <climits>
 #endif  // GTEST_OS_WINDOWS_MOBILE
 
 #include "gtest/internal/gtest-string.h"

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -35,11 +35,11 @@
 #define GTEST_SRC_GTEST_INTERNAL_INL_H_
 
 #ifndef _WIN32_WCE
-# include <errno.h>
+# include <cerrno>
 #endif  // !_WIN32_WCE
-#include <stddef.h>
-#include <stdlib.h>  // For strtoll/_strtoul64/malloc/free.
-#include <string.h>  // For memmove.
+#include <cstddef>
+#include <cstdlib>  // For strtoll/_strtoul64/malloc/free.
+#include <cstring>  // For memmove.
 
 #include <algorithm>
 #include <memory>

--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -30,10 +30,10 @@
 
 #include "gtest/internal/gtest-port.h"
 
-#include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <memory>
 

--- a/googletest/src/gtest-printers.cc
+++ b/googletest/src/gtest-printers.cc
@@ -42,7 +42,6 @@
 // defines Foo.
 
 #include "gtest/gtest-printers.h"
-#include <stdio.h>
 #include <cctype>
 #include <cwchar>
 #include <ostream>  // NOLINT

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -34,14 +34,10 @@
 #include "gtest/internal/custom/gtest.h"
 #include "gtest/gtest-spi.h"
 
-#include <ctype.h>
-#include <math.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <time.h>
-#include <wchar.h>
-#include <wctype.h>
+#include <cmath>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
 
 #include <algorithm>
 #include <iomanip>
@@ -49,7 +45,6 @@
 #include <list>
 #include <map>
 #include <ostream>  // NOLINT
-#include <sstream>
 #include <vector>
 
 #if GTEST_OS_LINUX

--- a/googletest/test/googletest-catch-exceptions-test_.cc
+++ b/googletest/test/googletest-catch-exceptions-test_.cc
@@ -32,8 +32,8 @@
 // exceptions, and the output is verified by
 // googletest-catch-exceptions-test.py.
 
-#include <stdio.h>  // NOLINT
-#include <stdlib.h>  // For exit().
+#include <cstdlib>  // For exit().
+#include <cstdio>  // NOLINT
 
 #include "gtest/gtest.h"
 

--- a/googletest/test/googletest-color-test_.cc
+++ b/googletest/test/googletest-color-test_.cc
@@ -32,7 +32,7 @@
 // colors in the output.  It prints "YES" and returns 1 if Google Test
 // decides to use colors, and prints "NO" and returns 0 otherwise.
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "gtest/gtest.h"
 #include "src/gtest-internal-inl.h"

--- a/googletest/test/googletest-death-test-test.cc
+++ b/googletest/test/googletest-death-test-test.cc
@@ -49,9 +49,12 @@ using testing::internal::AlwaysTrue;
 #  include <sys/wait.h>        // For waitpid.
 # endif  // GTEST_OS_WINDOWS
 
-# include <limits.h>
-# include <signal.h>
-# include <stdio.h>
+# if !GTEST_OS_LINUX
+#  include <csignal>
+# endif  // !GTEST_OS_LINUX
+
+# include <climits>
+# include <cstdio>
 
 # if GTEST_OS_LINUX
 #  include <sys/time.h>

--- a/googletest/test/googletest-output-test_.cc
+++ b/googletest/test/googletest-output-test_.cc
@@ -37,8 +37,6 @@
 #include "gtest/gtest.h"
 #include "src/gtest-internal-inl.h"
 
-#include <stdlib.h>
-
 #if _MSC_VER
 GTEST_DISABLE_MSC_WARNINGS_PUSH_(4127 /* conditional expression is constant */)
 #endif  //  _MSC_VER

--- a/googletest/test/googletest-param-test-test.cc
+++ b/googletest/test/googletest-param-test-test.cc
@@ -35,10 +35,8 @@
 #include "gtest/gtest.h"
 
 # include <algorithm>
-# include <iostream>
 # include <list>
 # include <set>
-# include <sstream>
 # include <string>
 # include <vector>
 

--- a/googletest/test/googletest-port-test.cc
+++ b/googletest/test/googletest-port-test.cc
@@ -28,7 +28,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // This file tests the internal cross-platform support utilities.
-#include <stdio.h>
+#include <cstdio>
 
 #include "gtest/internal/gtest-port.h"
 

--- a/googletest/test/googletest-throw-on-failure-test_.cc
+++ b/googletest/test/googletest-throw-on-failure-test_.cc
@@ -36,9 +36,8 @@
 
 #include "gtest/gtest.h"
 
-#include <stdio.h>                      // for fflush, fprintf, NULL, etc.
-#include <stdlib.h>                     // for exit
-#include <exception>                    // for set_terminate
+#include <cstdio>                      // for fflush, fprintf, NULL, etc.
+#include <cstdlib>                     // for exit
 
 // This terminate handler aborts the program using exit() rather than abort().
 // This avoids showing pop-ups on Windows systems and core dumps on Unix-like

--- a/googletest/test/gtest-unittest-api_test.cc
+++ b/googletest/test/gtest-unittest-api_test.cc
@@ -34,7 +34,7 @@
 
 #include "gtest/gtest.h"
 
-#include <string.h>  // For strcmp.
+#include <cstring>  // For strcmp.
 #include <algorithm>
 
 using ::testing::InitGoogleTest;

--- a/googletest/test/gtest_assert_by_exception_test.cc
+++ b/googletest/test/gtest_assert_by_exception_test.cc
@@ -32,9 +32,9 @@
 
 #include "gtest/gtest.h"
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
 #include <stdexcept>
 
 class ThrowListener : public testing::EmptyTestEventListener {

--- a/googletest/test/gtest_environment_test.cc
+++ b/googletest/test/gtest_environment_test.cc
@@ -30,8 +30,7 @@
 //
 // Tests using global test environments.
 
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdio>
 #include "gtest/gtest.h"
 #include "src/gtest-internal-inl.h"
 

--- a/googletest/test/gtest_premature_exit_test.cc
+++ b/googletest/test/gtest_premature_exit_test.cc
@@ -31,7 +31,7 @@
 // Tests that Google Test manipulates the premature-exit-detection
 // file correctly.
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "gtest/gtest.h"
 

--- a/googletest/test/gtest_repeat_test.cc
+++ b/googletest/test/gtest_repeat_test.cc
@@ -30,7 +30,6 @@
 
 // Tests the --gtest_repeat=number flag.
 
-#include <stdlib.h>
 #include <iostream>
 #include "gtest/gtest.h"
 #include "src/gtest-internal-inl.h"

--- a/googletest/test/gtest_throw_on_failure_ex_test.cc
+++ b/googletest/test/gtest_throw_on_failure_ex_test.cc
@@ -32,9 +32,9 @@
 
 #include "gtest/gtest.h"
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
 #include <stdexcept>
 
 // Prints the given failure message and exits the program with

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -55,10 +55,9 @@ TEST(CommandLineFlagsTest, CanBeAccessedInCodeOnceGTestHIsIncluded) {
   EXPECT_TRUE(dummy || !dummy);  // Suppresses warning that dummy is unused.
 }
 
-#include <limits.h>  // For INT_MAX.
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 
 #include <map>
 #include <ostream>


### PR DESCRIPTION
Tested **(gmock_build_tests and gtest_build_tests)** within the following environments:
 - macOS: Apple clang version 11.0.0 (clang-1100.0.33.8)
 - SL7.6: gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-36)
 - Ubuntu 18.04: gcc (Ubuntu 7.4.0-1ubuntu1~18.04.1) 7.4.0
 - CentOS8: gcc (GCC) 8.2.1 20180905 (Red Hat 8.2.1-3)

