### PR TITLE
Revert change that disallows empty test prefixes

### DIFF
--- a/googletest/include/gtest/gtest-param-test.h
+++ b/googletest/include/gtest/gtest-param-test.h
@@ -58,9 +58,7 @@ class FooTest : public ::testing::TestWithParam<const char*> {
 
 // Then, use the TEST_P macro to define as many parameterized tests
 // for this fixture as you want. The _P suffix is for "parameterized"
-// or "pattern", whichever you prefer to think. The arguments to the
-// TEST_P macro are the test_suite_name and test_case (both which must be
-// non-empty) that will form the test name.
+// or "pattern", whichever you prefer to think.
 
 TEST_P(FooTest, DoesBlah) {
   // Inside a test, access the test parameter with the GetParam() method
@@ -103,10 +101,10 @@ INSTANTIATE_TEST_SUITE_P(InstantiationName,
 
 // To distinguish different instances of the pattern, (yes, you
 // can instantiate it more than once) the first argument to the
-// INSTANTIATE_TEST_SUITE_P macro is a prefix (which must be non-empty) that
-// will be added to the actual test suite name. Remember to pick unique prefixes
-// for different instantiations. The tests from the instantiation above will
-// have these names:
+// INSTANTIATE_TEST_SUITE_P macro is a prefix that will be added to the
+// actual test suite name. Remember to pick unique prefixes for different
+// instantiations. The tests from the instantiation above will have
+// these names:
 //
 //    * InstantiationName/FooTest.DoesBlah/0 for "meeny"
 //    * InstantiationName/FooTest.DoesBlah/1 for "miny"
@@ -414,10 +412,6 @@ internal::CartesianProductHolder<Generator...> Combine(const Generator&... g) {
 }
 
 #define TEST_P(test_suite_name, test_name)                                     \
-  static_assert(sizeof(GTEST_STRINGIFY_(test_suite_name)) > 1,                 \
-                "test_suite_name must not be empty");                          \
-  static_assert(sizeof(GTEST_STRINGIFY_(test_name)) > 1,                       \
-                "test_name must not be empty");                                \
   class GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)                     \
       : public test_suite_name {                                               \
    public:                                                                     \
@@ -464,10 +458,6 @@ internal::CartesianProductHolder<Generator...> Combine(const Generator&... g) {
 #define GTEST_GET_SECOND_(first, second, ...) second
 
 #define INSTANTIATE_TEST_SUITE_P(prefix, test_suite_name, ...)                \
-  static_assert(sizeof(GTEST_STRINGIFY_(test_suite_name)) > 1,                \
-                "test_suite_name must not be empty");                         \
-  static_assert(sizeof(GTEST_STRINGIFY_(prefix)) > 1,                         \
-                "prefix must not be empty");                                  \
   static ::testing::internal::ParamGenerator<test_suite_name::ParamType>      \
       gtest_##prefix##test_suite_name##_EvalGenerator_() {                    \
     return GTEST_EXPAND_(GTEST_GET_FIRST_(__VA_ARGS__, DUMMY_PARAM_));        \

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -79,7 +79,16 @@
 #define GTEST_CONCAT_TOKEN_IMPL_(foo, bar) foo ## bar
 
 // Stringifies its argument.
-#define GTEST_STRINGIFY_(name) #name
+// Work around a bug in visual studio which doesn't accept code like this:
+//
+//   #define GTEST_STRINGIFY_(name) #name
+//   #define MACRO(a, b, c) ... GTEST_STRINGIFY_(a) ...
+//   MACRO(, x, y)
+//
+// Complaining about the argument to GTEST_STRINGIFY_ being empty.
+// This is allowed by the spec.
+#define GTEST_STRINGIFY_HELPER_(name, ...) #name
+#define GTEST_STRINGIFY_(...) GTEST_STRINGIFY_HELPER_(__VA_ARGS__,)
 
 namespace proto2 { class Message; }
 

--- a/googletest/include/gtest/internal/gtest-param-util.h
+++ b/googletest/include/gtest/internal/gtest-param-util.h
@@ -574,7 +574,10 @@ class ParameterizedTestSuiteInfo : public ParameterizedTestSuiteInfoBase {
 
           test_param_names.insert(param_name);
 
-          test_name_stream << test_info->test_base_name << "/" << param_name;
+          if (!test_info->test_base_name.empty()) {
+            test_name_stream << test_info->test_base_name << "/";
+          }
+          test_name_stream << param_name;
           MakeAndRegisterTestInfo(
               test_suite_name.c_str(), test_name_stream.GetString().c_str(),
               nullptr,  // No type parameter.

--- a/googletest/test/googletest-output-test-golden-lin.txt
+++ b/googletest/test/googletest-output-test-golden-lin.txt
@@ -966,9 +966,9 @@ Expected equality of these values:
 Stack trace: (omitted)
 
 [0;31m[  FAILED  ] [mPrintingFailingParams/FailingParamTest.Fails/0, where GetParam() = 2
-[0;32m[----------] [m1 test from All/EmptyBasenameParamInst
-[0;32m[ RUN      ] [mAll/EmptyBasenameParamInst.Passes/0
-[0;32m[       OK ] [mAll/EmptyBasenameParamInst.Passes/0
+[0;32m[----------] [m1 test from EmptyBasenameParamInst
+[0;32m[ RUN      ] [mEmptyBasenameParamInst.Passes/0
+[0;32m[       OK ] [mEmptyBasenameParamInst.Passes/0
 [0;32m[----------] [m2 tests from PrintingStrings/ParamTest
 [0;32m[ RUN      ] [mPrintingStrings/ParamTest.Success/a
 [0;32m[       OK ] [mPrintingStrings/ParamTest.Success/a

--- a/googletest/test/googletest-output-test-golden-lin.txt
+++ b/googletest/test/googletest-output-test-golden-lin.txt
@@ -12,7 +12,7 @@ Expected equality of these values:
   3
 Stack trace: (omitted)
 
-[0;32m[==========] [mRunning 85 tests from 40 test suites.
+[0;32m[==========] [mRunning 86 tests from 41 test suites.
 [0;32m[----------] [mGlobal test environment set-up.
 FooEnvironment::SetUp() called.
 BarEnvironment::SetUp() called.
@@ -966,6 +966,9 @@ Expected equality of these values:
 Stack trace: (omitted)
 
 [0;31m[  FAILED  ] [mPrintingFailingParams/FailingParamTest.Fails/0, where GetParam() = 2
+[0;32m[----------] [m1 test from All/EmptyBasenameParamInst
+[0;32m[ RUN      ] [mAll/EmptyBasenameParamInst.Passes/0
+[0;32m[       OK ] [mAll/EmptyBasenameParamInst.Passes/0
 [0;32m[----------] [m2 tests from PrintingStrings/ParamTest
 [0;32m[ RUN      ] [mPrintingStrings/ParamTest.Success/a
 [0;32m[       OK ] [mPrintingStrings/ParamTest.Success/a
@@ -998,8 +1001,8 @@ Failed
 Expected fatal failure.
 Stack trace: (omitted)
 
-[0;32m[==========] [m85 tests from 40 test suites ran.
-[0;32m[  PASSED  ] [m31 tests.
+[0;32m[==========] [m86 tests from 41 test suites ran.
+[0;32m[  PASSED  ] [m32 tests.
 [0;31m[  FAILED  ] [m54 tests, listed below:
 [0;31m[  FAILED  ] [mNonfatalFailureTest.EscapesStringOperands
 [0;31m[  FAILED  ] [mNonfatalFailureTest.DiffForLongStrings

--- a/googletest/test/googletest-output-test_.cc
+++ b/googletest/test/googletest-output-test_.cc
@@ -102,7 +102,7 @@ class EmptyBasenameParamInst : public testing::TestWithParam<int> {};
 
 TEST_P(EmptyBasenameParamInst, Passes) { EXPECT_EQ(1, GetParam()); }
 
-INSTANTIATE_TEST_SUITE_P(All, EmptyBasenameParamInst, testing::Values(1));
+INSTANTIATE_TEST_SUITE_P(, EmptyBasenameParamInst, testing::Values(1));
 
 static const char kGoldenString[] = "\"Line\0 1\"\nLine 2";
 

--- a/googletest/test/googletest-output-test_.cc
+++ b/googletest/test/googletest-output-test_.cc
@@ -96,6 +96,14 @@ INSTANTIATE_TEST_SUITE_P(PrintingFailingParams,
                          FailingParamTest,
                          testing::Values(2));
 
+// Tests that an empty value for the test suite basename yields just
+// the test name without any prior /
+class EmptyBasenameParamInst : public testing::TestWithParam<int> {};
+
+TEST_P(EmptyBasenameParamInst, Passes) { EXPECT_EQ(1, GetParam()); }
+
+INSTANTIATE_TEST_SUITE_P(All, EmptyBasenameParamInst, testing::Values(1));
+
 static const char kGoldenString[] = "\"Line\0 1\"\nLine 2";
 
 TEST(NonfatalFailureTest, EscapesStringOperands) {

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -5349,7 +5349,7 @@ TEST_P(CodeLocationForTESTP, Verify) {
   VERIFY_CODE_LOCATION;
 }
 
-INSTANTIATE_TEST_SUITE_P(All, CodeLocationForTESTP, Values(0));
+INSTANTIATE_TEST_SUITE_P(, CodeLocationForTESTP, Values(0));
 
 template <typename T>
 class CodeLocationForTYPEDTEST : public Test {


### PR DESCRIPTION
Reverted commits:

- 20b5b8ecc7a81d23b4716e22a2b35fd53379c8c6: "Googletest export": disallow empty prefix
- 4c25e2b87fcb78abcfdee2739db9ed7a19754cd3: "Googletest export": Remove test for empty prefix

Reason for revert: Breaks existing applications, such as ANGLE (angleproject.org), requires adding an extra prefix that needs to be typed for no reason (when testing from command line) and increases the logs' sizes by a non-trivial amount due to the very large number of tests ANGLE runs.

The original commit that disallowed empty test prefixes says:

> Add a compile time check to ensure that the parameters to TEST_P and INSTANTIATE_TEST_SUITE_P are not empty. Some compilers already fail in that case and, even where it works, it's likely to result in technically invalid code by virtue of creating reserved identifiers:
https://en.cppreference.com/w/cpp/language/identifiers

First, every project is perfectly capable of adding a prefix if they want to support such a compiler. This change penalizes every project.

Second, using a prefix such as `_p` also results in reserved identifiers, so this change is not really solving the problem.  For that matter, instead of generating `gtest_##prefix##...`, you can generate `gtest_x##prefix##...` to correctly fix the issue, including when empty prefixes are used.