### PR TITLE
Support multithreading on non-POSIX platforms and require threading support

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -540,10 +540,7 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 // gtest-port.h guarantees to #include <pthread.h> when GTEST_HAS_PTHREAD is
 // true.
 # include <pthread.h>  // NOLINT
-
-// For timespec and nanosleep, used below.
-# include <time.h>  // NOLINT
-#endif
+#endif  // GTEST_HAS_PTHREAD
 
 // Determines whether clone(2) is supported.
 // Usually it will only be available on Linux, excluding
@@ -1148,20 +1145,13 @@ void ClearInjectableArgvs();
 
 #endif  // GTEST_HAS_DEATH_TEST
 
-// Defines synchronization primitives.
-#if GTEST_IS_THREADSAFE
-# if GTEST_HAS_PTHREAD
 // Sleeps for (roughly) n milliseconds.  This function is only for testing
 // Google Test's own constructs.  Don't use it in user tests, either
 // directly or indirectly.
-inline void SleepMilliseconds(int n) {
-  const timespec time = {
-    0,                  // 0 seconds.
-    n * 1000L * 1000L,  // And n ms.
-  };
-  nanosleep(&time, nullptr);
-}
-# endif  // GTEST_HAS_PTHREAD
+GTEST_API_ void SleepMilliseconds(int n);
+
+// Defines synchronization primitives.
+#if GTEST_IS_THREADSAFE
 
 # if GTEST_HAS_NOTIFICATION_
 // Notification has already been imported into the namespace.
@@ -1212,8 +1202,6 @@ class Notification {
 };
 
 # elif GTEST_OS_WINDOWS && !GTEST_OS_WINDOWS_PHONE && !GTEST_OS_WINDOWS_RT
-
-GTEST_API_ void SleepMilliseconds(int n);
 
 // Provides leak-safe Windows kernel handle ownership.
 // Used in death tests and in threading support.

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -1344,8 +1344,7 @@ class ThreadWithParam : public ThreadWithParamBase {
 
   GTEST_DISALLOW_COPY_AND_ASSIGN_(ThreadWithParam);
 };
-# endif  // !GTEST_OS_WINDOWS && GTEST_HAS_PTHREAD ||
-         // GTEST_HAS_MUTEX_AND_THREAD_LOCAL_
+# endif  // GTEST_HAS_PTHREAD && !GTEST_OS_WINDOWS_MINGW
 
 # if GTEST_HAS_MUTEX_AND_THREAD_LOCAL_
 // Mutex and ThreadLocal have already been imported into the namespace.

--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -34,9 +34,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <chrono>
 #include <cstdint>
 #include <fstream>
 #include <memory>
+#include <thread>
 
 #if GTEST_OS_WINDOWS
 # include <windows.h>
@@ -277,11 +279,11 @@ size_t GetThreadCount() {
 
 #endif  // GTEST_OS_LINUX
 
-#if GTEST_IS_THREADSAFE && GTEST_OS_WINDOWS
-
 void SleepMilliseconds(int n) {
-  ::Sleep(static_cast<DWORD>(n));
+  std::this_thread::sleep_for(std::chrono::nanoseconds(n));
 }
+
+#if GTEST_IS_THREADSAFE && GTEST_OS_WINDOWS
 
 AutoHandle::AutoHandle()
     : handle_(INVALID_HANDLE_VALUE) {}


### PR DESCRIPTION
Resolves #2380. @EricWF, may I kindly ask you to have a look into this?

1. This is (almost) a minimal set of changes to utilise C++11 concurrency in GoogleTest. Commits are dependent on each other so it's impossible to divide it into smaller pull requests. 
2. Until now, GoogleTest has had 3 models of concurrency: POSIX, Windows and "unsupported", where only POSIX was thread-safe. This PR is inspired by POSIX implementation, hence thread-safety has been preserved.
3. Speaking of "unsupported" model, this PR removes dummy implementation for them as it unconditionally uses C++11 threading tools. Until now, [unsupported platforms have been silently compiling GTest synchronisation primitives](https://github.com/google/googletest/blob/67cc66080d64e3fa5124fe57ed0cf15e2cecfdeb/googletest/include/gtest/internal/gtest-port.h#L1846). I disliked the fact that users weren't even given a warning, so my implementation simply requires threading support (e.g. linking with pthread on Linux, Win32 on Windows etc.); otherwise it won't link. Options we have are:
a) embrace KISS, accept this breaking change, prepare GoogleTest for release 2.0 according to [Live at Head](https://youtu.be/tISy7EJQPzI?t=1127) philosophy. This yields crystal clear message that there is major incompatibility and allow us to pay off a bit more of technical debt. I guess this breaking change wouldn't be that severe because if someone's platform is _old and unsupported_ or _too bare-metal_, they probably don't even bother compiling tests on it.
b) not make any breaking changes by having proxy types such as `::testing::Mutex`, `::testing::MutexLock` and proxy macro `GTEST_THREAD_LOCAL`. Optionally, we could add an extra `#warning` directive for users of unsupported platforms that they shouldn't use threads.
4. Code is equivalent in its meaning to the previous POSIX model. I didn't even try to introduce atomics because my goal was to port things, not to optimise.
5. I've had problems with Windows DLLs - formally commits 784d0a6 and 142925c break the build and they are patched by 2c74ab5 and 455eb9d respectively. I extracted "fix" commits just in case you got some better idea how to handle that - but if you don't, then they should be squashed together so no commit breaks the build.

You'll find the detailed description in commit messages. Happy reviewing and please ask me questions.