### PR TITLE
Export LICENSE

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -36,6 +36,8 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
+exports_files(["LICENSE"])
+
 config_setting(
     name = "windows",
     constraint_values = ["@bazel_tools//platforms:windows"],


### PR DESCRIPTION
This makes it easier to include the license in redistributions, as required by the license.