### PR TITLE
Fix unit test failure on NoShortCircuitOnFailure and DetectsFlakyShortCircuit when GTEST_HAS_RTTI is 1

### DIFF
--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -6885,7 +6885,7 @@ TEST_F(PredicateFormatterFromMatcherTest, NoShortCircuitOnFailure) {
   EXPECT_FALSE(result);  // Implicit cast to bool.
   std::string expect =
       "Value of: dummy-name\nExpected: [DescribeTo]\n"
-      "  Actual: 1, [MatchAndExplain]";
+      "  Actual: 1" + OfType(internal::GetTypeName<Behavior>()) + ", [MatchAndExplain]";
   EXPECT_EQ(expect, result.message());
 }
 
@@ -6896,7 +6896,7 @@ TEST_F(PredicateFormatterFromMatcherTest, DetectsFlakyShortCircuit) {
       "Value of: dummy-name\nExpected: [DescribeTo]\n"
       "  The matcher failed on the initial attempt; but passed when rerun to "
       "generate the explanation.\n"
-      "  Actual: 2, [MatchAndExplain]";
+      "  Actual: 2" + OfType(internal::GetTypeName<Behavior>()) + ", [MatchAndExplain]";
   EXPECT_EQ(expect, result.message());
 }
 

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -140,7 +140,7 @@ Matcher<int> GreaterThan(int n) {
 
 std::string OfType(const std::string& type_name) {
 #if GTEST_HAS_RTTI
-  return " (of type " + type_name + ")";
+  return IsReadableTypeName(type_name) ? " (of type " + type_name + ")" : "";
 #else
   return "";
 #endif


### PR DESCRIPTION
This fixes unit test failure in gmock-matchers_test.cc when compiled using latest VS 2019 on Windows : 

[ RUN      ] PredicateFormatterFromMatcherTest.NoShortCircuitOnFailure
..\..\..\googlemock\test\gmock-matchers_test.cc(6889): error: Expected equality of these values:
  expect
    Which is: "Value of: dummy-name\nExpected: [DescribeTo]\n  Actual: 1, [MatchAndExplain]"
  result.message()
    Which is: "Value of: dummy-name\nExpected: [DescribeTo]\n  Actual: 1 (of type enum testing::gmock_matchers_test::`anonymous namespace'::PredicateFormatterFromMatcherTest::Behavior), [MatchAndExplain]"
With diff:
@@ -1,3 +1,3 @@
 Value of: dummy-name
 Expected: [DescribeTo]
-  Actual: 1, [MatchAndExplain]
+  Actual: 1 (of type enum testing::gmock_matchers_test::`anonymous namespace'::PredicateFormatterFromMatcherTest::Behavior), [MatchAndExplain]

[ RUN      ] PredicateFormatterFromMatcherTest.DetectsFlakyShortCircuit
..\..\..\googlemock\test\gmock-matchers_test.cc(6900): error: Expected equality of these values:
  expect
    Which is: "Value of: dummy-name\nExpected: [DescribeTo]\n  The matcher failed on the initial attempt; but passed when rerun to generate the explanation.\n  Actual: 2, [MatchAndExplain]"
  result.message()
    Which is: "Value of: dummy-name\nExpected: [DescribeTo]\n  The matcher failed on the initial attempt; but passed when rerun to generate the explanation.\n  Actual: 2 (of type enum testing::gmock_matchers_test::`anonymous namespace'::PredicateFormatterFromMatcherTest::Behavior), [MatchAndExplain]"
With diff:
@@ -2,3 +2,3 @@
 Expected: [DescribeTo]
   The matcher failed on the initial attempt; but passed when rerun to generate the explanation.
-  Actual: 2, [MatchAndExplain]
+  Actual: 2 (of type enum testing::gmock_matchers_test::`anonymous namespace'::PredicateFormatterFromMatcherTest::Behavior), [MatchAndExplain]