### PR TITLE
Fix a typo in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,6 @@ matrix:
       env: BUILD_TYPE=Debug VERBOSE=1 CXX_FLAGS=-std=c++11
     - os: linux
       compiler: clang
-      env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11 -Wgnu-zero-variadic-macro-arguments
-    - os: linux
-      compiler: clang
       env: BUILD_TYPE=Release VERBOSE=1 CXX_FLAGS=-std=c++11 NO_EXCEPTION=ON NO_RTTI=ON COMPILER_IS_GNUCXX=ON
     - os: osx
       compiler: gcc

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -34,11 +34,11 @@ cd build
 cmake -Dgtest_build_samples=ON \
       -Dgtest_build_tests=ON \
       -Dgmock_build_tests=ON \
-      -Dcxx_no_exception=$NO_EXCEPTION \
-      -Dcxx_no_rtti=$NO_RTTI \
-      -DCMAKE_COMPILER_IS_GNUCXX=$COMPILER_IS_GNUCXX \
-      -DCMAKE_CXX_FLAGS=$CXX_FLAGS \
-      -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+      -Dcxx_no_exception="$NO_EXCEPTION" \
+      -Dcxx_no_rtti="$NO_RTTI" \
+      -DCMAKE_COMPILER_IS_GNUCXX="$COMPILER_IS_GNUCXX" \
+      -DCMAKE_CXX_FLAGS="$CXX_FLAGS" \
+      -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
       ..
 make
 CTEST_OUTPUT_ON_FAILURE=1 make test


### PR DESCRIPTION
The old code was trying to pass -Wgnu-zero-variadic-macro-arguments
as part of CXXFLAGS, but it forgot the quotation marks needed around
whitespace. This meant that option was ignored:
https://travis-ci.org/github/google/googletest/jobs/666534177#L760

Unfortunately, the codebase is not remotely clean with respect to that
warning option. It fails like this:
https://travis-ci.org/github/Quuxplusone/googletest/jobs/668118135

So, remove that failing configuration from the test matrix until
someone has time to look at it.