### PR TITLE
fix signed/unsigned comparison issue (on OpenBSD)

### DIFF
--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -208,7 +208,7 @@ size_t GetThreadCount() {
 
   // exclude empty members
   int nthreads = 0;
-  for (int i = 0; i < size / mib[4]; i++) {
+  for (size_t i = 0; i < size / mib[4]; i++) {
     if (info[i].p_tid != -1)
       nthreads++;
   }


### PR DESCRIPTION
This fixes the following error I got when compiling on OpenBSD (with gcc 8.3.0)

```
In file included from /home/jbohl/dev/buildlibCZI/_deps/googletest-src/googletest/src/gtest-all.cc:45:
/home/jbohl/dev/buildlibCZI/_deps/googletest-src/googletest/src/gtest-port.cc: In function 'size_t testing::internal::GetThreadCount()':
/home/jbohl/dev/buildlibCZI/_deps/googletest-src/googletest/src/gtest-port.cc:210:21: error: comparison of integer expressions of different signedness: 'int' and 'size_t' {aka 'long unsigned int'} [-Werror=sign-compare]
   for (int i = 0; i < size / mib[4]; i++) {
                   ~~^~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```