### PR TITLE
Fix FlatTuple compilation on older msvc.

### DIFF
--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1185,7 +1185,7 @@ struct FlatTupleBase<FlatTuple<T...>, IndexSequence<Idx...>>
 
 // Analog to std::tuple but with different tradeoffs.
 // This class minimizes the template instantiation depth, thus allowing more
-// elements that std::tuple would. std::tuple has been seen to require an
+// elements than std::tuple would. std::tuple has been seen to require an
 // instantiation depth of more than 10x the number of elements in some
 // implementations.
 // FlatTuple and ElemFromList are not recursive and have a fixed depth
@@ -1196,7 +1196,9 @@ template <typename... T>
 class FlatTuple
     : private FlatTupleBase<FlatTuple<T...>,
                             typename MakeIndexSequence<sizeof...(T)>::type> {
-  using Indices = typename FlatTuple::FlatTupleBase::Indices;
+
+  using Indices = typename FlatTupleBase<FlatTuple<T...>,
+                            typename MakeIndexSequence<sizeof...(T)>::type>::Indices;
 
  public:
   FlatTuple() = default;


### PR DESCRIPTION
googletest 1.10.0 fails to compile on msvc version 19.00.23917
with one compilation error:

src\googletest\include\gtest\internal\gtest-internal.h(1188) : error C2039:
'FlatTupleBase<testing::internal::FlatTuple<bool,bool>,testing::internal::IndexSequence<0,1> >':
is not a member of 'testing::internal::FlatTuple<bool,bool>'

This PR fixes the compilation error by explicitly specifying the full type that Indices is
located in the base type.