### PR TITLE
Add matchers for testing exception properties

### DIFF
--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -4812,7 +4812,8 @@ class ExceptionMatcherImpl {
 //
 //   EXPECT_THAT(
 //       []() { throw std::runtime_error("message"); },
-//       Throws
+//       Throws<std::runtime_error>(
+//           Property(&std::runtime_error::what, HasSubstr("message"))));
 
 template <typename Err>
 PolymorphicMatcher<internal::ExceptionMatcherImpl<Err>>

--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -4843,7 +4843,7 @@ ThrowsMessage(const MessageMatcher& messageMatcher) {
   // literals, e.g. ThrowsMessage("message").
   return MakePolymorphicMatcher(
       internal::ExceptionMatcherImpl<Err>{
-          Property("description", &std::exception::what,
+          Property("what", &std::exception::what,
                    MatcherCast<std::string>(messageMatcher))});
 }
 template <typename Err, typename Message = std::string>
@@ -4854,7 +4854,7 @@ ThrowsMessageHasSubstr(const internal::StringLike<Message>& message) {
       "expected an std::exception-derived class");
   return MakePolymorphicMatcher(
       internal::ExceptionMatcherImpl<Err>{
-          Property("description", &std::exception::what, HasSubstr(message))});
+          Property("what", &std::exception::what, HasSubstr(message))});
 }
 
 #endif  // GTEST_HAS_EXCEPTIONS

