### PR TITLE
Fix always false condition and clean function body

### DIFF
--- a/googletest/src/gtest-filepath.cc
+++ b/googletest/src/gtest-filepath.cc
@@ -349,33 +349,19 @@ FilePath FilePath::RemoveTrailingPathSeparator() const {
 // For example, "bar///foo" becomes "bar/foo". Does not eliminate other
 // redundancies that might be in a pathname involving "." or "..".
 void FilePath::Normalize() {
-  if (pathname_.c_str() == nullptr) {
-    pathname_ = "";
-    return;
-  }
-  const char* src = pathname_.c_str();
-  char* const dest = new char[pathname_.length() + 1];
-  char* dest_ptr = dest;
-  memset(dest_ptr, 0, pathname_.length() + 1);
+  std::string normalized_pathname;
+  normalized_pathname.reserve(pathname_.length());
 
-  while (*src != '\0') {
-    *dest_ptr = *src;
-    if (!IsPathSeparator(*src)) {
-      src++;
-    } else {
-#if GTEST_HAS_ALT_PATH_SEP_
-      if (*dest_ptr == kAlternatePathSeparator) {
-        *dest_ptr = kPathSeparator;
-      }
-#endif
-      while (IsPathSeparator(*src))
-        src++;
-    }
-    dest_ptr++;
-  }
-  *dest_ptr = '\0';
-  pathname_ = dest;
-  delete[] dest;
+  for (const auto character : pathname_)
+    if (!IsPathSeparator(character))
+      normalized_pathname.push_back(character);
+    else if (normalized_pathname.empty() ||
+             normalized_pathname.back() != kPathSeparator)
+      normalized_pathname.push_back(kPathSeparator);
+    else
+      continue;
+
+  pathname_ = normalized_pathname;
 }
 
 }  // namespace internal


### PR DESCRIPTION
An always false condition was remove from Normalize member function of FilePath and the body of the function which was poorly written, is improved.

Closes #2647 