### PR TITLE
Remove a duplicated include

### DIFF
--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -111,10 +111,6 @@
 #include "gtest/internal/gtest-internal.h"
 #include "gtest/internal/gtest-port.h"
 
-#if GTEST_HAS_ABSL
-#include "absl/strings/string_view.h"
-#endif  // GTEST_HAS_ABSL
-
 namespace testing {
 
 // Definitions in the internal* namespaces are subject to change without notice.


### PR DESCRIPTION
Detection of string_view type (whether it's std or Abseil) is done in googletest/include/gtest/internal/gtest-port.h with GTEST_INTERNAL_HAS_STRING_VIEW.