### PR TITLE
Remove duplicate codes existed in get-nprocessors.sh

### DIFF
--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -3,21 +3,6 @@ set -evx
 
 . ci/get-nprocessors.sh
 
-# if possible, ask for the precise number of processors,
-# otherwise take 2 processors as reasonable default; see
-# https://docs.travis-ci.com/user/speeding-up-the-build/#Makefile-optimization
-if [ -x /usr/bin/getconf ]; then
-    NPROCESSORS=$(/usr/bin/getconf _NPROCESSORS_ONLN)
-else
-    NPROCESSORS=2
-fi
-# as of 2017-09-04 Travis CI reports 32 processors, but GCC build
-# crashes if parallelized too much (maybe memory consumption problem),
-# so limit to 4 processors for the time being.
-if [ $NPROCESSORS -gt 4 ] ; then
-	echo "$0:Note: Limiting processors to use by make from $NPROCESSORS to 4."
-	NPROCESSORS=4
-fi
 # Tell make to use the processors. No preceding '-' required.
 MAKEFLAGS="j${NPROCESSORS}"
 export MAKEFLAGS


### PR DESCRIPTION
Remove the duplicate code in `travis.sh`, which already exists in `get-nprocessors.sh`.