### PR TITLE
fix GTEST_REMOVE_LEGACY_TEST_CASEAPI_ build/test errors (Linux)

### DIFF
--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -1168,6 +1168,7 @@ class StreamingListener : public EmptyTestEventListener {
            StreamableToString(unit_test.elapsed_time()) + "ms");
   }
 
+#ifndef GTEST_REMOVE_LEGACY_TEST_CASEAPI_
   // Note that "event=TestCaseStart" is a wire format and has to remain
   // "case" for compatibilty
   void OnTestCaseStart(const TestCase& test_case) override {
@@ -1181,6 +1182,16 @@ class StreamingListener : public EmptyTestEventListener {
            "&elapsed_time=" + StreamableToString(test_case.elapsed_time()) +
            "ms");
   }
+#else
+  void OnTestSuiteStart(const TestSuite& test_suite) override {
+    SendLn(std::string("event=TestSuiteStart&name=") + test_suite.name());
+  }
+  void OnTestSuiteEnd(const TestSuite& test_suite) override {
+    SendLn("event=TestSuiteEnd&passed=" + FormatBool(test_suite.Passed()) +
+           "&elapsed_time=" + StreamableToString(test_suite.elapsed_time()) +
+           "ms");
+  }
+#endif
 
   void OnTestStart(const TestInfo& test_info) override {
     SendLn(std::string("event=TestStart&name=") + test_info.name());

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -113,6 +113,7 @@ TEST_F(StreamingListenerTest, OnTestIterationEnd) {
   EXPECT_EQ("event=TestIterationEnd&passed=1&elapsed_time=0ms\n", *output());
 }
 
+#ifndef GTEST_REMOVE_LEGACY_TEST_CASEAPI_
 TEST_F(StreamingListenerTest, OnTestCaseStart) {
   *output() = "";
   streamer_.OnTestCaseStart(TestCase("FooTest", "Bar", nullptr, nullptr));
@@ -124,6 +125,19 @@ TEST_F(StreamingListenerTest, OnTestCaseEnd) {
   streamer_.OnTestCaseEnd(TestCase("FooTest", "Bar", nullptr, nullptr));
   EXPECT_EQ("event=TestCaseEnd&passed=1&elapsed_time=0ms\n", *output());
 }
+#else
+TEST_F(StreamingListenerTest, OnTestSuiteStart) {
+  *output() = "";
+  streamer_.OnTestSuiteStart(TestSuite("FooTest", "Bar", nullptr, nullptr));
+  EXPECT_EQ("event=TestSuiteStart&name=FooTest\n", *output());
+}
+
+TEST_F(StreamingListenerTest, OnTestSuiteEnd) {
+  *output() = "";
+  streamer_.OnTestSuiteEnd(TestSuite("FooTest", "Bar", nullptr, nullptr));
+  EXPECT_EQ("event=TestSuiteEnd&passed=1&elapsed_time=0ms\n", *output());
+}
+#endif
 
 TEST_F(StreamingListenerTest, OnTestStart) {
   *output() = "";


### PR DESCRIPTION
fix error (defined(GTEST_REMOVE_LEGACY_TEST_CASEAPI_) && GTEST_CAN_STREAM_RESULTS_)

```
docker run --rm -it -v $(pwd):/gtest -w /gtest ubuntu:18.04 bash
apt-get update && apt-get install -q -y git cmake make g++ lcov
mkdir mybuild
cd mybuild
cmake -Dgtest_build_tests=ON -Dgmock_build_tests=ON -DCMAKE_CXX_FLAGS=-DGTEST_REMOVE_LEGACY_TEST_CASEAPI_ ${GTEST_REPO_DIR}
make && make test
```