### PR TITLE
Introduce `EXPECT(...)` API to gtest

### DIFF
--- a/googletest/CONTRIBUTORS
+++ b/googletest/CONTRIBUTORS
@@ -32,6 +32,7 @@ Russ Cox <rsc@google.com>
 Russ Rufer <russ@pentad.com>
 Sean Mcafee <eefacm@gmail.com>
 Sigurður Ásgeirsson <siggi@google.com>
+Tianjiao Yin <ytj000@gmail.com>
 Tracy Bialik <tracy@pentad.com>
 Vadim Berman <vadimb@google.com>
 Vlad Losev <vladl@google.com>


### PR DESCRIPTION
Usually we use `EXPECT_EQ(a, b)`, `EXPECT_GE(a, b)` to check assertions `a == b`, `a >= b`. I am proposing EXPECT(expr) that’s more consistent with the assertions. Basically `EXPECT(expr)` will be translated to corresponding gtest API like this:

* `EXPECT(val1 == val2)` ==> `EXPECT_EQ(val1, val2)`
* `EXPECT(val1 != val2)` ==> `EXPECT_NE(val1, val2)`
* `EXPECT(val1 <  val2)` ==> `EXPECT_LT(val1, val2)`
* `EXPECT(val1 <= val2)` ==> `EXPECT_LE(val1, val2)`
* `EXPECT(val1 >  val2)` ==> `EXPECT_GT(val1, val2)`
* `EXPECT(val1 >= val2)` ==> `EXPECT_GE(val1, val2)`
* `EXPECT(condition)`    ==> `EXPECT_TRUE(condition)`

For example

    TEST(Test, Example) {
      int a = 2, b = 5;
      EXPECT_GE(a + a, b);
      EXPECT(a + a >= b);
      EXPECT_TRUE(a + a >= b);
    }

This test case prints following error message

    test/Testing.cpp:11: Failure
    Expected: (a + a) >= (b), actual: 4 vs 5
    test/Testing.cpp:12: Failure
    Expected: a + a >= b, actual: 4 vs 5
    test/Testing.cpp:13: Failure
    Value of: a + a >= b
      Actual: false
    Expected: true

Currently C++17 is required for this macro. It is tested in GCC 9.2

    $ cmake -Dgtest_build_tests=ON -DCMAKE_CXX_FLAGS="-std=c++17" <gtest_dir>
    $ make -j48 && make test

If people feel this is a good idea, I can port to C++11 and add more unit-test in separate commit. 
In case there is correctness concern, I will use code generator to generate random expression and test whether the evaluation result is unchanged.

P.S. Features and comparison table:

1) `EXPECT(a == b)` shows value of `a` and `b` if assertion failed
2) `EXPECT(a || b && c)` is supported and has short circuit evaluation.
   By Comparison, `BOOST_TEST(a || b)` and `CHECK(a || b)` (from catch2)
   fails to compile
3) `EXPECT(x ? y : z)` is supported
4) `EXPECT(x = vector<int>{1,2})` is supported
5) If `expr` is constexpr, assertion will be tested at compile-time.

| Macro Name          | EXPECT | EXPECT_TRUE | CHECK (catch2) | BOOST_TEST |
|---------------------|--------|-------------|----------------|------------|
| Show failure reason | Yes    | No          | Yes            | Yes        |
| Support (A \|\| B)    | Yes    | Yes         | No             | No         |
| Support ?:          | Yes    | Yes         | ?              | No         |
| Support ','         | Yes    | No          | Yes            | No         |
| Compile-time test   | Yes    | No          | No             | No         |
