### PR TITLE
Allow using other frameworks supported by PlatformIO

### DIFF
--- a/library.json
+++ b/library.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/google/googletest.git"
   },
   "version": "1.10.0",
-  "frameworks": "arduino",
+  "frameworks": "*",
   "platforms": [
         "espressif32",
         "espressif8266"


### PR DESCRIPTION
There is no reason to bound googletest only to the Arduino framework. This will allow using googletest for testing on a native machine as well.