### PR TITLE
Fix Clang's `-Wdeprecated-copy` warnings in C++20

### DIFF
--- a/googlemock/include/gmock/gmock-actions.h
+++ b/googlemock/include/gmock/gmock-actions.h
@@ -571,12 +571,12 @@ class PolymorphicAction {
    private:
     Impl impl_;
 
-    GTEST_DISALLOW_ASSIGN_(MonomorphicImpl);
+    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(MonomorphicImpl);
   };
 
   Impl impl_;
 
-  GTEST_DISALLOW_ASSIGN_(PolymorphicAction);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(PolymorphicAction);
 };
 
 // Creates an Action from its implementation and returns it.  The
@@ -718,12 +718,12 @@ class ReturnAction {
     bool performed_;
     const std::shared_ptr<R> wrapper_;
 
-    GTEST_DISALLOW_ASSIGN_(Impl);
+    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
   const std::shared_ptr<R> value_;
 
-  GTEST_DISALLOW_ASSIGN_(ReturnAction);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(ReturnAction);
 };
 
 // Implements the ReturnNull() action.
@@ -785,12 +785,12 @@ class ReturnRefAction {
    private:
     T& ref_;
 
-    GTEST_DISALLOW_ASSIGN_(Impl);
+    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
   T& ref_;
 
-  GTEST_DISALLOW_ASSIGN_(ReturnRefAction);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(ReturnRefAction);
 };
 
 // Implements the polymorphic ReturnRefOfCopy(x) action, which can be
@@ -832,12 +832,12 @@ class ReturnRefOfCopyAction {
    private:
     T value_;
 
-    GTEST_DISALLOW_ASSIGN_(Impl);
+    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
   const T value_;
 
-  GTEST_DISALLOW_ASSIGN_(ReturnRefOfCopyAction);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(ReturnRefOfCopyAction);
 };
 
 // Implements the polymorphic ReturnRoundRobin(v) action, which can be
@@ -895,7 +895,7 @@ class AssignAction {
   T1* const ptr_;
   const T2 value_;
 
-  GTEST_DISALLOW_ASSIGN_(AssignAction);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(AssignAction);
 };
 
 #if !GTEST_OS_WINDOWS_MOBILE
@@ -918,7 +918,7 @@ class SetErrnoAndReturnAction {
   const int errno_;
   const T result_;
 
-  GTEST_DISALLOW_ASSIGN_(SetErrnoAndReturnAction);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(SetErrnoAndReturnAction);
 };
 
 #endif  // !GTEST_OS_WINDOWS_MOBILE
@@ -1024,12 +1024,12 @@ class IgnoreResultAction {
 
     const Action<OriginalFunction> action_;
 
-    GTEST_DISALLOW_ASSIGN_(Impl);
+    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
   const A action_;
 
-  GTEST_DISALLOW_ASSIGN_(IgnoreResultAction);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(IgnoreResultAction);
 };
 
 template <typename InnerAction, size_t... I>
@@ -1468,11 +1468,11 @@ auto InvokeArgumentAdl(AdlTag, F f, Args... args) -> decltype(f(args...)) {
       GMOCK_ACTION_FIELD_PARAMS_(params)                                      \
                                                                               \
      private:                                                                 \
-      GTEST_DISALLOW_ASSIGN_(gmock_Impl);                                     \
+      GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(gmock_Impl);                                     \
     };                                                                        \
                                                                               \
    private:                                                                   \
-    GTEST_DISALLOW_ASSIGN_(full_name);                                        \
+    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(full_name);                                        \
   };                                                                          \
   template <GMOCK_ACTION_TYPENAME_PARAMS_(params)>                            \
   inline full_name<GMOCK_ACTION_TYPE_PARAMS_(params)> name(                   \
@@ -1511,13 +1511,7 @@ auto InvokeArgumentAdl(AdlTag, F f, Args... args) -> decltype(f(args...)) {
       }                                                                       \
       template <GMOCK_ACTION_TEMPLATE_ARGS_NAMES_>                            \
       return_type gmock_PerformImpl(GMOCK_ACTION_ARG_TYPES_AND_NAMES_) const; \
-                                                                              \
-     private:                                                                 \
-      GTEST_DISALLOW_ASSIGN_(gmock_Impl);                                     \
     };                                                                        \
-                                                                              \
-   private:                                                                   \
-    GTEST_DISALLOW_ASSIGN_(name##Action);                                     \
   };                                                                          \
   inline name##Action name() { return name##Action(); }                       \
   template <typename F>                                                       \

--- a/googlemock/include/gmock/gmock-actions.h
+++ b/googlemock/include/gmock/gmock-actions.h
@@ -717,13 +717,9 @@ class ReturnAction {
    private:
     bool performed_;
     const std::shared_ptr<R> wrapper_;
-
-    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
   const std::shared_ptr<R> value_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(ReturnAction);
 };
 
 // Implements the ReturnNull() action.
@@ -784,13 +780,9 @@ class ReturnRefAction {
 
    private:
     T& ref_;
-
-    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
   T& ref_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(ReturnRefAction);
 };
 
 // Implements the polymorphic ReturnRefOfCopy(x) action, which can be
@@ -836,8 +828,6 @@ class ReturnRefOfCopyAction {
   };
 
   const T value_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(ReturnRefOfCopyAction);
 };
 
 // Implements the polymorphic ReturnRoundRobin(v) action, which can be
@@ -894,8 +884,6 @@ class AssignAction {
  private:
   T1* const ptr_;
   const T2 value_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(AssignAction);
 };
 
 #if !GTEST_OS_WINDOWS_MOBILE
