### PR TITLE
pkg-config: Remove pthread link flag from Cflags

### DIFF
--- a/googlemock/cmake/gmock.pc.in
+++ b/googlemock/cmake/gmock.pc.in
@@ -8,4 +8,4 @@ Version: @PROJECT_VERSION@
 URL: https://github.com/google/googletest
 Requires: gtest
 Libs: -L${libdir} -lgmock @CMAKE_THREAD_LIBS_INIT@
-Cflags: -I${includedir} @GTEST_HAS_PTHREAD_MACRO@ @CMAKE_THREAD_LIBS_INIT@
+Cflags: -I${includedir} @GTEST_HAS_PTHREAD_MACRO@

--- a/googlemock/cmake/gmock_main.pc.in
+++ b/googlemock/cmake/gmock_main.pc.in
@@ -8,4 +8,4 @@ Version: @PROJECT_VERSION@
 URL: https://github.com/google/googletest
 Requires: gmock
 Libs: -L${libdir} -lgmock_main @CMAKE_THREAD_LIBS_INIT@
-Cflags: -I${includedir} @GTEST_HAS_PTHREAD_MACRO@ @CMAKE_THREAD_LIBS_INIT@
+Cflags: -I${includedir} @GTEST_HAS_PTHREAD_MACRO@

--- a/googletest/cmake/gtest.pc.in
+++ b/googletest/cmake/gtest.pc.in
@@ -7,4 +7,4 @@ Description: GoogleTest (without main() function)
 Version: @PROJECT_VERSION@
 URL: https://github.com/google/googletest
 Libs: -L${libdir} -lgtest @CMAKE_THREAD_LIBS_INIT@
-Cflags: -I${includedir} @GTEST_HAS_PTHREAD_MACRO@ @CMAKE_THREAD_LIBS_INIT@
+Cflags: -I${includedir} @GTEST_HAS_PTHREAD_MACRO@

--- a/googletest/cmake/gtest_main.pc.in
+++ b/googletest/cmake/gtest_main.pc.in
@@ -8,4 +8,4 @@ Version: @PROJECT_VERSION@
 URL: https://github.com/google/googletest
 Requires: gtest
 Libs: -L${libdir} -lgtest_main @CMAKE_THREAD_LIBS_INIT@
-Cflags: -I${includedir} @GTEST_HAS_PTHREAD_MACRO@ @CMAKE_THREAD_LIBS_INIT@
+Cflags: -I${includedir} @GTEST_HAS_PTHREAD_MACRO@


### PR DESCRIPTION
Remove the threads link library variable references from the pkg-config
Cflags: field, removing -lpthread(s) from the compile flags.

"-l*" linker flags should only be part of the Libs: section and should
not be part of the Cflags: section in pkg-config files.

This was first suggested in
https://github.com/google/googletest/pull/2006 and further discussed in
https://github.com/google/googletest/pull/2483 .