### PR TITLE
Fix `-Wgnu-zero-variadic-macro-arguments`

### DIFF
--- a/googlemock/include/gmock/internal/gmock-pp.h
+++ b/googlemock/include/gmock/internal/gmock-pp.h
@@ -28,16 +28,16 @@
 // Requires: the number of arguments after expansion is at most 15.
 #define GMOCK_PP_NARG(...) \
   GMOCK_PP_INTERNAL_16TH(  \
-      (__VA_ARGS__, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1))
+      (__VA_ARGS__, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0))
 
 // Returns 1 if the expansion of arguments has an unprotected comma. Otherwise
 // returns 0. Requires no more than 15 unprotected commas.
 #define GMOCK_PP_HAS_COMMA(...) \
   GMOCK_PP_INTERNAL_16TH(       \
-      (__VA_ARGS__, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0))
+      (__VA_ARGS__, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0))
 
 // Returns the first argument.
-#define GMOCK_PP_HEAD(...) GMOCK_PP_INTERNAL_HEAD((__VA_ARGS__))
+#define GMOCK_PP_HEAD(...) GMOCK_PP_INTERNAL_HEAD((__VA_ARGS__, unusedArg))
 
 // Returns the tail. A variadic list of all arguments minus the first. Requires
 // at least one argument.

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -82,7 +82,7 @@ macro(config_compiler_and_linker)
     # http://stackoverflow.com/questions/3232669 explains the issue.
     set(cxx_base_flags "${cxx_base_flags} -wd4702")
   elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(cxx_base_flags "-Wall -Wshadow -Werror -Wconversion")
+    set(cxx_base_flags "-Wall -Wshadow -Werror -Wconversion -Wgnu-zero-variadic-macro-arguments")
     set(cxx_exception_flags "-fexceptions")
     set(cxx_no_exception_flags "-fno-exceptions")
     set(cxx_strict_flags "-W -Wpointer-arith -Wreturn-type -Wcast-qual -Wwrite-strings -Wswitch -Wunused-parameter -Wcast-align -Wchar-subscripts -Winline -Wredundant-decls")

--- a/googletest/include/gtest/gtest-typed-test.h
+++ b/googletest/include/gtest/gtest-typed-test.h
@@ -188,10 +188,12 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
 #define GTEST_NAME_GENERATOR_(TestSuiteName) \
   gtest_type_params_##TestSuiteName##_NameGenerator
 
-#define TYPED_TEST_SUITE(CaseName, Types, ...)                          \
-  typedef ::testing::internal::GenerateTypeList<Types>::type            \
-      GTEST_TYPE_PARAMS_(CaseName);                                     \
-  typedef ::testing::internal::NameGeneratorSelector<__VA_ARGS__>::type \
+#define TYPED_TEST_SUITE(...) \
+    TYPED_TEST_SUITE_INTERNAL(__VA_ARGS__,, unusedArg)
+#define TYPED_TEST_SUITE_INTERNAL(CaseName, Types, Names, ...)    \
+  typedef ::testing::internal::GenerateTypeList<Types>::type      \
+      GTEST_TYPE_PARAMS_(CaseName);                               \
+  typedef ::testing::internal::NameGeneratorSelector<Names>::type \
       GTEST_NAME_GENERATOR_(CaseName)
 
 #define TYPED_TEST(CaseName, TestName)                                        \
@@ -307,9 +309,11 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
   REGISTER_TYPED_TEST_SUITE_P
 #endif  // GTEST_REMOVE_LEGACY_TEST_CASEAPI_
 
-#define INSTANTIATE_TYPED_TEST_SUITE_P(Prefix, SuiteName, Types, ...)       \
+#define INSTANTIATE_TYPED_TEST_SUITE_P(...)       \
+    INSTANTIATE_TYPED_TEST_SUITE_P_INTERNAL(__VA_ARGS__,, unusedArg)
+#define INSTANTIATE_TYPED_TEST_SUITE_P_INTERNAL(Prefix, SuiteName, Types, Names, ...) \
   static_assert(sizeof(GTEST_STRINGIFY_(Prefix)) > 1,                       \
-                "test-suit-prefix must not be empty");                      \
+                "test-suite-prefix must not be empty");                     \
   static bool gtest_##Prefix##_##SuiteName GTEST_ATTRIBUTE_UNUSED_ =        \
       ::testing::internal::TypeParameterizedTestSuite<                      \
           SuiteName, GTEST_SUITE_NAMESPACE_(SuiteName)::gtest_AllTests_,    \
@@ -321,7 +325,7 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
                    GTEST_REGISTERED_TEST_NAMES_(SuiteName),                 \
                    ::testing::internal::GenerateNames<                      \
                        ::testing::internal::NameGeneratorSelector<          \
-                           __VA_ARGS__>::type,                              \
+                           Names>::type,                                    \
                        ::testing::internal::GenerateTypeList<Types>::type>())
 
 // Legacy API is deprecated but still available


### PR DESCRIPTION
Passing zero arguments to the variadic part of a macro is a GNU
extension and triggers warnings when build projects using GTest and
GMock with `-pedantic`.

 - Fix uses of `GMOCK_PP_INTERNAL_16TH` to always receive at least 17
arguments. (this was triggered when `GMOCK_PP_NARG` or `GMOCK_PP_HAS_COMMA`
were used with an argument containing no commas).
 - Fix `GMOCK_PP_HEAD` to append a dummy unused argument so that
`GMOCK_PP_INTERNAL_HEAD` always has two arguments.
 - Fix `TYPED_TEST_SUITE` and `INSTANTIATE_TYPED_TEST_SUITE_P` when called
without a name generator by making the argument default to no token
before proxying to an internal implementation.