### PR TITLE
Fix internal memory leak in Windows _Crt report.

### DIFF
--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -536,6 +536,9 @@ class ThreadLocalRegistryImpl {
   // Returns a value that can be used to identify the thread from other threads.
   static ThreadLocalValueHolderBase* GetValueOnCurrentThread(
       const ThreadLocalBase* thread_local_instance) {
+#ifdef _MSC_VER
+    MemoryIsNotDeallocated memory_is_not_deallocated;
+#endif  // _MSC_VER
     DWORD current_thread = ::GetCurrentThreadId();
     MutexLock lock(&mutex_);
     ThreadIdToThreadLocals* const thread_to_thread_locals =


### PR DESCRIPTION
We use "MemoryIsNotDeallocated" to aovid internal expected leak reported
in Windows _Crt report, like:

```cpp
    {
    #ifdef _MSC_VER
    	MemoryIsNotDeallocated memory_is_not_deeallocated;
    #endif

    	static ThreadIdToThreadLocals* map = new ThreadIdToThreadLocals();
	return map;
    }
```

But int the above code, only "new ThreadIdToThreadLocals()" is
protected, if we invoke "insert()" function of the return value,
the memory allocated in "insert()" will be reported to _Crt report
also. This change try to fix this issue.