### PR TITLE
Removing tiny-dnn from "Who is using.."

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ following notable projects:
 *   [Protocol Buffers](https://github.com/google/protobuf), Google's data
     interchange format.
 *   The [OpenCV](http://opencv.org/) computer vision library.
-*   [tiny-dnn](https://github.com/tiny-dnn/tiny-dnn): header only,
-    dependency-free deep learning framework in C++11.
 
 ## Related Open Source Projects
 


### PR DESCRIPTION
The tiny-dnn project is not using googletest anymore, for more details see (https://github.com/tiny-dnn/tiny-dnn/commit/d0d35ca2f4e75b3f647787e19ee7f31d0784b398).

Removing it from the "Who is Using Google Test?" list so as to keep it accurate.