### PR TITLE
Set minimum C++ version to be C++11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,9 +24,6 @@ Win32-Release/
 x64-Debug/
 x64-Release/
 
-# Eclipse
-.project
-
 # Ignore autoconf / automake files
 Makefile.in
 aclocal.m4

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ Win32-Release/
 x64-Debug/
 x64-Release/
 
+# Eclipse
+.project
+
 # Ignore autoconf / automake files
 Makefile.in
 aclocal.m4

--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -78,6 +78,11 @@ set(gmock_build_include_dirs
   "${gtest_SOURCE_DIR}")
 include_directories(${gmock_build_include_dirs})
 
+# Set minimum C++ version to C++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 ########################################################################
 #
 # Defines the gmock & gmock_main libraries.  User tests should link

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -117,6 +117,11 @@ set(gtest_build_include_dirs
   "${gtest_SOURCE_DIR}")
 include_directories(${gtest_build_include_dirs})
 
+# Set minimum C++ version to C++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 ########################################################################
 #
 # Defines the gtest & gtest_main libraries.  User tests should link


### PR DESCRIPTION
Hey All,

I just pulled down GoogleTest on my MacOS and tried to build it locally.  I ran into some build errors with CMake because clang was defaulting to a C++ version less than C++11.  I edited the CMake files in GoogleTest, and GoogleMock to enforce a minimum version of C++11, which will allow GoogleTest to work out-of-the-box on MacOS.

Thanks,
Seth