### PR TITLE
Add the last expectation's retirement in Sequence

### DIFF
--- a/googlemock/src/gmock-spec-builders.cc
+++ b/googlemock/src/gmock-spec-builders.cc
@@ -127,6 +127,7 @@ void ExpectationBase::RetireAllPreRequisites()
         expectations.push_back(next);
       }
     }
+    retires_on_saturation_ = true;
   }
 }
 

--- a/googlemock/test/gmock-spec-builders_test.cc
+++ b/googlemock/test/gmock-spec-builders_test.cc
@@ -1284,7 +1284,7 @@ TEST(InSequenceTest, NestedInSequence) {
   a.DoA(3);
 }
 
-TEST(InSequenceTest, ExpectationsOutOfScopeAreNotAffected) {
+TEST(InSequenceTest, ExpectationsOutOfScopeAreNotAffected1) {
   MockA a;
   {
     InSequence dummy;
@@ -1293,6 +1293,24 @@ TEST(InSequenceTest, ExpectationsOutOfScopeAreNotAffected) {
     EXPECT_CALL(a, DoA(2));
   }
   EXPECT_CALL(a, DoA(3));
+
+  EXPECT_NONFATAL_FAILURE({  // NOLINT
+    a.DoA(2);
+  }, "Unexpected mock function call");
+  a.DoA(3);
+  a.DoA(1);
+  a.DoA(2);
+}
+
+TEST(InSequenceTest, ExpectationsOutOfScopeAreNotAffected2) {
+  MockA a;
+  EXPECT_CALL(a, DoA(3));
+  {
+    InSequence dummy;
+
+    EXPECT_CALL(a, DoA(1));
+    EXPECT_CALL(a, DoA(2));
+  }
 
   EXPECT_NONFATAL_FAILURE({  // NOLINT
     a.DoA(2);
@@ -1459,6 +1477,28 @@ TEST(SequenceTest, Retirement) {
   a.DoA(1);
   a.DoA(2);
   a.DoA(1);
+}
+
+TEST(SequenceTest, RetirementLastExpectationInSequence) {
+  MockA a;
+  Sequence s;
+
+  EXPECT_CALL(a, DoA(_))
+      .Times(AnyNumber());
+
+  EXPECT_CALL(a, DoA(1))
+      .InSequence(s);
+  EXPECT_CALL(a, DoA(_))
+      .InSequence(s)
+      .RetiresOnSaturation();
+  EXPECT_CALL(a, DoA(1))
+      .InSequence(s);
+
+  a.DoA(1);
+  a.DoA(2);
+  a.DoA(1);
+  a.DoA(1);
+  a.DoA(2);
 }
 
 // Tests Expectation.


### PR DESCRIPTION
This pull request is adding last expectation's retirement in a sequence
to make expectations above sequences work

If this is a good approach I or someone else can go further 
(please refer to issue https://github.com/google/googletest/issues/2744)