### PR TITLE
Export Test - Do Not Merge

### DIFF
--- a/googletest/src/gtest-death-test.cc
+++ b/googletest/src/gtest-death-test.cc
@@ -1364,7 +1364,7 @@ static pid_t ExecDeathTestSpawnChild(char* const* argv, int close_fd) {
 
   if (!use_fork) {
     static const bool stack_grows_down = StackGrowsDown();
-    const auto stack_size = static_cast<size_t>(getpagesize());
+    const auto stack_size = static_cast<size_t>(getpagesize() * 2);
     // MMAP_ANONYMOUS is not defined on Mac, so we use MAP_ANON instead.
     void* const stack = mmap(nullptr, stack_size, PROT_READ | PROT_WRITE,
                              MAP_ANON | MAP_PRIVATE, -1, 0);


### PR DESCRIPTION
Export Test - Do Not Merge


Clone+exec death test allocates a single page of stack to run chdir + exec on.
This is not enough when gtest is built with ASan and run on particular
hardware.

With ASan on x86_64, ExecDeathTestChildMain has frame size of 1728 bytes.

Call to chdir() in ExecDeathTestChildMain ends up in
_dl_runtime_resolve_xsavec, which attempts to save register state on the stack;
according to cpuid(0xd) XSAVE register save area size is 2568 on my machine.