### PR TITLE
Revert faulty Windows.h include fix and attempt to fix #2822 properly

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -86,7 +86,6 @@
 
 #ifdef _MSC_VER
 # include <crtdbg.h>  // NOLINT
-# include <debugapi.h>  // NOLINT
 #endif
 
 # include <io.h>  // NOLINT

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -81,7 +81,6 @@
 
 #elif GTEST_OS_WINDOWS  // We are on Windows proper.
 
-# include <Windows.h>  // NOLINT
 # include <windows.h>  // NOLINT
 # undef min
 


### PR DESCRIPTION
Revert the faulty fix from a9f6c1ed14 - that commit cannot concievably fix the issue it sets out to fix, and breaks cross compilation with mingw from case sensitive file systems (causing issue #2840) - see the individual commit message for more detail.

Instead remove the explicit include of debugapi.h - the documentation for IsDebuggerPresent says that including windows.h is enough, and that header takes care of including whichever header declares IsDebuggerPresent in that particular Windows SDK version. This should hopefully fix #2822 properly.