### PR TITLE
Add additional valid characters to parameter names

### DIFF
--- a/googletest/include/gtest/internal/gtest-param-util.h
+++ b/googletest/include/gtest/internal/gtest-param-util.h
@@ -633,6 +633,8 @@ class ParameterizedTestSuiteInfo : public ParameterizedTestSuiteInfoBase {
       int line;
   };
   typedef ::std::vector<InstantiationInfo> InstantiationContainer;
+  
+  static std::string validParamChars = "_-:/";
 
   static bool IsValidParamName(const std::string& name) {
     // Check for empty string
@@ -641,7 +643,7 @@ class ParameterizedTestSuiteInfo : public ParameterizedTestSuiteInfoBase {
 
     // Check for invalid characters
     for (std::string::size_type index = 0; index < name.size(); ++index) {
-      if (!isalnum(name[index]) && name[index] != '_')
+      if (!isalnum(name[index]) && validParamChars.find(name[index]) == std::string::npos)
         return false;
     }
 


### PR DESCRIPTION
I feel as though the alphanumeric + `_` charset is too restrictive, especially when formatting complex objects into names.  Added a few extra characters which will help with this.