@@ -917,8 +905,6 @@ class SetErrnoAndReturnAction {
  private:
   const int errno_;
   const T result_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(SetErrnoAndReturnAction);
 };
 
 #endif  // !GTEST_OS_WINDOWS_MOBILE
@@ -1023,13 +1009,9 @@ class IgnoreResultAction {
         OriginalFunction;
 
     const Action<OriginalFunction> action_;
-
-    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
   const A action_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(IgnoreResultAction);
 };
 
 template <typename InnerAction, size_t... I>

--- a/googlemock/include/gmock/gmock-generated-actions.h
+++ b/googlemock/include/gmock/gmock-generated-actions.h
@@ -435,16 +435,12 @@
       template <GMOCK_ACTION_TEMPLATE_ARGS_NAMES_>\
       return_type gmock_PerformImpl(GMOCK_ACTION_ARG_TYPES_AND_NAMES_) const;\
       GMOCK_INTERNAL_DEFN_##value_params\
-     private:\
-      GTEST_DISALLOW_ASSIGN_(gmock_Impl);\
     };\
     template <typename F> operator ::testing::Action<F>() const {\
       return ::testing::Action<F>(\
           new gmock_Impl<F>(GMOCK_INTERNAL_LIST_##value_params));\
     }\
     GMOCK_INTERNAL_DEFN_##value_params\
-   private:\
-    GTEST_DISALLOW_ASSIGN_(GMOCK_ACTION_CLASS_(name, value_params));\
   };\
   template <GMOCK_INTERNAL_DECL_##template_params\
             GMOCK_INTERNAL_DECL_TYPE_##value_params>\

--- a/googlemock/include/gmock/gmock-generated-actions.h.pump
+++ b/googlemock/include/gmock/gmock-generated-actions.h.pump
@@ -254,7 +254,7 @@ $range k 0..n-1
       return_type gmock_PerformImpl(GMOCK_ACTION_ARG_TYPES_AND_NAMES_) const;\
       GMOCK_INTERNAL_DEFN_##value_params\
      private:\
-      GTEST_DISALLOW_ASSIGN_(gmock_Impl);\
+      GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(gmock_Impl);\
     };\
     template <typename F> operator ::testing::Action<F>() const {\
       return ::testing::Action<F>(\
@@ -262,7 +262,7 @@ $range k 0..n-1
     }\
     GMOCK_INTERNAL_DEFN_##value_params\
    private:\
-    GTEST_DISALLOW_ASSIGN_(GMOCK_ACTION_CLASS_(name, value_params));\
+    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(GMOCK_ACTION_CLASS_(name, value_params));\
   };\
   template <GMOCK_INTERNAL_DECL_##template_params\
             GMOCK_INTERNAL_DECL_TYPE_##value_params>\

--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -445,7 +445,7 @@ class MatcherCastImpl<T, Matcher<U> > {
    private:
     const Matcher<U> source_matcher_;
 
-    GTEST_DISALLOW_ASSIGN_(Impl);
+    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 };
 
