### PR TITLE
Set cpp11 compile feature with target_compile_features if available.

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -188,6 +188,10 @@ function(cxx_library_with_type name type cxx_flags)
     endif()
     target_link_libraries(${name} PUBLIC ${threads_spec})
   endif()
+
+  if (NOT "${CMAKE_VERSION}" VERSION_LESS "3.8")
+    target_compile_features(${name} PUBLIC cxx_std_11)
+  endif()
 endfunction()
 
 ########################################################################


### PR DESCRIPTION
Use `target_compile_features` to use c++11 if target_compile_features is available. 
This fix compilation with clang and gcc when c++11 isn't specified by user. Otherwise user need to set `-DCMAKE_CXX_STANDARD=11`.

The fix the issue that have been reopened there: https://github.com/google/googletest/issues/1519

This only fix the issue for user using cmake version that support `target_compile_features`, ie CMake greater than 3.1.

This solution is better than `set(CMAKE_CXX_STANDARD 11)` because in superbuild, it won't override any user `CMAKE_CXX_STANDARD` already set variables.
This c++11 requirement will be propagated to any target that `target_link_libraries` as a minimum requirement and won't downgrade any user c++ standard requirement.

And maybe to test if it work as expected, i suggest that `CXX_FLAGS=-std=c++11` gets removed from `.travis.yml` and `-DCMAKE_CXX_FLAGS=$CXX_FLAGS ` from `ci/travis.sh` ? Min version for ci seems to be CMake 3.12 so everything would work the same.