### PR TITLE
Set kErrorOnUninstantiatedParameterizedTest et al. to true

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -414,8 +414,8 @@ namespace {
 // inserted to report ether an error or a log message.
 //
 // This configuration bit will likely be removed at some point.
-constexpr bool kErrorOnUninstantiatedParameterizedTest = false;
-constexpr bool kErrorOnUninstantiatedTypeParameterizedTest = false;
+constexpr bool kErrorOnUninstantiatedParameterizedTest = true;
+constexpr bool kErrorOnUninstantiatedTypeParameterizedTest = true;
 
 // A test that fails at a given file/line location with a given message.
 class FailureTest : public Test {

--- a/googletest/test/googletest-output-test-golden-lin.txt
+++ b/googletest/test/googletest-output-test-golden-lin.txt
@@ -984,6 +984,8 @@ Stack trace: (omitted)
 [0;31m[  FAILED  ] [mPrintingStrings/ParamTest.Failure/a, where GetParam() = "a"
 [0;32m[----------] [m3 tests from GoogleTestVerification
 [0;32m[ RUN      ] [mGoogleTestVerification.UninstantiatedParamaterizedTestSuite<NoTests>
+googletest-output-test_.cc:#: Failure
+
 Paramaterized test suite NoTests is instantiated via INSTANTIATE_TEST_SUITE_P, but no tests are defined via TEST_P . No test cases will run.
 
 Ideally, INSTANTIATE_TEST_SUITE_P should only ever be invoked from code that always depend on code that provides TEST_P. Failing to do so is often an indication of dead code, e.g. the last TEST_P was removed but the rest got left behind.
@@ -991,8 +993,12 @@ Ideally, INSTANTIATE_TEST_SUITE_P should only ever be invoked from code that alw
 To suppress this error for this test suite, insert the following line (in a non-header) in the namespace it is defined in:
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(NoTests);
-[0;32m[       OK ] [mGoogleTestVerification.UninstantiatedParamaterizedTestSuite<NoTests>
+Stack trace: (omitted)
+
+[0;31m[  FAILED  ] [mGoogleTestVerification.UninstantiatedParamaterizedTestSuite<NoTests>
 [0;32m[ RUN      ] [mGoogleTestVerification.UninstantiatedParamaterizedTestSuite<DetectNotInstantiatedTest>
+googletest-output-test_.cc:#: Failure
+
 Paramaterized test suite DetectNotInstantiatedTest is defined via TEST_P, but never instantiated. None of the test cases will run. Either no INSTANTIATE_TEST_SUITE_P is provided or the only ones provided expand to nothing.
 
 Ideally, TEST_P definitions should only ever be included as part of binaries that intend to use them. (As opposed to, for example, being placed in a library that may be linked in to get other utilities.)
@@ -1000,8 +1006,12 @@ Ideally, TEST_P definitions should only ever be included as part of binaries tha
 To suppress this error for this test suite, insert the following line (in a non-header) in the namespace it is defined in:
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(DetectNotInstantiatedTest);
-[0;32m[       OK ] [mGoogleTestVerification.UninstantiatedParamaterizedTestSuite<DetectNotInstantiatedTest>
+Stack trace: (omitted)
+
+[0;31m[  FAILED  ] [mGoogleTestVerification.UninstantiatedParamaterizedTestSuite<DetectNotInstantiatedTest>
 [0;32m[ RUN      ] [mGoogleTestVerification.UninstantiatedTypeParamaterizedTestSuite<DetectNotInstantiatedTypesTest>
+googletest-output-test_.cc:#: Failure
+
 Type paramaterized test suite DetectNotInstantiatedTypesTest is defined via REGISTER_TYPED_TEST_SUITE_P, but never instantiated via INSTANTIATE_TYPED_TEST_SUITE_P. None of the test cases will run.
 
 Ideally, TYPED_TEST_P definitions should only ever be included as part of binaries that intend to use them. (As opposed to, for example, being placed in a library that may be linked in to get other utilities.)
@@ -1009,7 +1019,9 @@ Ideally, TYPED_TEST_P definitions should only ever be included as part of binari
 To suppress this error for this test suite, insert the following line (in a non-header) in the namespace it is definedin in:
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(DetectNotInstantiatedTypesTest);
-[0;32m[       OK ] [mGoogleTestVerification.UninstantiatedTypeParamaterizedTestSuite<DetectNotInstantiatedTypesTest>
+Stack trace: (omitted)
+
+[0;31m[  FAILED  ] [mGoogleTestVerification.UninstantiatedTypeParamaterizedTestSuite<DetectNotInstantiatedTypesTest>
 [0;32m[----------] [mGlobal test environment tear-down
 BarEnvironment::TearDown() called.
 googletest-output-test_.cc:#: Failure
@@ -1024,8 +1036,8 @@ Expected fatal failure.
 Stack trace: (omitted)
 
 [0;32m[==========] [m88 tests from 41 test suites ran.
-[0;32m[  PASSED  ] [m34 tests.
-[0;31m[  FAILED  ] [m54 tests, listed below:
+[0;32m[  PASSED  ] [m31 tests.
+[0;31m[  FAILED  ] [m57 tests, listed below:
 [0;31m[  FAILED  ] [mNonfatalFailureTest.EscapesStringOperands
 [0;31m[  FAILED  ] [mNonfatalFailureTest.DiffForLongStrings
 [0;31m[  FAILED  ] [mFatalFailureTest.FatalFailureInSubroutine
@@ -1080,8 +1092,11 @@ Stack trace: (omitted)
 [0;31m[  FAILED  ] [mBadDynamicFixture2.Derived
 [0;31m[  FAILED  ] [mPrintingFailingParams/FailingParamTest.Fails/0, where GetParam() = 2
 [0;31m[  FAILED  ] [mPrintingStrings/ParamTest.Failure/a, where GetParam() = "a"
+[0;31m[  FAILED  ] [mGoogleTestVerification.UninstantiatedParamaterizedTestSuite<NoTests>
+[0;31m[  FAILED  ] [mGoogleTestVerification.UninstantiatedParamaterizedTestSuite<DetectNotInstantiatedTest>
+[0;31m[  FAILED  ] [mGoogleTestVerification.UninstantiatedTypeParamaterizedTestSuite<DetectNotInstantiatedTypesTest>
 
-54 FAILED TESTS
+57 FAILED TESTS
 [0;33m  YOU HAVE 1 DISABLED TEST
 
 [mNote: Google Test filter = FatalFailureTest.*:LoggingTest.*


### PR DESCRIPTION
This will start reporting missing instantiations of parameterized tests as a failing test under the GoogleTestVerification test suite (they are currently reported, but just as a notice from a passing test).

NOTE: It is expected that this will surface existing issues in downstream consumers.