### PR TITLE
add CMAKE_CXX_STANDARD to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,18 +11,13 @@ project(googletest-distribution)
 set(GOOGLETEST_VERSION 1.10.0)
 
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.1")
-    set(CMAKE_CXX_STANDARD 11)
-    set(CMAKE_CXX_STANDARD_REQUIRED OFF)
-endif()
-
-if(WIN32)
-  if(MSVC)
-    if(MSVC_TOOLSET_VERSION EQUAL 140 OR MSVC_TOOLSET_VERSION EQUAL 141)
-      # there is a bug reported on https://developercommunity.visualstudio.com/content/problem/9696/c17-not-available-by-default.html
-      # string_view is not available unless we use the /std:c++latest switch
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++latest")
+    if(NOT CYGWIN AND NOT MSYS)
+      set(CMAKE_CXX_EXTENSIONS OFF)
+      if(APPLE)
+        set(CMAKE_CXX_STANDARD 11)
+        set(CMAKE_CXX_STANDARD_REQUIRED OFF)
+      endif()
     endif()
-  endif()
 endif()
 
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,17 @@ project(googletest-distribution)
 set(GOOGLETEST_VERSION 1.10.0)
 
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.1")
-  if(NOT CYGWIN AND NOT MSYS)
-    set(CMAKE_CXX_EXTENSIONS OFF)
+    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_STANDARD_REQUIRED OFF)
+endif()
+
+if(WIN32)
+  if(MSVC)
+    if(MSVC_TOOLSET_VERSION EQUAL 140 OR MSVC_TOOLSET_VERSION EQUAL 141)
+      # there is a bug reported on https://developercommunity.visualstudio.com/content/problem/9696/c17-not-available-by-default.html
+      # string_view is not available unless we use the /std:c++latest switch
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++latest")
+    endif()
   endif()
 endif()
 

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -2234,21 +2234,38 @@ using StringView = ::absl::string_view;
 }  // namespace internal
 }  // namespace testing
 #else
-# ifdef __has_include
-#   if __has_include(<string_view>) && __cplusplus >= 201703L
-// Otherwise for C++17 and higher use std::string_view for Matcher<>
-// specializations.
-#   define GTEST_INTERNAL_HAS_STRING_VIEW 1
-#include <string_view>
-namespace testing {
-namespace internal {
-using StringView = ::std::string_view;
-}  // namespace internal
-}  // namespace testing
-// The case where absl is configured NOT to alias std::string_view is not
-// supported.
-#  endif  // __has_include(<string_view>) && __cplusplus >= 201703L
-# endif  // __has_include
+  #ifdef __has_include
+    #if __has_include(<string_view>) && __cplusplus > 201402L
+    // Otherwise for C++17 and higher use std::string_view for Matcher<>
+    // specializations.
+    #   define GTEST_INTERNAL_HAS_STRING_VIEW 1
+    #include <string_view>
+    namespace testing {
+    namespace internal {
+    using StringView = ::std::string_view;
+    }  // namespace internal
+    }  // namespace testing
+    // The case where absl is configured NOT to alias std::string_view is not
+    // supported.
+    #  endif  // __has_include(<string_view>) && __cplusplus > 201402L
+  #else 
+    // well, what if __has_include is not supported by the compiler ? that may be the case with older msvc ?
+    // it might not make sense to actually check for that, since string_view is available from c++17
+    // but uh, let me fix msvc tests for now
+    #if __cplusplus > 201402L
+    // Otherwise for C++17 and higher use std::string_view for Matcher<>
+    // specializations.
+    #   define GTEST_INTERNAL_HAS_STRING_VIEW 1
+    #include <string_view>
+    namespace testing {
+    namespace internal {
+    using StringView = ::std::string_view;
+    }  // namespace internal
+    }  // namespace testing
+    // The case where absl is configured NOT to alias std::string_view is not
+    // supported.
+    #endif
+  # endif  // __has_include
 #endif  // GTEST_HAS_ABSL
 
 #endif  // GTEST_INCLUDE_GTEST_INTERNAL_GTEST_PORT_H_


### PR DESCRIPTION
this fixes errors related to enabling C++11 like `no member named 'make_tuple' in namespace 'std'` and like `deleted function definitions are a C++11 extension` in
googletest/googletest/include/gtest/internal/gtest-port.h

I can see there was a modification in #2706 which probably broke things lately