### PR TITLE
Use .has_value() instead of operator bool

### DIFF
--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -3283,7 +3283,7 @@ class OptionalMatcher {
 
     bool MatchAndExplain(Optional optional,
                          MatchResultListener* listener) const override {
-      if (!optional) {
+      if (!optional.has_value()) {
         *listener << "which is not engaged";
         return false;
       }


### PR DESCRIPTION
We think that implicit conversions and especially to
bool are a terrible idea.
Google style guide agrees:
https://google.github.io/styleguide/cppguide.html#Implicit_Conversions

For this reason we have our own optional<T> that does not have
the implicit conversion to bool and would still like to use this matcher.
As std::optional also has .has_value() this should still work.