### PR TITLE
Remove MSVC workaround: wmain link error

### DIFF
--- a/googlemock/src/gmock_main.cc
+++ b/googlemock/src/gmock_main.cc
@@ -48,20 +48,13 @@ void loop() { RUN_ALL_TESTS(); }
 #endif
 
 #else
-
-// MS C++ compiler/linker has a bug on Windows (not on Windows CE), which
-// causes a link error when _tmain is defined in a static library and UNICODE
-// is enabled. For this reason instead of _tmain, main function is used on
-// Windows. See the following link to track the current status of this bug:
-// https://web.archive.org/web/20170912203238/connect.microsoft.com/VisualStudio/feedback/details/394464/wmain-link-error-in-the-static-library
-// // NOLINT
-#if GTEST_OS_WINDOWS_MOBILE
+#if __MSC_VER
 # include <tchar.h>  // NOLINT
 
 GTEST_API_ int _tmain(int argc, TCHAR** argv) {
 #else
 GTEST_API_ int main(int argc, char** argv) {
-#endif  // GTEST_OS_WINDOWS_MOBILE
+#endif  // __MSC_VER
   std::cout << "Running main() from gmock_main.cc\n";
   // Since Google Mock depends on Google Test, InitGoogleMock() is
   // also responsible for initializing Google Test.  Therefore there's

--- a/googlemock/src/gmock_main.cc
+++ b/googlemock/src/gmock_main.cc
@@ -55,7 +55,7 @@ GTEST_API_ int _tmain(int argc, TCHAR** argv) {
 #else
 GTEST_API_ int main(int argc, char** argv) {
 #endif  // __MSC_VER
-  std::cout << "Running main() from gmock_main.cc\n";
+  std::cout << "Running main() from " << __FILE__ << '\n';
   // Since Google Mock depends on Google Test, InitGoogleMock() is
   // also responsible for initializing Google Test.  Therefore there's
   // no need for calling testing::InitGoogleTest() separately.

--- a/googletest/src/gtest_main.cc
+++ b/googletest/src/gtest_main.cc
@@ -27,7 +27,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <cstdio>
+#include <iostream>
 #include "gtest/gtest.h"
 
 #if GTEST_OS_ESP8266 || GTEST_OS_ESP32
@@ -45,9 +45,14 @@ void loop() { RUN_ALL_TESTS(); }
 #endif
 
 #else
+#if __MSC_VER
+# include <tchar.h>  // NOLINT
 
-GTEST_API_ int main(int argc, char **argv) {
-  printf("Running main() from %s\n", __FILE__);
+GTEST_API_ int _tmain(int argc, TCHAR** argv) {
+#else
+GTEST_API_ int main(int argc, char** argv) {
+#endif  // __MSC_VER
+  std::cout << "Running main() from " << __FILE__ << '\n';
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Two commits here:
298a40f0 - removing workaround to the bug that has been patched
a909becd - just me secretly trying to smuggle some unification to both main files