### PR TITLE
fix test failures in some cmake configurations

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -277,7 +277,12 @@ function(py_test name)
   if (PYTHONINTERP_FOUND)
     if ("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" VERSION_GREATER 3.1)
       file(TO_CMAKE_PATH "$ENV{PATH}" PATH)
-      file(TO_NATIVE_PATH "${CMAKE_BINARY_DIR}/bin;${CMAKE_BINARY_DIR}/bin/$<CONFIG>;${PATH}" PATH)
+      list(INSERT PATH 0 "${CMAKE_BINARY_DIR}/bin" "${CMAKE_BINARY_DIR}/bin/$<CONFIG>")
+      if(CMAKE_HOST_WIN32)
+        file(TO_NATIVE_PATH "${PATH}" PATH)
+      else(CMAKE_HOST_WIN32)
+        string(REPLACE ";" ":" PATH "${PATH}")
+      endif()
       if (CMAKE_CONFIGURATION_TYPES)
         # Multi-configuration build generators as for Visual Studio save
         # output in a subdirectory of CMAKE_CURRENT_BINARY_DIR (Debug,


### PR DESCRIPTION
This partially fixes #2368, where tests are failing due to the file
`RunTest.ps1` not being found. The bug occurs when the project is built
using cmake under Windows and using a single configuration generator
(ie. NMake).

The fix replaces powershell invocation with native CMake calls. This
will also solve problems caused by powershell execution policies
(#2687).

This should be considered a partial fix because it only works for CMake
versions newer than 3.0. However, it should be an acceptable fix since
it won't be the first place that an outdated CMake would fail. Perhaps
a new issue should be raised to either raise the minimum version of
CMake, or rewrite all parts of the project that uses newer features.