--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -4774,15 +4774,15 @@ class ExceptionMatcherImpl {
   ExceptionMatcherImpl(Matcher<const Err&> matcher)
       : matcher_(std::move(matcher)) {}
 
-  void DescribeTo(::std::ostream* os) const {
-    *os << "throws an exception of type " << GetTypeName<Err>();
+  void DescribeTo(std::ostream* os) const {
+    *os << "throws an exception which is a " << GetTypeName<Err>();
     if (matcher_.GetDescriber() != nullptr) {
       *os << " which ";
       matcher_.DescribeTo(os);
     }
   }
 
-  void DescribeNegationTo(::std::ostream* os) const {
+  void DescribeNegationTo(std::ostream* os) const {
     *os << "not (";
     DescribeTo(os);
     *os << ")";
@@ -4793,7 +4793,7 @@ class ExceptionMatcherImpl {
     try {
       (void)(std::forward<T>(x)());
     } catch (const Err& err) {
-      *listener << "throws an exception of type " << GetTypeName<Err>();
+      *listener << "throws an exception which is a " << GetTypeName<Err>();
       if (matcher_.GetDescriber() != nullptr) {
         *listener << " ";
         return matcher_.MatchAndExplain(err, listener);
@@ -4826,7 +4826,6 @@ class ExceptionMatcherImpl {
 // Throws()
 // Throws(exceptionMatcher)
 // ThrowsMessage(messageMatcher)
-// ThrowsMessageHasSubstr(message)
 //
 // This matcher accepts a callable and verifies that when invoked, it throws
 // an exception with the given type and properties.
@@ -4840,10 +4839,6 @@ class ExceptionMatcherImpl {
 //   EXPECT_THAT(
 //       []() { throw std::runtime_error("message"); },
 //       ThrowsMessage<std::runtime_error>(HasSubstr("message")));
-//
-//   EXPECT_THAT(
-//       []() { throw std::runtime_error("message"); },
-//       ThrowsMessageHasSubstr<std::runtime_error>("message"));
 //
 //   EXPECT_THAT(
 //       []() { throw std::runtime_error("message"); },
@@ -4881,16 +4876,6 @@ ThrowsMessage(const MessageMatcher& messageMatcher) {
       internal::ExceptionMatcherImpl<Err>{
           Property("what", &std::exception::what,
                    MatcherCast<std::string>(messageMatcher))});
-}
-template <typename Err, typename Message = std::string>
-PolymorphicMatcher<internal::ExceptionMatcherImpl<Err>>
-ThrowsMessageHasSubstr(const internal::StringLike<Message>& message) {
-  static_assert(
-      std::is_base_of<std::exception, Err>::value,
-      "expected an std::exception-derived class");
-  return MakePolymorphicMatcher(
-      internal::ExceptionMatcherImpl<Err>{
-          Property("what", &std::exception::what, HasSubstr(message))});
 }
 
 #endif  // GTEST_HAS_EXCEPTIONS

--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -4738,7 +4738,6 @@ class ExceptionMatcherImpl {
   ExceptionMatcherImpl(Matcher<const Err&> matcher)
       : matcher_(std::move(matcher)) {}
 
- public:
   void DescribeTo(::std::ostream* os) const {
     *os << "throws an exception of type " << GetTypeName<Err>();
     if (matcher_.GetDescriber() != nullptr) {
@@ -4775,7 +4774,7 @@ class ExceptionMatcherImpl {
       *listener << "with description \"" << err.what() << "\"";
       return false;
     } catch (...) {
-      *listener << "throws an exception of some other type";
+      *listener << "throws an exception of an unknown type";
       return false;
     }
     *listener << "does not throw any exception";

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -8131,10 +8131,6 @@ TEST(ThrowsTest, Examples) {
 
   EXPECT_THAT(
       []() { throw std::runtime_error("message"); },
-      ThrowsMessageHasSubstr<std::runtime_error>("message"));
-
-  EXPECT_THAT(
-      []() { throw std::runtime_error("message"); },
       Throws<std::runtime_error>(
           Property(&std::runtime_error::what, HasSubstr("message"))));
 }
@@ -8165,14 +8161,9 @@ TEST(ThrowsTest, CallableExecutedExactlyOnce) {
 
   EXPECT_THAT(
       [&a]() { a++; throw std::runtime_error("message"); },
-      ThrowsMessageHasSubstr<std::runtime_error>("message"));
-  EXPECT_EQ(a, 4u);
-
-  EXPECT_THAT(
-      [&a]() { a++; throw std::runtime_error("message"); },
       Throws<std::runtime_error>(
           Property(&std::runtime_error::what, HasSubstr("message"))));
-  EXPECT_EQ(a, 5u);
+  EXPECT_EQ(a, 4u);
 }
 
 TEST(ThrowsTest, Describe) {
@@ -8180,7 +8171,7 @@ TEST(ThrowsTest, Describe) {
   std::stringstream ss;
   matcher.DescribeTo(&ss);
   auto explanation = ss.str();
-  EXPECT_THAT(explanation, testing::HasSubstr("std::runtime_error"));
+  EXPECT_THAT(explanation, HasSubstr("std::runtime_error"));
 }
 
 TEST(ThrowsTest, Success) {
@@ -8189,7 +8180,7 @@ TEST(ThrowsTest, Success) {
   EXPECT_TRUE(
       matcher.MatchAndExplain(
           []() { throw std::runtime_error("error message"); }, &listener));
-  EXPECT_THAT(listener.str(), testing::HasSubstr("std::runtime_error"));
+  EXPECT_THAT(listener.str(), HasSubstr("std::runtime_error"));
 }
 
 TEST(ThrowsTest, FailWrongType) {
@@ -8198,8 +8189,8 @@ TEST(ThrowsTest, FailWrongType) {
   EXPECT_FALSE(
       matcher.MatchAndExplain(
           []() { throw std::logic_error("error message"); }, &listener));
-  EXPECT_THAT(listener.str(), testing::HasSubstr("std::logic_error"));
-  EXPECT_THAT(listener.str(), testing::HasSubstr("\"error message\""));
+  EXPECT_THAT(listener.str(), HasSubstr("std::logic_error"));
+  EXPECT_THAT(listener.str(), HasSubstr("\"error message\""));
 }
 
 TEST(ThrowsTest, FailWrongTypeNonStd) {
@@ -8210,7 +8201,7 @@ TEST(ThrowsTest, FailWrongTypeNonStd) {
           []() { throw 10; }, &listener));
   EXPECT_THAT(
       listener.str(),
-      testing::HasSubstr("throws an exception of an unknown type"));
+      HasSubstr("throws an exception of an unknown type"));
 }
 
 TEST(ThrowsTest, FailNoThrow) {
@@ -8221,7 +8212,7 @@ TEST(ThrowsTest, FailNoThrow) {
           []() { (void)0; }, &listener));
   EXPECT_THAT(
       listener.str(),
-      testing::HasSubstr("does not throw any exception"));
+      HasSubstr("does not throw any exception"));
 }
 
 class ThrowsPredicateTest: public TestWithParam<Matcher<void (*)()>> {};
@@ -8231,8 +8222,8 @@ TEST_P(ThrowsPredicateTest, Describe) {
   std::stringstream ss;
   matcher.DescribeTo(&ss);
   auto explanation = ss.str();
-  EXPECT_THAT(explanation, testing::HasSubstr("std::runtime_error"));
-  EXPECT_THAT(explanation, testing::HasSubstr("error message"));
+  EXPECT_THAT(explanation, HasSubstr("std::runtime_error"));
+  EXPECT_THAT(explanation, HasSubstr("error message"));
 }
 
 TEST_P(ThrowsPredicateTest, Success) {
@@ -8241,7 +8232,7 @@ TEST_P(ThrowsPredicateTest, Success) {
   EXPECT_TRUE(
       matcher.MatchAndExplain(
           []() { throw std::runtime_error("error message"); }, &listener));
-  EXPECT_THAT(listener.str(), testing::HasSubstr("std::runtime_error"));
+  EXPECT_THAT(listener.str(), HasSubstr("std::runtime_error"));
 }
 
 TEST_P(ThrowsPredicateTest, FailWrongType) {
@@ -8250,8 +8241,8 @@ TEST_P(ThrowsPredicateTest, FailWrongType) {
   EXPECT_FALSE(
       matcher.MatchAndExplain(
           []() { throw std::logic_error("error message"); }, &listener));
-  EXPECT_THAT(listener.str(), testing::HasSubstr("std::logic_error"));
-  EXPECT_THAT(listener.str(), testing::HasSubstr("\"error message\""));
+  EXPECT_THAT(listener.str(), HasSubstr("std::logic_error"));
+  EXPECT_THAT(listener.str(), HasSubstr("\"error message\""));
 }
 
 TEST_P(ThrowsPredicateTest, FailWrongTypeNonStd) {
@@ -8262,7 +8253,7 @@ TEST_P(ThrowsPredicateTest, FailWrongTypeNonStd) {
           []() { throw 10; }, &listener));
   EXPECT_THAT(
       listener.str(),
-      testing::HasSubstr("throws an exception of an unknown type"));
+      HasSubstr("throws an exception of an unknown type"));
 }
 
 TEST_P(ThrowsPredicateTest, FailWrongMessage) {
@@ -8271,8 +8262,8 @@ TEST_P(ThrowsPredicateTest, FailWrongMessage) {
   EXPECT_FALSE(
       matcher.MatchAndExplain(
           []() { throw std::runtime_error("wrong message"); }, &listener));
-  EXPECT_THAT(listener.str(), testing::HasSubstr("std::runtime_error"));
-  EXPECT_THAT(listener.str(), testing::HasSubstr("wrong message"));
+  EXPECT_THAT(listener.str(), HasSubstr("std::runtime_error"));
+  EXPECT_THAT(listener.str(), HasSubstr("wrong message"));
 }
 
 TEST_P(ThrowsPredicateTest, FailNoThrow) {
@@ -8283,18 +8274,16 @@ TEST_P(ThrowsPredicateTest, FailNoThrow) {
           []() { (void)0; }, &listener));
   EXPECT_THAT(
       listener.str(),
-      testing::HasSubstr("does not throw any exception"));
+      HasSubstr("does not throw any exception"));
 }
 
 INSTANTIATE_TEST_SUITE_P(AllMessagePredicates, ThrowsPredicateTest,
-    ::testing::Values(
+    Values(
         static_cast<Matcher<void (*)()>>(
             Throws<std::runtime_error>(
                 Property(&std::exception::what, HasSubstr("error message")))),
         static_cast<Matcher<void (*)()>>(
-            ThrowsMessage<std::runtime_error>(HasSubstr("error message"))),
-        static_cast<Matcher<void (*)()>>(
-            ThrowsMessageHasSubstr<std::runtime_error>("error message"))));
+            ThrowsMessage<std::runtime_error>(HasSubstr("error message")))));
 
 // Tests that Throws<E1>(Matcher<E2>{}) compiles even when E2 != const E1&.
 TEST(ThrowsPredicateCompilesTest, ExceptionMatcherAcceptsBroadType) {
@@ -8329,26 +8318,6 @@ TEST(ThrowsPredicateCompilesTest, MessageMatcherAcceptsNonMatcher) {
   EXPECT_FALSE(
       matcher.Matches(
           []() { throw std::runtime_error("wrong error message"); }));
-}
-
-// Tests that ThrowsMessageHasSubstr accepts types that're
-// explicitly-convertible to std::string.
-TEST(ThrowsPredicateCompilesTest, StringLikeMessage) {
-  struct SomeCustomString {
-    std::string inner;
-
-    // Note: explicit conversion.
-    explicit operator std::string() const { return inner; }
-  };
-
-  Matcher<void (*)()> matcher = ThrowsMessageHasSubstr<std::runtime_error>(
-      SomeCustomString{"error message"});
-  EXPECT_TRUE(
-      matcher.Matches(
-          []() { throw std::runtime_error("error message"); }));
-  EXPECT_FALSE(
-      matcher.Matches(
-          []() { throw std::runtime_error("wrong message"); }));
 }
 
 #endif  // GTEST_HAS_EXCEPTIONS

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -8282,10 +8282,8 @@ TEST(ThrowsPredicateCompilesTest, StringLikeMessage) {
     std::string inner;
 
     // Note: explicit conversion.
-    explicit operator std::string() const {
-      return inner;
-    }
-};
+    explicit operator std::string() const { return inner; }
+  };
 
   Matcher<void (*)()> matcher = ThrowsMessageHasSubstr<std::runtime_error>(
       SomeCustomString{"error message"});

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -8145,6 +8145,36 @@ TEST(ThrowsTest, DoesNotGenerateDuplicateCatchClauseWarning) {
       Throws<std::exception>());
 }
 
+TEST(ThrowsTest, CallableExecutedExactlyOnce) {
+  size_t a = 0;
+
+  EXPECT_THAT(
+      [&a]() { a++; throw 10; },
+      Throws<int>());
+  EXPECT_EQ(a, 1);
+
+  EXPECT_THAT(
+      [&a]() { a++; throw std::runtime_error("message"); },
+      Throws<std::runtime_error>());
+  EXPECT_EQ(a, 2);
+
+  EXPECT_THAT(
+      [&a]() { a++; throw std::runtime_error("message"); },
+      ThrowsMessage<std::runtime_error>(HasSubstr("message")));
+  EXPECT_EQ(a, 3);
+
+  EXPECT_THAT(
+      [&a]() { a++; throw std::runtime_error("message"); },
+      ThrowsMessageHasSubstr<std::runtime_error>("message"));
+  EXPECT_EQ(a, 4);
+
+  EXPECT_THAT(
+      [&a]() { a++; throw std::runtime_error("message"); },
+      Throws<std::runtime_error>(
+          Property(&std::runtime_error::what, HasSubstr("message"))));
+  EXPECT_EQ(a, 5);
+}
+
 TEST(ThrowsTest, Describe) {
   Matcher<void (*)()> matcher = Throws<std::runtime_error>();
   std::stringstream ss;

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -8119,6 +8119,26 @@ TEST(MatcherPMacroTest, WorksOnMoveOnlyType) {
 
 #if GTEST_HAS_EXCEPTIONS
 
+// Test that examples from documentation compile
+TEST(ThrowsTest, Examples) {
+  EXPECT_THAT(
+      []() { throw std::runtime_error("message"); },
+      Throws<std::runtime_error>());
+
+  EXPECT_THAT(
+      []() { throw std::runtime_error("message"); },
+      ThrowsMessage<std::runtime_error>(HasSubstr("message")));
+
+  EXPECT_THAT(
+      []() { throw std::runtime_error("message"); },
+      ThrowsMessageHasSubstr<std::runtime_error>("message"));
+
+  EXPECT_THAT(
+      []() { throw std::runtime_error("message"); },
+      Throws<std::runtime_error>(
+          Property(&std::runtime_error::what, HasSubstr("message"))));
+}
+
 TEST(ThrowsTest, Describe) {
   Matcher<void (*)()> matcher = Throws<std::runtime_error>();
   std::stringstream ss;

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -8139,6 +8139,12 @@ TEST(ThrowsTest, Examples) {
           Property(&std::runtime_error::what, HasSubstr("message"))));
 }
 
+TEST(ThrowsTest, DoesNotGenerateDuplicateCatchClauseWarning) {
+  EXPECT_THAT(
+      []() { throw std::exception(); },
+      Throws<std::exception>());
+}
+
 TEST(ThrowsTest, Describe) {
   Matcher<void (*)()> matcher = Throws<std::runtime_error>();
   std::stringstream ss;

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -8210,7 +8210,7 @@ TEST(ThrowsTest, FailWrongTypeNonStd) {
           []() { throw 10; }, &listener));
   EXPECT_THAT(
       listener.str(),
-      testing::HasSubstr("throws an exception of some other type"));
+      testing::HasSubstr("throws an exception of an unknown type"));
 }
 
 TEST(ThrowsTest, FailNoThrow) {
@@ -8262,7 +8262,7 @@ TEST_P(ThrowsPredicateTest, FailWrongTypeNonStd) {
           []() { throw 10; }, &listener));
   EXPECT_THAT(
       listener.str(),
-      testing::HasSubstr("throws an exception of some other type"));
+      testing::HasSubstr("throws an exception of an unknown type"));
 }
 
 TEST_P(ThrowsPredicateTest, FailWrongMessage) {

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -8151,28 +8151,28 @@ TEST(ThrowsTest, CallableExecutedExactlyOnce) {
   EXPECT_THAT(
       [&a]() { a++; throw 10; },
       Throws<int>());
-  EXPECT_EQ(a, 1);
+  EXPECT_EQ(a, 1u);
 
   EXPECT_THAT(
       [&a]() { a++; throw std::runtime_error("message"); },
       Throws<std::runtime_error>());
-  EXPECT_EQ(a, 2);
+  EXPECT_EQ(a, 2u);
 
   EXPECT_THAT(
       [&a]() { a++; throw std::runtime_error("message"); },
       ThrowsMessage<std::runtime_error>(HasSubstr("message")));
-  EXPECT_EQ(a, 3);
+  EXPECT_EQ(a, 3u);
 
   EXPECT_THAT(
       [&a]() { a++; throw std::runtime_error("message"); },
       ThrowsMessageHasSubstr<std::runtime_error>("message"));
-  EXPECT_EQ(a, 4);
+  EXPECT_EQ(a, 4u);
 
   EXPECT_THAT(
       [&a]() { a++; throw std::runtime_error("message"); },
       Throws<std::runtime_error>(
           Property(&std::runtime_error::what, HasSubstr("message"))));
-  EXPECT_EQ(a, 5);
+  EXPECT_EQ(a, 5u);
 }
 
 TEST(ThrowsTest, Describe) {


### PR DESCRIPTION
This PR adds matchers that accept a callable and verify that when invoked, it throws an exception with the given type and properties.

Fixes #952