### PR TITLE
Iterate untyped expectations vector back without reverse_iterator to workaround a bug  in VS 2019 16.4

### DIFF
--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -1731,9 +1731,13 @@ class FunctionMocker<R(Args...)> final : public UntypedFunctionMockerBase {
     g_gmock_mutex.AssertHeld();
     // See the definition of untyped_expectations_ for why access to
     // it is unprotected here.
-    for (auto& untyped_expectations : untyped_expectations_) {
+    for (typename UntypedExpectations::const_iterator it =
+            untyped_expectations_.end();
+        it != untyped_expectations_.begin(); --it) {
+      typename UntypedExpectations::const_iterator tmp = it;
+      --tmp;
       TypedExpectation<F>* const exp =
-          static_cast<TypedExpectation<F>*>(untyped_expectations.get());
+          static_cast<TypedExpectation<F>*>(tmp->get());
       if (exp->ShouldHandleArguments(args)) {
         return exp;
       }

--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -1731,11 +1731,9 @@ class FunctionMocker<R(Args...)> final : public UntypedFunctionMockerBase {
     g_gmock_mutex.AssertHeld();
     // See the definition of untyped_expectations_ for why access to
     // it is unprotected here.
-    for (typename UntypedExpectations::const_reverse_iterator it =
-             untyped_expectations_.rbegin();
-         it != untyped_expectations_.rend(); ++it) {
+    for (auto& untyped_expectations : untyped_expectations_) {
       TypedExpectation<F>* const exp =
-          static_cast<TypedExpectation<F>*>(it->get());
+          static_cast<TypedExpectation<F>*>(untyped_expectations.get());
       if (exp->ShouldHandleArguments(args)) {
         return exp;
       }


### PR DESCRIPTION
Workaround fix for #2628 
Using range based for-loop generates code that doesn't crash and the bug does not reproduce.