### PR TITLE
Export Test - Do Not Merge

### DIFF
--- a/googlemock/include/gmock/gmock-actions.h
+++ b/googlemock/include/gmock/gmock-actions.h
@@ -1335,15 +1335,17 @@ class ActionHelper {
  public:
   template <typename... Ts>
   static Result Perform(Impl* impl, const std::tuple<Ts...>& args) {
-    return Apply(impl, args, MakeIndexSequence<sizeof...(Ts)>{},
-                 MakeIndexSequence<10 - sizeof...(Ts)>{});
+    static constexpr size_t kMaxArgs = sizeof...(Ts) <= 10 ? sizeof...(Ts) : 10;
+    return Apply(impl, args, MakeIndexSequence<kMaxArgs>{},
+                 MakeIndexSequence<10 - kMaxArgs>{});
   }
 
  private:
   template <typename... Ts, std::size_t... tuple_ids, std::size_t... rest_ids>
   static Result Apply(Impl* impl, const std::tuple<Ts...>& args,
                       IndexSequence<tuple_ids...>, IndexSequence<rest_ids...>) {
-    return impl->template gmock_PerformImpl<Ts...>(
+    return impl->template gmock_PerformImpl<
+        typename std::tuple_element<tuple_ids, std::tuple<Ts...>>::type...>(
         args, std::get<tuple_ids>(args)...,
         ((void)rest_ids, ExcessiveArg())...);
   }

--- a/googlemock/test/gmock-actions_test.cc
+++ b/googlemock/test/gmock-actions_test.cc
@@ -1550,6 +1550,26 @@ TEST(MoveOnlyArgumentsTest, ReturningActions) {
   EXPECT_EQ(x, 3);
 }
 
+ACTION(ReturnArity) {
+  return std::tuple_size<args_type>::value;
+}
+
+TEST(ActionMacro, LargeArity) {
+  EXPECT_EQ(
+      1, testing::Action<int(int)>(ReturnArity()).Perform(std::make_tuple(0)));
+  EXPECT_EQ(
+      10,
+      testing::Action<int(int, int, int, int, int, int, int, int, int, int)>(
+          ReturnArity())
+          .Perform(std::make_tuple(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)));
+  EXPECT_EQ(
+      20,
+      testing::Action<int(int, int, int, int, int, int, int, int, int, int, int,
+                          int, int, int, int, int, int, int, int, int)>(
+          ReturnArity())
+          .Perform(std::make_tuple(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
+                                   14, 15, 16, 17, 18, 19)));
+}
 
 }  // Unnamed namespace
 


### PR DESCRIPTION
Export Test - Do Not Merge

Fix the ACTION* macros to allow for more than 10 arguments in the action.
Only the first 10 will be passed as individual arguments as `argN`, but the rest
can be accessed from the `args` tuple.