@@ -862,12 +862,12 @@ class RefMatcher<T&> {
    private:
     const Super& object_;
 
-    GTEST_DISALLOW_ASSIGN_(Impl);
+    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
   T& object_;
 
-  GTEST_DISALLOW_ASSIGN_(RefMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(RefMatcher);
 };
 
 // Polymorphic helper functions for narrow and wide string matchers.
@@ -971,7 +971,7 @@ class StrEqualityMatcher {
   const bool expect_eq_;
   const bool case_sensitive_;
 
-  GTEST_DISALLOW_ASSIGN_(StrEqualityMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(StrEqualityMatcher);
 };
 
 // Implements the polymorphic HasSubstr(substring) matcher, which
@@ -1027,7 +1027,7 @@ class HasSubstrMatcher {
  private:
   const StringType substring_;
 
-  GTEST_DISALLOW_ASSIGN_(HasSubstrMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(HasSubstrMatcher);
 };
 
 // Implements the polymorphic StartsWith(substring) matcher, which
@@ -1084,7 +1084,7 @@ class StartsWithMatcher {
  private:
   const StringType prefix_;
 
-  GTEST_DISALLOW_ASSIGN_(StartsWithMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(StartsWithMatcher);
 };
 
 // Implements the polymorphic EndsWith(substring) matcher, which
@@ -1140,7 +1140,7 @@ class EndsWithMatcher {
  private:
   const StringType suffix_;
 
-  GTEST_DISALLOW_ASSIGN_(EndsWithMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(EndsWithMatcher);
 };
 
 // Implements a matcher that compares the two fields of a 2-tuple
@@ -1235,7 +1235,7 @@ class NotMatcherImpl : public MatcherInterface<const T&> {
  private:
   const Matcher<T> matcher_;
 
-  GTEST_DISALLOW_ASSIGN_(NotMatcherImpl);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(NotMatcherImpl);
 };
 
 // Implements the Not(m) matcher, which matches a value that doesn't
@@ -1255,7 +1255,7 @@ class NotMatcher {
  private:
   InnerMatcher matcher_;
 
-  GTEST_DISALLOW_ASSIGN_(NotMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(NotMatcher);
 };
 
 // Implements the AllOf(m1, m2) matcher for a particular argument type
@@ -1318,7 +1318,7 @@ class AllOfMatcherImpl : public MatcherInterface<const T&> {
  private:
   const std::vector<Matcher<T> > matchers_;
 
-  GTEST_DISALLOW_ASSIGN_(AllOfMatcherImpl);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(AllOfMatcherImpl);
 };
 
 // VariadicMatcher is used for the variadic implementation of
@@ -1358,7 +1358,7 @@ class VariadicMatcher {
 
   std::tuple<Args...> matchers_;
 
-  GTEST_DISALLOW_ASSIGN_(VariadicMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(VariadicMatcher);
 };
 
 template <typename... Args>
@@ -1424,7 +1424,7 @@ class AnyOfMatcherImpl : public MatcherInterface<const T&> {
  private:
   const std::vector<Matcher<T> > matchers_;
 
-  GTEST_DISALLOW_ASSIGN_(AnyOfMatcherImpl);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(AnyOfMatcherImpl);
 };
 
 // AnyOfMatcher is used for the variadic implementation of AnyOf(m_1, m_2, ...).
@@ -1453,7 +1453,7 @@ class SomeOfArrayMatcher {
  private:
   const ::std::vector<T> matchers_;
 
-  GTEST_DISALLOW_ASSIGN_(SomeOfArrayMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(SomeOfArrayMatcher);
 };
 
 template <typename T>
@@ -1498,7 +1498,7 @@ class TrulyMatcher {
  private:
   Predicate predicate_;
 
-  GTEST_DISALLOW_ASSIGN_(TrulyMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(TrulyMatcher);
 };
 
 // Used for implementing Matches(matcher), which turns a matcher into
@@ -1536,7 +1536,7 @@ class MatcherAsPredicate {
  private:
   M matcher_;
 
-  GTEST_DISALLOW_ASSIGN_(MatcherAsPredicate);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(MatcherAsPredicate);
 };
 
 // For implementing ASSERT_THAT() and EXPECT_THAT().  The template
@@ -1588,7 +1588,7 @@ class PredicateFormatterFromMatcher {
  private:
   const M matcher_;
 
-  GTEST_DISALLOW_ASSIGN_(PredicateFormatterFromMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(PredicateFormatterFromMatcher);
 };
 
 // A helper function for converting a matcher to a predicate-formatter
@@ -1741,7 +1741,7 @@ class FloatingEqMatcher {
     // max_abs_error will be used for value comparison when >= 0.
     const FloatType max_abs_error_;
 
-    GTEST_DISALLOW_ASSIGN_(Impl);
+    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
   // The following 3 type conversion operators allow FloatEq(expected) and
@@ -1771,7 +1771,7 @@ class FloatingEqMatcher {
   // max_abs_error will be used for value comparison when >= 0.
   const FloatType max_abs_error_;
 
-  GTEST_DISALLOW_ASSIGN_(FloatingEqMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(FloatingEqMatcher);
 };
 
 // A 2-tuple ("binary") wrapper around FloatingEqMatcher:
@@ -1902,12 +1902,12 @@ class PointeeMatcher {
    private:
     const Matcher<const Pointee&> matcher_;
 
-    GTEST_DISALLOW_ASSIGN_(Impl);
+    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
   const InnerMatcher matcher_;
 
-  GTEST_DISALLOW_ASSIGN_(PointeeMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(PointeeMatcher);
 };
 
 #if GTEST_HAS_RTTI
@@ -1945,7 +1945,7 @@ class WhenDynamicCastToMatcherBase {
     *os << "when dynamic_cast to " << GetToName() << ", ";
   }
 
-  GTEST_DISALLOW_ASSIGN_(WhenDynamicCastToMatcherBase);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(WhenDynamicCastToMatcherBase);
 };
 
 // Primary template.
@@ -2044,7 +2044,7 @@ class FieldMatcher {
   // or "whose field `name_of_field` " if the name is known.
   const std::string whose_field_;
 
-  GTEST_DISALLOW_ASSIGN_(FieldMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(FieldMatcher);
 };
 
 // Implements the Property() matcher for matching a property
@@ -2114,7 +2114,7 @@ class PropertyMatcher {
   // unknown or "whose property `name_of_property` " if the name is known.
   const std::string whose_property_;
 
-  GTEST_DISALLOW_ASSIGN_(PropertyMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(PropertyMatcher);
 };
 
 // Type traits specifying various features of different functors for ResultOf.
@@ -2205,13 +2205,13 @@ class ResultOfMatcher {
     mutable CallableStorageType callable_;
     const Matcher<ResultType> matcher_;
 
-    GTEST_DISALLOW_ASSIGN_(Impl);
+    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };  // class Impl
 
   const CallableStorageType callable_;
   const InnerMatcher matcher_;
 
-  GTEST_DISALLOW_ASSIGN_(ResultOfMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(ResultOfMatcher);
 };
 
 // Implements a matcher that checks the size of an STL-style container.
@@ -2256,12 +2256,12 @@ class SizeIsMatcher {
 
    private:
     const Matcher<SizeType> size_matcher_;
-    GTEST_DISALLOW_ASSIGN_(Impl);
+    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
  private:
   const SizeMatcher size_matcher_;
-  GTEST_DISALLOW_ASSIGN_(SizeIsMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(SizeIsMatcher);
 };
 
 // Implements a matcher that checks the begin()..end() distance of an STL-style
@@ -2313,12 +2313,12 @@ class BeginEndDistanceIsMatcher {
 
    private:
     const Matcher<DistanceType> distance_matcher_;
-    GTEST_DISALLOW_ASSIGN_(Impl);
+    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
  private:
   const DistanceMatcher distance_matcher_;
-  GTEST_DISALLOW_ASSIGN_(BeginEndDistanceIsMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(BeginEndDistanceIsMatcher);
 };
 
 // Implements an equality matcher for any STL-style container whose elements
@@ -2412,7 +2412,7 @@ class ContainerEqMatcher {
  private:
   const StlContainer expected_;
 
-  GTEST_DISALLOW_ASSIGN_(ContainerEqMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(ContainerEqMatcher);
 };
 
 // A comparator functor that uses the < operator to compare two values.
@@ -2495,7 +2495,7 @@ class WhenSortedByMatcher {
   const Comparator comparator_;
   const ContainerMatcher matcher_;
 
-  GTEST_DISALLOW_ASSIGN_(WhenSortedByMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(WhenSortedByMatcher);
 };
 
 // Implements Pointwise(tuple_matcher, rhs_container).  tuple_matcher
@@ -2612,14 +2612,14 @@ class PointwiseMatcher {
     const Matcher<InnerMatcherArg> mono_tuple_matcher_;
     const RhsStlContainer rhs_;
 
-    GTEST_DISALLOW_ASSIGN_(Impl);
+    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
  private:
   const TupleMatcher tuple_matcher_;
   const RhsStlContainer rhs_;
 
-  GTEST_DISALLOW_ASSIGN_(PointwiseMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(PointwiseMatcher);
 };
 
 // Holds the logic common to ContainsMatcherImpl and EachMatcherImpl.
@@ -2663,7 +2663,7 @@ class QuantifierMatcherImpl : public MatcherInterface<Container> {
  protected:
   const Matcher<const Element&> inner_matcher_;
 
-  GTEST_DISALLOW_ASSIGN_(QuantifierMatcherImpl);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(QuantifierMatcherImpl);
 };
 
 // Implements Contains(element_matcher) for the given argument type Container.
@@ -2692,7 +2692,7 @@ class ContainsMatcherImpl : public QuantifierMatcherImpl<Container> {
   }
 
  private:
-  GTEST_DISALLOW_ASSIGN_(ContainsMatcherImpl);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(ContainsMatcherImpl);
 };
 
 // Implements Each(element_matcher) for the given argument type Container.
@@ -2721,7 +2721,7 @@ class EachMatcherImpl : public QuantifierMatcherImpl<Container> {
   }
 
  private:
-  GTEST_DISALLOW_ASSIGN_(EachMatcherImpl);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(EachMatcherImpl);
 };
 
 // Implements polymorphic Contains(element_matcher).
@@ -2739,7 +2739,7 @@ class ContainsMatcher {
  private:
   const M inner_matcher_;
 
-  GTEST_DISALLOW_ASSIGN_(ContainsMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(ContainsMatcher);
 };
 
 // Implements polymorphic Each(element_matcher).
@@ -2757,7 +2757,7 @@ class EachMatcher {
  private:
   const M inner_matcher_;
 
-  GTEST_DISALLOW_ASSIGN_(EachMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(EachMatcher);
 };
 
 struct Rank1 {};
@@ -2829,7 +2829,7 @@ class KeyMatcherImpl : public MatcherInterface<PairType> {
  private:
   const Matcher<const KeyType&> inner_matcher_;
 
-  GTEST_DISALLOW_ASSIGN_(KeyMatcherImpl);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(KeyMatcherImpl);
 };
 
 // Implements polymorphic Key(matcher_for_key).
@@ -2847,7 +2847,7 @@ class KeyMatcher {
  private:
   const M matcher_for_key_;
 
-  GTEST_DISALLOW_ASSIGN_(KeyMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(KeyMatcher);
 };
 
 // Implements Pair(first_matcher, second_matcher) for the given argument pair
@@ -2934,7 +2934,7 @@ class PairMatcherImpl : public MatcherInterface<PairType> {
   const Matcher<const FirstType&> first_matcher_;
   const Matcher<const SecondType&> second_matcher_;
 
-  GTEST_DISALLOW_ASSIGN_(PairMatcherImpl);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(PairMatcherImpl);
 };
 
 // Implements polymorphic Pair(first_matcher, second_matcher).
@@ -2954,7 +2954,7 @@ class PairMatcher {
   const FirstMatcher first_matcher_;
   const SecondMatcher second_matcher_;
 
-  GTEST_DISALLOW_ASSIGN_(PairMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(PairMatcher);
 };
 
 // Implements ElementsAre() and ElementsAreArray().
@@ -3101,7 +3101,7 @@ class ElementsAreMatcherImpl : public MatcherInterface<Container> {
 
   ::std::vector<Matcher<const Element&> > matchers_;
 
-  GTEST_DISALLOW_ASSIGN_(ElementsAreMatcherImpl);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(ElementsAreMatcherImpl);
 };
 
 // Connectivity matrix of (elements X matchers), in element-major order.
@@ -3205,7 +3205,7 @@ class GTEST_API_ UnorderedElementsAreMatcherImplBase {
   UnorderedMatcherRequire::Flags match_flags_;
   MatcherDescriberVec matcher_describers_;
 
-  GTEST_DISALLOW_ASSIGN_(UnorderedElementsAreMatcherImplBase);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(UnorderedElementsAreMatcherImplBase);
 };
 
 // Implements UnorderedElementsAre, UnorderedElementsAreArray, IsSubsetOf, and
@@ -3302,7 +3302,7 @@ class UnorderedElementsAreMatcherImpl
 
   ::std::vector<Matcher<const Element&> > matchers_;
 
-  GTEST_DISALLOW_ASSIGN_(UnorderedElementsAreMatcherImpl);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(UnorderedElementsAreMatcherImpl);
 };
 
 // Functor for use in TransformTuple.
@@ -3340,7 +3340,7 @@ class UnorderedElementsAreMatcher {
 
  private:
   const MatcherTuple matchers_;
-  GTEST_DISALLOW_ASSIGN_(UnorderedElementsAreMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(UnorderedElementsAreMatcher);
 };
 
 // Implements ElementsAre.
@@ -3370,7 +3370,7 @@ class ElementsAreMatcher {
 
  private:
   const MatcherTuple matchers_;
-  GTEST_DISALLOW_ASSIGN_(ElementsAreMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(ElementsAreMatcher);
 };
 
 // Implements UnorderedElementsAreArray(), IsSubsetOf(), and IsSupersetOf().
@@ -3393,7 +3393,7 @@ class UnorderedElementsAreArrayMatcher {
   UnorderedMatcherRequire::Flags match_flags_;
   ::std::vector<T> matchers_;
 
-  GTEST_DISALLOW_ASSIGN_(UnorderedElementsAreArrayMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(UnorderedElementsAreArrayMatcher);
 };
 
 // Implements ElementsAreArray().
@@ -3416,7 +3416,7 @@ class ElementsAreArrayMatcher {
  private:
   const ::std::vector<T> matchers_;
 
-  GTEST_DISALLOW_ASSIGN_(ElementsAreArrayMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(ElementsAreArrayMatcher);
 };
 
 // Given a 2-tuple matcher tm of type Tuple2Matcher and a value second
@@ -3479,7 +3479,7 @@ class BoundSecondMatcher {
     const Matcher<const ArgTuple&> mono_tuple2_matcher_;
     const Second second_value_;
 
-    GTEST_DISALLOW_ASSIGN_(Impl);
+    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
   const Tuple2Matcher tuple2_matcher_;
@@ -3552,12 +3552,12 @@ class OptionalMatcher {
 
    private:
     const Matcher<ValueType> value_matcher_;
-    GTEST_DISALLOW_ASSIGN_(Impl);
+    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
  private:
   const ValueMatcher value_matcher_;
-  GTEST_DISALLOW_ASSIGN_(OptionalMatcher);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(OptionalMatcher);
 };
 
 namespace variant_matcher {

--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -444,8 +444,6 @@ class MatcherCastImpl<T, Matcher<U> > {
 
    private:
     const Matcher<U> source_matcher_;
-
-    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 };
 
@@ -861,13 +859,9 @@ class RefMatcher<T&> {
 
    private:
     const Super& object_;
-
-    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
   T& object_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(RefMatcher);
 };
 
 // Polymorphic helper functions for narrow and wide string matchers.
@@ -970,8 +964,6 @@ class StrEqualityMatcher {
   const StringType string_;
   const bool expect_eq_;
   const bool case_sensitive_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(StrEqualityMatcher);
 };
 
 // Implements the polymorphic HasSubstr(substring) matcher, which
@@ -1026,8 +1018,6 @@ class HasSubstrMatcher {
 
  private:
   const StringType substring_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(HasSubstrMatcher);
 };
 
 // Implements the polymorphic StartsWith(substring) matcher, which
@@ -1083,8 +1073,6 @@ class StartsWithMatcher {
 
  private:
   const StringType prefix_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(StartsWithMatcher);
 };
 
 // Implements the polymorphic EndsWith(substring) matcher, which
@@ -1139,8 +1127,6 @@ class EndsWithMatcher {
 
  private:
   const StringType suffix_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(EndsWithMatcher);
 };
 
 // Implements a matcher that compares the two fields of a 2-tuple
@@ -1234,8 +1220,6 @@ class NotMatcherImpl : public MatcherInterface<const T&> {
 
  private:
   const Matcher<T> matcher_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(NotMatcherImpl);
 };
 
 // Implements the Not(m) matcher, which matches a value that doesn't
@@ -1317,8 +1301,6 @@ class AllOfMatcherImpl : public MatcherInterface<const T&> {
 
  private:
   const std::vector<Matcher<T> > matchers_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(AllOfMatcherImpl);
 };
 
 // VariadicMatcher is used for the variadic implementation of
@@ -1423,8 +1405,6 @@ class AnyOfMatcherImpl : public MatcherInterface<const T&> {
 
  private:
   const std::vector<Matcher<T> > matchers_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(AnyOfMatcherImpl);
 };
 
 // AnyOfMatcher is used for the variadic implementation of AnyOf(m_1, m_2, ...).
@@ -1452,8 +1432,6 @@ class SomeOfArrayMatcher {
 
  private:
   const ::std::vector<T> matchers_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(SomeOfArrayMatcher);
 };
 
 template <typename T>
@@ -1587,8 +1565,6 @@ class PredicateFormatterFromMatcher {
 
  private:
   const M matcher_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(PredicateFormatterFromMatcher);
 };
 
 // A helper function for converting a matcher to a predicate-formatter
@@ -1740,8 +1716,6 @@ class FloatingEqMatcher {
     const bool nan_eq_nan_;
     // max_abs_error will be used for value comparison when >= 0.
     const FloatType max_abs_error_;
-
-    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
   // The following 3 type conversion operators allow FloatEq(expected) and
@@ -1770,8 +1744,6 @@ class FloatingEqMatcher {
   const bool nan_eq_nan_;
   // max_abs_error will be used for value comparison when >= 0.
   const FloatType max_abs_error_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(FloatingEqMatcher);
 };
 
 // A 2-tuple ("binary") wrapper around FloatingEqMatcher:
@@ -1901,13 +1873,9 @@ class PointeeMatcher {
 
    private:
     const Matcher<const Pointee&> matcher_;
-
-    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
   const InnerMatcher matcher_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(PointeeMatcher);
 };
 
 #if GTEST_HAS_RTTI
@@ -1944,8 +1912,6 @@ class WhenDynamicCastToMatcherBase {
   static void GetCastTypeDescription(::std::ostream* os) {
     *os << "when dynamic_cast to " << GetToName() << ", ";
   }
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(WhenDynamicCastToMatcherBase);
 };
 
 // Primary template.
@@ -2043,8 +2009,6 @@ class FieldMatcher {
   // Contains either "whose given field " if the name of the field is unknown
   // or "whose field `name_of_field` " if the name is known.
   const std::string whose_field_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(FieldMatcher);
 };
 
 // Implements the Property() matcher for matching a property
@@ -2113,8 +2077,6 @@ class PropertyMatcher {
   // Contains either "whose given property " if the name of the property is
   // unknown or "whose property `name_of_property` " if the name is known.
   const std::string whose_property_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(PropertyMatcher);
 };
 
 // Type traits specifying various features of different functors for ResultOf.
@@ -2204,14 +2166,10 @@ class ResultOfMatcher {
     // how many times the callable will be invoked.
     mutable CallableStorageType callable_;
     const Matcher<ResultType> matcher_;
-
-    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };  // class Impl
 
   const CallableStorageType callable_;
   const InnerMatcher matcher_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(ResultOfMatcher);
 };
 
 // Implements a matcher that checks the size of an STL-style container.
@@ -2256,12 +2214,10 @@ class SizeIsMatcher {
 
    private:
     const Matcher<SizeType> size_matcher_;
-    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
  private:
   const SizeMatcher size_matcher_;
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(SizeIsMatcher);
 };
 
 // Implements a matcher that checks the begin()..end() distance of an STL-style
@@ -2313,12 +2269,10 @@ class BeginEndDistanceIsMatcher {
 
    private:
     const Matcher<DistanceType> distance_matcher_;
-    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
  private:
   const DistanceMatcher distance_matcher_;
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(BeginEndDistanceIsMatcher);
 };
 
 // Implements an equality matcher for any STL-style container whose elements
@@ -2411,8 +2365,6 @@ class ContainerEqMatcher {
 
  private:
   const StlContainer expected_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(ContainerEqMatcher);
 };
 
 // A comparator functor that uses the < operator to compare two values.
@@ -2494,8 +2446,6 @@ class WhenSortedByMatcher {
  private:
   const Comparator comparator_;
   const ContainerMatcher matcher_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(WhenSortedByMatcher);
 };
 
 // Implements Pointwise(tuple_matcher, rhs_container).  tuple_matcher
@@ -2611,15 +2561,11 @@ class PointwiseMatcher {
    private:
     const Matcher<InnerMatcherArg> mono_tuple_matcher_;
     const RhsStlContainer rhs_;
-
-    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
  private:
   const TupleMatcher tuple_matcher_;
   const RhsStlContainer rhs_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(PointwiseMatcher);
 };
 
 // Holds the logic common to ContainsMatcherImpl and EachMatcherImpl.
@@ -2662,8 +2608,6 @@ class QuantifierMatcherImpl : public MatcherInterface<Container> {
 
  protected:
   const Matcher<const Element&> inner_matcher_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(QuantifierMatcherImpl);
 };
 
 // Implements Contains(element_matcher) for the given argument type Container.
@@ -2738,8 +2682,6 @@ class ContainsMatcher {
 
  private:
   const M inner_matcher_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(ContainsMatcher);
 };
 
 // Implements polymorphic Each(element_matcher).
@@ -2756,8 +2698,6 @@ class EachMatcher {
 
  private:
   const M inner_matcher_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(EachMatcher);
 };
 
 struct Rank1 {};
@@ -2828,8 +2768,6 @@ class KeyMatcherImpl : public MatcherInterface<PairType> {
 
  private:
   const Matcher<const KeyType&> inner_matcher_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(KeyMatcherImpl);
 };
 
 // Implements polymorphic Key(matcher_for_key).
@@ -2846,8 +2784,6 @@ class KeyMatcher {
 
  private:
   const M matcher_for_key_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(KeyMatcher);
 };
 
 // Implements Pair(first_matcher, second_matcher) for the given argument pair
@@ -2933,8 +2869,6 @@ class PairMatcherImpl : public MatcherInterface<PairType> {
 
   const Matcher<const FirstType&> first_matcher_;
   const Matcher<const SecondType&> second_matcher_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(PairMatcherImpl);
 };
 
 // Implements polymorphic Pair(first_matcher, second_matcher).
@@ -2953,8 +2887,6 @@ class PairMatcher {
  private:
   const FirstMatcher first_matcher_;
   const SecondMatcher second_matcher_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(PairMatcher);
 };
 
 // Implements ElementsAre() and ElementsAreArray().
@@ -3340,7 +3272,6 @@ class UnorderedElementsAreMatcher {
 
  private:
   const MatcherTuple matchers_;
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(UnorderedElementsAreMatcher);
 };
 
 // Implements ElementsAre.
@@ -3370,7 +3301,6 @@ class ElementsAreMatcher {
 
  private:
   const MatcherTuple matchers_;
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(ElementsAreMatcher);
 };
 
 // Implements UnorderedElementsAreArray(), IsSubsetOf(), and IsSupersetOf().
@@ -3415,8 +3345,6 @@ class ElementsAreArrayMatcher {
 
  private:
   const ::std::vector<T> matchers_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(ElementsAreArrayMatcher);
 };
 
 // Given a 2-tuple matcher tm of type Tuple2Matcher and a value second
@@ -3478,8 +3406,6 @@ class BoundSecondMatcher {
    private:
     const Matcher<const ArgTuple&> mono_tuple2_matcher_;
     const Second second_value_;
-
-    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
   const Tuple2Matcher tuple2_matcher_;
@@ -3552,12 +3478,10 @@ class OptionalMatcher {
 
    private:
     const Matcher<ValueType> value_matcher_;
-    GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(Impl);
   };
 
  private:
   const ValueMatcher value_matcher_;
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(OptionalMatcher);
 };
 
 namespace variant_matcher {

--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -880,7 +880,7 @@ class GTEST_API_ ExpectationBase {
   mutable bool action_count_checked_;  // Under mutex_.
   mutable Mutex mutex_;  // Protects action_count_checked_.
 
-  GTEST_DISALLOW_ASSIGN_(ExpectationBase);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(ExpectationBase);
 };  // class ExpectationBase
 
 // Impements an expectation for the given function type.
@@ -1296,7 +1296,7 @@ class MockSpec {
   // The argument matchers specified in the spec.
   ArgumentMatcherTuple matchers_;
 
-  GTEST_DISALLOW_ASSIGN_(MockSpec);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(MockSpec);
 };  // class MockSpec
 
 // Wrapper type for generically holding an ordinary value or lvalue reference.

--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -1295,8 +1295,6 @@ class MockSpec {
   internal::FunctionMocker<F>* const function_mocker_;
   // The argument matchers specified in the spec.
   ArgumentMatcherTuple matchers_;
-
-  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(MockSpec);
 };  // class MockSpec
 
 // Wrapper type for generically holding an ordinary value or lvalue reference.

--- a/googlemock/src/gmock-matchers.cc
+++ b/googlemock/src/gmock-matchers.cc
@@ -219,7 +219,7 @@ class MaxBipartiteMatchState {
   ::std::vector<size_t> left_;
   ::std::vector<size_t> right_;
 
-  GTEST_DISALLOW_ASSIGN_(MaxBipartiteMatchState);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(MaxBipartiteMatchState);
 };
 
 const size_t MaxBipartiteMatchState::kUnused;

--- a/googlemock/test/gmock-actions_test.cc
+++ b/googlemock/test/gmock-actions_test.cc
@@ -576,7 +576,7 @@ class FromType {
  private:
   bool* const converted_;
 
-  GTEST_DISALLOW_ASSIGN_(FromType);
+  GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(FromType);
 };
 
 class ToType {

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -705,8 +705,8 @@ class Base {
  public:
   virtual ~Base() {}
   Base() {}
- private:
-  GTEST_DISALLOW_COPY_AND_ASSIGN_(Base);
+  Base(const Base&) = delete;
+  Base& operator=(const Base&) = delete;
 };
 
 class Derived : public Base {
@@ -2941,11 +2941,10 @@ TEST(AllArgsTest, WorksForNonTuple) {
 class AllArgsHelper {
  public:
   AllArgsHelper() {}
+  AllArgsHelper(const AllArgsHelper&) = delete;
+  AllArgsHelper& operator=(const AllArgsHelper&) = delete;
 
   MOCK_METHOD2(Helper, int(char x, int y));
-
- private:
-  GTEST_DISALLOW_COPY_AND_ASSIGN_(AllArgsHelper);
 };
 
 TEST(AllArgsTest, WorksInWithClause) {
@@ -2965,6 +2964,8 @@ TEST(AllArgsTest, WorksInWithClause) {
 class OptionalMatchersHelper {
  public:
   OptionalMatchersHelper() {}
+  OptionalMatchersHelper(const OptionalMatchersHelper&) = delete;
+  OptionalMatchersHelper& operator=(const OptionalMatchersHelper&) = delete;
 
   MOCK_METHOD0(NoArgs, int());
 
@@ -2974,9 +2975,6 @@ class OptionalMatchersHelper {
 
   MOCK_METHOD1(Overloaded, int(char x));
   MOCK_METHOD2(Overloaded, int(char x, int y));
-
- private:
-  GTEST_DISALLOW_COPY_AND_ASSIGN_(OptionalMatchersHelper);
 };
 
 TEST(AllArgsTest, WorksWithoutMatchers) {
@@ -3720,13 +3718,14 @@ class Uncopyable {
  public:
   Uncopyable() : value_(-1) {}
   explicit Uncopyable(int a_value) : value_(a_value) {}
+  Uncopyable(const Uncopyable&) = delete;
+  Uncopyable& operator=(const Uncopyable&) = delete;
 
   int value() const { return value_; }
   void set_value(int i) { value_ = i; }
 
  private:
   int value_;
-  GTEST_DISALLOW_COPY_AND_ASSIGN_(Uncopyable);
 };
 
 // Returns true if and only if x.value() is positive.
@@ -3741,22 +3740,17 @@ struct AStruct {
   AStruct() : x(0), y(1.0), z(5), p(nullptr) {}
   AStruct(const AStruct& rhs)
       : x(rhs.x), y(rhs.y), z(rhs.z.value()), p(rhs.p) {}
+  AStruct& operator=(const AStruct&) = delete;
 
   int x;           // A non-const field.
   const double y;  // A const field.
   Uncopyable z;    // An uncopyable field.
   const char* p;   // A pointer field.
-
- private:
-  GTEST_DISALLOW_ASSIGN_(AStruct);
 };
 
 // A derived struct for testing Field().
 struct DerivedStruct : public AStruct {
   char ch;
-
- private:
-  GTEST_DISALLOW_ASSIGN_(DerivedStruct);
 };
 
 // Tests that Field(&Foo::field, ...) works when field is non-const.
@@ -4559,6 +4553,8 @@ TEST(ExplainmatcherResultTest, MonomorphicMatcher) {
 class NotCopyable {
  public:
   explicit NotCopyable(int a_value) : value_(a_value) {}
+  NotCopyable(const NotCopyable&) = delete;
+  NotCopyable& operator=(const NotCopyable&) = delete;
 
   int value() const { return value_; }
 
@@ -4571,8 +4567,6 @@ class NotCopyable {
   }
  private:
   int value_;
-
-  GTEST_DISALLOW_COPY_AND_ASSIGN_(NotCopyable);
 };
 
 TEST(ByRefTest, AllowsNotCopyableConstValueInMatchers) {

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1079,6 +1079,7 @@ class NativeArray {
   NativeArray(const NativeArray& rhs) {
     (this->*rhs.clone_)(rhs.array_, rhs.size_);
   }
+  NativeArray& operator=(const NativeArray&) = delete;
 
   ~NativeArray() {
     if (clone_ != &NativeArray::InitRef)
@@ -1118,8 +1119,6 @@ class NativeArray {
   const Element* array_;
   size_t size_;
   void (NativeArray::*clone_)(const Element*, size_t);
-
-  GTEST_DISALLOW_ASSIGN_(NativeArray);
 };
 
 // Backport of std::index_sequence.
@@ -1407,8 +1406,6 @@ constexpr bool InstantiateTypedTestCase_P_IsDeprecated() { return true; }
     GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)() {}                   \
     ~GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)() override = default; \
     GTEST_DISALLOW_COPY_AND_ASSIGN_(GTEST_TEST_CLASS_NAME_(test_suite_name,   \
-                                                           test_name));       \
-    GTEST_DISALLOW_MOVE_AND_ASSIGN_(GTEST_TEST_CLASS_NAME_(test_suite_name,   \
                                                            test_name));       \
                                                                               \
    private:                                                                   \

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -190,10 +190,8 @@
 //   GTEST_AMBIGUOUS_ELSE_BLOCKER_ - for disabling a gcc warning.
 //   GTEST_ATTRIBUTE_UNUSED_  - declares that a class' instances or a
 //                              variable don't have to be used.
-//   GTEST_DISALLOW_ASSIGN_   - disables copy operator=.
+//   GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_ - disables copy operator=.
 //   GTEST_DISALLOW_COPY_AND_ASSIGN_ - disables copy ctor and operator=.
-//   GTEST_DISALLOW_MOVE_ASSIGN_   - disables move operator=.
-//   GTEST_DISALLOW_MOVE_AND_ASSIGN_ - disables move ctor and operator=.
 //   GTEST_MUST_USE_RESULT_   - declares that a function's result must be used.
 //   GTEST_INTENTIONAL_CONST_COND_PUSH_ - start code section where MSVC C4127 is
 //                                        suppressed (constant conditional).
@@ -675,25 +673,17 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 
 // A macro to disallow copy operator=
 // This should be used in the private: declarations for a class.
-#define GTEST_DISALLOW_ASSIGN_(type) \
+#define GTEST_DISALLOW_ASSIGN_BUT_DEFAULT_COPY_(type) \
+  public: \
+  type(type const &) = default; \
+  private: \
   type& operator=(type const &) = delete
 
 // A macro to disallow copy constructor and operator=
 // This should be used in the private: declarations for a class.
 #define GTEST_DISALLOW_COPY_AND_ASSIGN_(type) \
   type(type const &) = delete; \
-  GTEST_DISALLOW_ASSIGN_(type)
-
-// A macro to disallow move operator=
-// This should be used in the private: declarations for a class.
-#define GTEST_DISALLOW_MOVE_ASSIGN_(type) \
-  type& operator=(type &&) noexcept = delete
-
-// A macro to disallow move constructor and operator=
-// This should be used in the private: declarations for a class.
-#define GTEST_DISALLOW_MOVE_AND_ASSIGN_(type) \
-  type(type &&) noexcept = delete; \
-  GTEST_DISALLOW_MOVE_ASSIGN_(type)
+  type& operator=(type const &) = delete
 
 // Tell the compiler to warn about unused return values for functions declared
 // with this macro.  The macro should be used on function declarations
@@ -881,6 +871,7 @@ class GTEST_API_ RE {
   // A copy constructor is required by the Standard to initialize object
   // references from r-values.
   RE(const RE& other) { Init(other.pattern()); }
+  RE& operator=(const RE&) = delete;
 
   // Constructs an RE from a string.
   RE(const ::std::string& regex) { Init(regex.c_str()); }  // NOLINT
@@ -920,8 +911,6 @@ class GTEST_API_ RE {
   const char* full_pattern_;  // For FullMatch();
 
 # endif
-
-  GTEST_DISALLOW_ASSIGN_(RE);
 };
 
 #endif  // GTEST_USES_PCRE

--- a/googletest/test/googletest-port-test.cc
+++ b/googletest/test/googletest-port-test.cc
@@ -1168,6 +1168,7 @@ class DestructorTracker {
   DestructorTracker() : index_(GetNewIndex()) {}
   DestructorTracker(const DestructorTracker& /* rhs */)
       : index_(GetNewIndex()) {}
+  DestructorTracker& operator=(const DestructorTracker&) = delete;
   ~DestructorTracker() {
     // We never access DestructorCall::List() concurrently, so we don't need
     // to protect this access with a mutex.
@@ -1180,8 +1181,6 @@ class DestructorTracker {
     return DestructorCall::List().size() - 1;
   }
   const size_t index_;
-
-  GTEST_DISALLOW_ASSIGN_(DestructorTracker);
 };
 
 typedef ThreadLocal<DestructorTracker>* ThreadParam;


### PR DESCRIPTION
Fixes #1305.
(I think. Hopefully you've got a buildbot that will tell me if this breaks something.)