### PR TITLE
Ensure that gtest/gmock pkgconfig requirements specify version

### DIFF
--- a/googlemock/cmake/gmock.pc.in
+++ b/googlemock/cmake/gmock.pc.in
@@ -5,6 +5,6 @@ Name: gmock
 Description: GoogleMock (without main() function)
 Version: @PROJECT_VERSION@
 URL: https://github.com/google/googletest
-Requires: gtest
+Requires: gtest = @PROJECT_VERSION@
 Libs: -L${libdir} -lgmock @CMAKE_THREAD_LIBS_INIT@
 Cflags: -I${includedir} @GTEST_HAS_PTHREAD_MACRO@

--- a/googlemock/cmake/gmock_main.pc.in
+++ b/googlemock/cmake/gmock_main.pc.in
@@ -5,6 +5,6 @@ Name: gmock_main
 Description: GoogleMock (with main() function)
 Version: @PROJECT_VERSION@
 URL: https://github.com/google/googletest
-Requires: gmock
+Requires: gmock = @PROJECT_VERSION@
 Libs: -L${libdir} -lgmock_main @CMAKE_THREAD_LIBS_INIT@
 Cflags: -I${includedir} @GTEST_HAS_PTHREAD_MACRO@

--- a/googletest/cmake/gtest_main.pc.in
+++ b/googletest/cmake/gtest_main.pc.in
@@ -5,6 +5,6 @@ Name: gtest_main
 Description: GoogleTest (with main() function)
 Version: @PROJECT_VERSION@
 URL: https://github.com/google/googletest
-Requires: gtest
+Requires: gtest = @PROJECT_VERSION@
 Libs: -L${libdir} -lgtest_main @CMAKE_THREAD_LIBS_INIT@
 Cflags: -I${includedir} @GTEST_HAS_PTHREAD_MACRO@


### PR DESCRIPTION
Google Test and Google Mock require matching versions to work,
so this requirement should be described in the pkgconfig files.

This change is derived from the one used for the Fedora gtest package.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>