### PR TITLE
Remove exclusion of *-main and*-all targets

### DIFF
--- a/library.json
+++ b/library.json
@@ -25,14 +25,10 @@
             "ci",
             "googlemock/cmake",
             "googlemock/scripts",
-            "googlemock/src/gmock-all.cc",
-            "googlemock/src/gmock_main.cc",
             "googlemock/test",
             "googlemock/CMakeLists.txt",
             "googletest/cmake",
             "googletest/scripts",
-            "googletest/src/gtest-all.cc",
-            "googletest/src/gtest_main.cc",
             "googletest/test",
             "googletest/CMakeLists.txt"
           ]


### PR DESCRIPTION
Removing exclusion of *-main and*-all targets from the library.json used on platformio.

Closes #2671 