### PR TITLE
Export Test - Do Not Merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ runs tests from your binary in parallel to provide significant speed-up.
 is a VS Code extension allowing to view Google Tests in a tree view, and
 run/debug your tests.
 
-[Catch2 and Google Test Explorer](https://github.com/matepek/vscode-catch2-test-adapter)
-is a VS Code extension allowing to view Google Tests in a tree view, and
-run/debug your tests.
+[C++ TestMate](https://github.com/matepek/vscode-catch2-test-adapter) is a VS
+Code extension allowing to view Google Tests in a tree view, and run/debug your
+tests.
 
 [Cornichon](https://pypi.org/project/cornichon/) is a small Gherkin DSL parser
 that generates stub code for Google Test.

--- a/googlemock/docs/cook_book.md
+++ b/googlemock/docs/cook_book.md
@@ -2686,7 +2686,7 @@ TEST(EventQueueTest, EnqueueEventTest) {
   EventQueue event_queue(&mock_event_dispatcher);
 
   const int32 kEventId = 321;
-  Notification done;
+  absl::Notification done;
   EXPECT_CALL(mock_event_dispatcher, DispatchEvent(kEventId))
       .WillOnce(Notify(&done));
 

--- a/googlemock/include/gmock/gmock-actions.h
+++ b/googlemock/include/gmock/gmock-actions.h
@@ -1335,15 +1335,17 @@ class ActionHelper {
  public:
   template <typename... Ts>
   static Result Perform(Impl* impl, const std::tuple<Ts...>& args) {
-    return Apply(impl, args, MakeIndexSequence<sizeof...(Ts)>{},
-                 MakeIndexSequence<10 - sizeof...(Ts)>{});
+    static constexpr size_t kMaxArgs = sizeof...(Ts) <= 10 ? sizeof...(Ts) : 10;
+    return Apply(impl, args, MakeIndexSequence<kMaxArgs>{},
+                 MakeIndexSequence<10 - kMaxArgs>{});
   }
 
  private:
   template <typename... Ts, std::size_t... tuple_ids, std::size_t... rest_ids>
   static Result Apply(Impl* impl, const std::tuple<Ts...>& args,
                       IndexSequence<tuple_ids...>, IndexSequence<rest_ids...>) {
-    return impl->template gmock_PerformImpl<Ts...>(
+    return impl->template gmock_PerformImpl<
+        typename std::tuple_element<tuple_ids, std::tuple<Ts...>>::type...>(
         args, std::get<tuple_ids>(args)...,
         ((void)rest_ids, ExcessiveArg())...);
   }

--- a/googlemock/include/gmock/gmock-actions.h
+++ b/googlemock/include/gmock/gmock-actions.h
@@ -1512,6 +1512,7 @@ auto InvokeArgumentAdl(AdlTag, F f, Args... args) -> decltype(f(args...)) {
       return_type gmock_PerformImpl(GMOCK_ACTION_ARG_TYPES_AND_NAMES_) const; \
     };                                                                        \
   };                                                                          \
+  inline name##Action name() GTEST_MUST_USE_RESULT_;                          \
   inline name##Action name() { return name##Action(); }                       \
   template <typename F>                                                       \
   template <GMOCK_ACTION_TEMPLATE_ARGS_NAMES_>                                \

--- a/googlemock/include/gmock/gmock-generated-actions.h
+++ b/googlemock/include/gmock/gmock-generated-actions.h
@@ -442,7 +442,13 @@
     }\
     GMOCK_INTERNAL_DEFN_##value_params\
   };\
-  template <GMOCK_INTERNAL_DECL_##template_params\
+  template <GMOCK_INTERNAL_DECL_##template_params                   \
+            GMOCK_INTERNAL_DECL_TYPE_##value_params>\
+  GMOCK_ACTION_CLASS_(name, value_params)<\
+      GMOCK_INTERNAL_LIST_##template_params\
+      GMOCK_INTERNAL_LIST_TYPE_##value_params> name(\
+          GMOCK_INTERNAL_DECL_##value_params) GTEST_MUST_USE_RESULT_;\
+  template <GMOCK_INTERNAL_DECL_##template_params                   \
             GMOCK_INTERNAL_DECL_TYPE_##value_params>\
   inline GMOCK_ACTION_CLASS_(name, value_params)<\
       GMOCK_INTERNAL_LIST_##template_params\

--- a/googlemock/include/gmock/gmock-generated-actions.h.pump
+++ b/googlemock/include/gmock/gmock-generated-actions.h.pump
@@ -260,7 +260,13 @@ $range k 0..n-1
     }\
     GMOCK_INTERNAL_DEFN_##value_params\
   };\
-  template <GMOCK_INTERNAL_DECL_##template_params\
+  template <GMOCK_INTERNAL_DECL_##template_params                   \
+            GMOCK_INTERNAL_DECL_TYPE_##value_params>\
+  GMOCK_ACTION_CLASS_(name, value_params)<\
+      GMOCK_INTERNAL_LIST_##template_params\
+      GMOCK_INTERNAL_LIST_TYPE_##value_params> name(\
+          GMOCK_INTERNAL_DECL_##value_params) GTEST_MUST_USE_RESULT_;\
+  template <GMOCK_INTERNAL_DECL_##template_params                   \
             GMOCK_INTERNAL_DECL_TYPE_##value_params>\
   inline GMOCK_ACTION_CLASS_(name, value_params)<\
       GMOCK_INTERNAL_LIST_##template_params\

--- a/googlemock/test/gmock-actions_test.cc
+++ b/googlemock/test/gmock-actions_test.cc
@@ -32,11 +32,13 @@
 //
 // This file tests the built-in actions.
 
-// Silence C4800 (C4800: 'int *const ': forcing value
-// to bool 'true' or 'false') for MSVC 15
+// Silence C4100 (unreferenced formal parameter) for MSVC
 #ifdef _MSC_VER
-#if _MSC_VER == 1900
 #  pragma warning(push)
+#  pragma warning(disable:4100)
+#if _MSC_VER == 1900
+// and silence C4800 (C4800: 'int *const ': forcing value
+// to bool 'true' or 'false') for MSVC 15
 #  pragma warning(disable:4800)
 #endif
 #endif

--- a/googlemock/test/gmock-actions_test.cc
+++ b/googlemock/test/gmock-actions_test.cc
@@ -1550,6 +1550,26 @@ TEST(MoveOnlyArgumentsTest, ReturningActions) {
   EXPECT_EQ(x, 3);
 }
 
+ACTION(ReturnArity) {
+  return std::tuple_size<args_type>::value;
+}
+
+TEST(ActionMacro, LargeArity) {
+  EXPECT_EQ(
+      1, testing::Action<int(int)>(ReturnArity()).Perform(std::make_tuple(0)));
+  EXPECT_EQ(
+      10,
+      testing::Action<int(int, int, int, int, int, int, int, int, int, int)>(
+          ReturnArity())
+          .Perform(std::make_tuple(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)));
+  EXPECT_EQ(
+      20,
+      testing::Action<int(int, int, int, int, int, int, int, int, int, int, int,
+                          int, int, int, int, int, int, int, int, int)>(
+          ReturnArity())
+          .Perform(std::make_tuple(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
+                                   14, 15, 16, 17, 18, 19)));
+}
 
 }  // Unnamed namespace
 

