### PR TITLE
Update documentation from "iff" to "if and only if" in gen_gtest_pred_impl.py

### DIFF
--- a/googletest/scripts/gen_gtest_pred_impl.py
+++ b/googletest/scripts/gen_gtest_pred_impl.py
@@ -544,10 +544,10 @@ class Predicate%(n)sTest : public testing::Test {
     }
   }
 
-  // true iff the test function is expected to run to finish.
+  // true if and only if the test function is expected to run to finish.
   static bool expected_to_finish_;
 
-  // true iff the test function did run to finish.
+  // true if and only if the test function did run to finish.
   static bool finished_;
 """ % DEFS
 
@@ -576,12 +576,12 @@ typedef Predicate%(n)sTest ASSERT_PRED%(n)sTest;
     """Returns the test for a predicate assertion macro.
 
     Args:
-      use_format:     true iff the assertion is a *_PRED_FORMAT*.
-      use_assert:     true iff the assertion is a ASSERT_*.
-      expect_failure: true iff the assertion is expected to fail.
-      use_functor:    true iff the first argument of the assertion is
+      use_format:     true if and only if the assertion is a *_PRED_FORMAT*.
+      use_assert:     true if and only if the assertion is a ASSERT_*.
+      expect_failure: true if and only if the assertion is expected to fail.
+      use_functor:    true if and only if the first argument of the assertion is
                       a functor (as opposed to a function)
-      use_user_type:  true iff the predicate functor/function takes
+      use_user_type:  true if and only if the predicate functor/function takes
                       argument(s) of a user-defined type.
 
     Example:


### PR DESCRIPTION
After 7bd4a7f3 [gtest_pred_impl_unittest.cc](https://github.com/google/googletest/blob/8697709e0308af4cd5b09dc108480804e5447cf0/googletest/test/gtest_pred_impl_unittest.cc) used to be newer than its template.

Sorry, I haven't checked it out before :)