### PR TITLE
Add the last expectation's retirement in Sequence

### DIFF
--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -1217,6 +1217,10 @@ class TypedExpectation : public ExpectationBase {
       Retire();
     }
 
+    if (immediate_prerequisites_.size() > 0 && AllPrerequisitesAreSatisfied() && IsSaturated()) {
+      Retire();
+    }
+
     // Must be done after IncrementCount()!
     *what << "Mock function call matches " << source_text() <<"...\n";
     return &(GetCurrentAction(mocker, args));

--- a/googlemock/test/gmock-spec-builders_test.cc
+++ b/googlemock/test/gmock-spec-builders_test.cc
@@ -1284,7 +1284,7 @@ TEST(InSequenceTest, NestedInSequence) {
   a.DoA(3);
 }
 
-TEST(InSequenceTest, ExpectationsOutOfScopeAreNotAffected) {
+TEST(InSequenceTest, ExpectationsOutOfScopeAreNotAffected1) {
   MockA a;
   {
     InSequence dummy;
@@ -1293,6 +1293,24 @@ TEST(InSequenceTest, ExpectationsOutOfScopeAreNotAffected) {
     EXPECT_CALL(a, DoA(2));
   }
   EXPECT_CALL(a, DoA(3));
+
+  EXPECT_NONFATAL_FAILURE({  // NOLINT
+    a.DoA(2);
+  }, "Unexpected mock function call");
+  a.DoA(3);
+  a.DoA(1);
+  a.DoA(2);
+}
+
+TEST(InSequenceTest, ExpectationsOutOfScopeAreNotAffected2) {
+  MockA a;
+  EXPECT_CALL(a, DoA(3));
+  {
+    InSequence dummy;
+
+    EXPECT_CALL(a, DoA(1));
+    EXPECT_CALL(a, DoA(2));
+  }
 
   EXPECT_NONFATAL_FAILURE({  // NOLINT
     a.DoA(2);
@@ -1459,6 +1477,28 @@ TEST(SequenceTest, Retirement) {
   a.DoA(1);
   a.DoA(2);
   a.DoA(1);
+}
+
+TEST(SequenceTest, RetirementLastExpectationInSequence) {
+  MockA a;
+  Sequence s;
+
+  EXPECT_CALL(a, DoA(_))
+      .Times(AnyNumber());
+
+  EXPECT_CALL(a, DoA(1))
+      .InSequence(s);
+  EXPECT_CALL(a, DoA(_))
+      .InSequence(s)
+      .RetiresOnSaturation();
+  EXPECT_CALL(a, DoA(1))
+      .InSequence(s);
+
+  a.DoA(1);
+  a.DoA(2);
+  a.DoA(1);
+  a.DoA(1);
+  a.DoA(2);
 }
 
 // Tests Expectation.


### PR DESCRIPTION
This pull request is adding last expectation's retirement in a sequence
to make expectations above sequences work
(please refer to issue #2744)