### PR TITLE
fix clang tidy modernize-use-equals-default warnings

### DIFF
--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1458,7 +1458,7 @@ class NeverThrown {
   class GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)                    \
       : public parent_class {                                                 \
    public:                                                                    \
-    GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)() {}                   \
+    GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)() = default;           \
     ~GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)() override = default; \
     GTEST_DISALLOW_COPY_AND_ASSIGN_(GTEST_TEST_CLASS_NAME_(test_suite_name,   \
                                                            test_name));       \


### PR DESCRIPTION
Prior to the fix using `TEST_F` will cause clang tidy warnings like

```
/home/jasjuang/sample/unit-test/SampleTest.cpp:23:1: warning: use '= default' to define a trivial default constructor [modernize-use-equals-default]
TEST_F(SampleTest, OnePlusOne)
^
/usr/include/gtest/gtest.h:2369:3: note: expanded from macro 'TEST_F'
  GTEST_TEST_(test_fixture, test_name, test_fixture, \
  ^
/usr/include/gtest/internal/gtest-internal.h:1358:58: note: expanded from macro 'GTEST_TEST_'
    GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)() {}                   \
                                                         ^
```

This PR eliminates this warning.