--- a/googletest/docs/primer.md
+++ b/googletest/docs/primer.md
@@ -169,7 +169,7 @@ you'll get a compiler error. We used to require the arguments to support the
 `<<` is supported, it will be called to print the arguments when the assertion
 fails; otherwise googletest will attempt to print them in the best way it can.
 For more details and how to customize the printing of the arguments, see the
-[documentation](../../googlemock/docs/cook_book.md#teaching-gmock-how-to-print-your-values).
+[documentation](./advanced.md#teaching-googletest-how-to-print-your-values).
 
 These assertions can work with a user-defined type, but only if you define the
 corresponding comparison operator (e.g., `==` or `<`). Since this is discouraged

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -269,6 +269,7 @@
 #endif
 
 #include <iostream>  // NOLINT
+#include <locale>
 #include <memory>
 #include <string>  // NOLINT
 #include <tuple>
@@ -2045,7 +2046,14 @@ GTEST_DISABLE_MSC_DEPRECATED_PUSH_()
 inline int ChDir(const char* dir) { return chdir(dir); }
 #endif
 inline FILE* FOpen(const char* path, const char* mode) {
+#if GTEST_OS_WINDOWS
+  std::wstring_convert<std::codecvt<wchar_t, char, std::mbstate_t>> converter;
+  std::wstring wide_path = converter.from_bytes(path);
+  std::wstring wide_mode = converter.from_bytes(mode);
+  return _wfopen(wide_path.c_str(), wide_mode.c_str());
+#else
   return fopen(path, mode);
+#endif  // GTEST_OS_WINDOWS
 }
 #if !GTEST_OS_WINDOWS_MOBILE
 inline FILE *FReopen(const char* path, const char* mode, FILE* stream) {

--- a/googletest/src/gtest-filepath.cc
+++ b/googletest/src/gtest-filepath.cc
@@ -349,33 +349,21 @@ FilePath FilePath::RemoveTrailingPathSeparator() const {
 // For example, "bar///foo" becomes "bar/foo". Does not eliminate other
 // redundancies that might be in a pathname involving "." or "..".
 void FilePath::Normalize() {
-  if (pathname_.c_str() == nullptr) {
-    pathname_ = "";
-    return;
-  }
-  const char* src = pathname_.c_str();
-  char* const dest = new char[pathname_.length() + 1];
-  char* dest_ptr = dest;
-  memset(dest_ptr, 0, pathname_.length() + 1);
+  std::string normalized_pathname;
+  normalized_pathname.reserve(pathname_.length());
 
-  while (*src != '\0') {
-    *dest_ptr = *src;
-    if (!IsPathSeparator(*src)) {
-      src++;
+  for (const char character : pathname_) {
+    if (!IsPathSeparator(character)) {
+      normalized_pathname.push_back(character);
+    } else if (normalized_pathname.empty() ||
+               normalized_pathname.back() != kPathSeparator) {
+      normalized_pathname.push_back(kPathSeparator);
     } else {
-#if GTEST_HAS_ALT_PATH_SEP_
-      if (*dest_ptr == kAlternatePathSeparator) {
-        *dest_ptr = kPathSeparator;
-      }
-#endif
-      while (IsPathSeparator(*src))
-        src++;
+      continue;
     }
-    dest_ptr++;
   }
-  *dest_ptr = '\0';
-  pathname_ = dest;
-  delete[] dest;
+
+  pathname_ = normalized_pathname;
 }
 
 }  // namespace internal


### PR DESCRIPTION
Export Test - Do Not Merge

Fix the ACTION* macros to allow for more than 10 arguments in the action.
Only the first 10 will be passed as individual arguments as `argN`, but the rest
can be accessed from the `args` tuple.
