### PR TITLE
Move Unwrap helper to internal namespace

### DIFF
--- a/googletest/include/gtest/gtest-matchers.h
+++ b/googletest/include/gtest/gtest-matchers.h
@@ -535,11 +535,6 @@ class ComparisonBase {
   }
 
  private:
-  template <typename T>
-  static const T& Unwrap(const T& v) { return v; }
-  template <typename T>
-  static const T& Unwrap(std::reference_wrapper<T> v) { return v; }
-
   template <typename Lhs, typename = Rhs>
   class Impl : public MatcherInterface<Lhs> {
    public:

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1243,6 +1243,17 @@ class FlatTuple
   }
 };
 
+// utility functions to unwrap std::reference_wrapper
+template <typename T>
+const T& Unwrap(const T& v) {
+    return v;
+}
+
+template <typename T>
+const T& Unwrap(std::reference_wrapper<T> v) {
+    return v;
+}
+
 // Utility functions to be called with static_assert to induce deprecation
 // warnings.
 GTEST_INTERNAL_DEPRECATED(


### PR DESCRIPTION
Allow to use this methods in custom matchers to avoid code duplication.