### PR TITLE
Fix GetFailureReporter() memory leak

### DIFF
--- a/googlemock/src/gmock-internal-utils.cc
+++ b/googlemock/src/gmock-internal-utils.cc
@@ -115,9 +115,8 @@ GTEST_API_ FailureReporterInterface* GetFailureReporter() {
   // thread-safe.  We may need to add additional synchronization to
   // protect failure_reporter if we port Google Mock to other
   // compilers.
-  static FailureReporterInterface* const failure_reporter =
-      new GoogleTestFailureReporter();
-  return failure_reporter;
+  static GoogleTestFailureReporter failure_reporter;
+  return &failure_reporter;
 }
 
 // Protects global resources (stdout in particular) used by Log().

--- a/googlemock/src/gmock-internal-utils.cc
+++ b/googlemock/src/gmock-internal-utils.cc
@@ -110,11 +110,6 @@ class GoogleTestFailureReporter : public FailureReporterInterface {
 // Returns the global failure reporter.  Will create a
 // GoogleTestFailureReporter and return it the first time called.
 GTEST_API_ FailureReporterInterface* GetFailureReporter() {
-  // Points to the global failure reporter used by Google Mock.  gcc
-  // guarantees that the following use of failure_reporter is
-  // thread-safe.  We may need to add additional synchronization to
-  // protect failure_reporter if we port Google Mock to other
-  // compilers.
   static GoogleTestFailureReporter failure_reporter;
   return &failure_reporter;
 }


### PR DESCRIPTION
Failing code:
```c++
#include "gmock/gmock.h"
#include "gtest/gtest.h"

class MyMock {
public:
    MOCK_METHOD(void, my_function, (char const*), ());
};

TEST(MyTest, Leak) {
    MyMock my_mock;

    EXPECT_CALL(my_mock, my_function("LEAK"));
    // unsatisfied expectation will cause a memory leak
}
```
---
I changed the implementation to Meyer's singleton so it's better than it was, though I'm not very happy with it. Feel free to propose sth.