### PR TITLE
Replace the last instance of `throw()` with `noexcept`. NFC.

### DIFF
--- a/googletest/test/googletest-death-test_ex_test.cc
+++ b/googletest/test/googletest-death-test_ex_test.cc
@@ -59,7 +59,7 @@ TEST(CxxExceptionDeathTest, ExceptionIsFailure) {
 
 class TestException : public std::exception {
  public:
-  const char* what() const throw() override { return "exceptional message"; }
+  const char* what() const noexcept override { return "exceptional message"; }
 };
 
 TEST(CxxExceptionDeathTest, PrintsMessageForStdExceptions) {


### PR DESCRIPTION
Fixes a `-Wdeprecated` warning.

    /home/travis/build/Quuxplusone/googletest/googletest/test/googletest-death-test_ex_test.cc:62:28: error:
          dynamic exception specifications are deprecated [-Werror,-Wdeprecated]
      const char* what() const throw() override { return "exceptional message"; }
                               ^~~~~~~
    /home/travis/build/Quuxplusone/googletest/googletest/test/googletest-death-test_ex_test.cc:62:28: note:
          use 'noexcept' instead
      const char* what() const throw() override { return "exceptional message"; }
                               ^~~~~~~
                               noexcept


@zhangxy988 PTAL