### PR TITLE
Fix compilation on OpenBSD 6.7

### DIFF
--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -198,7 +198,8 @@ size_t GetThreadCount() {
   if (sysctl(mib, miblen, NULL, &size, NULL, 0)) {
     return 0;
   }
-  mib[5] = size / mib[4];
+
+  mib[5] = static_cast<int>(size / static_cast<size_t>(mib[4]));
 
   // populate array of structs
   struct kinfo_proc info[mib[5]];
@@ -207,8 +208,8 @@ size_t GetThreadCount() {
   }
 
   // exclude empty members
-  int nthreads = 0;
-  for (size_t i = 0; i < size / mib[4]; i++) {
+  size_t nthreads = 0;
+  for (size_t i = 0; i < size / static_cast<size_t>(mib[4]); i++) {
     if (info[i].p_tid != -1)
       nthreads++;
   }


### PR DESCRIPTION
Building on OpenBSD 6.7 current fails due to implicit numeric
conversions.

    OpenBSD clang version 8.0.1 (tags/RELEASE_801/final) (based on LLVM 8.0.1)
    Target: amd64-unknown-openbsd6.7
    Thread model: posix
    InstalledDir: /usr/bin

    In file included from /tmp/u/build/_deps/googletest-src/googletest/src/gtest-all.cc:45:
    /tmp/u/build/_deps/googletest-src/googletest/src/gtest-port.cc:201:19: error: implicit conversion changes signedness:
          'int' to 'unsigned long' [-Werror,-Wsign-conversion]
      mib[5] = size / mib[4];
                    ~ ^~~~~~
    /tmp/u/build/_deps/googletest-src/googletest/src/gtest-port.cc:211:33: error: implicit conversion changes signedness:
          'int' to 'unsigned long' [-Werror,-Wsign-conversion]
      for (size_t i = 0; i < size / mib[4]; i++) {
                                  ~ ^~~~~~
    /tmp/u/build/_deps/googletest-src/googletest/src/gtest-port.cc:215:10: error: implicit conversion changes signedness:
          'int' to 'size_t' (aka 'unsigned long') [-Werror,-Wsign-conversion]
      return nthreads;
      ~~~~~~ ^~~~~~~~
    /tmp/u/build/_deps/googletest-src/googletest/src/gtest-port.cc:201:17: error: implicit conversion loses integer
          precision: 'unsigned long' to 'int' [-Werror,-Wshorten-64-to-32]
      mib[5] = size / mib[4];
             ~ ~~~~~^~~~~~~~
    4 errors generated.