### PR TITLE
fix a link to documentation

### DIFF
--- a/googletest/docs/primer.md
+++ b/googletest/docs/primer.md
@@ -169,7 +169,7 @@ you'll get a compiler error. We used to require the arguments to support the
 `<<` is supported, it will be called to print the arguments when the assertion
 fails; otherwise googletest will attempt to print them in the best way it can.
 For more details and how to customize the printing of the arguments, see the
-[documentation](../../googlemock/docs/cook_book.md#teaching-gmock-how-to-print-your-values).
+[documentation](./advanced.md#teaching-googletest-how-to-print-your-values).
 
 These assertions can work with a user-defined type, but only if you define the
 corresponding comparison operator (e.g., `==` or `<`). Since this is discouraged


### PR DESCRIPTION
fix a documentation link on "how to customize the printing of the arguments"