### PR TITLE
Refactor gtest-filepath

### DIFF
--- a/googletest/include/gtest/internal/gtest-filepath.h
+++ b/googletest/include/gtest/internal/gtest-filepath.h
@@ -61,16 +61,12 @@ namespace internal {
 
 class GTEST_API_ FilePath {
  public:
-  FilePath() : pathname_("") { }
-  FilePath(const FilePath& rhs) : pathname_(rhs.pathname_) { }
+  FilePath() = default;
+  FilePath(FilePath&& rhs) = default;
+  FilePath& operator=(FilePath&& rhs) = default;
 
   explicit FilePath(const std::string& pathname) : pathname_(pathname) {
     Normalize();
-  }
-
-  FilePath& operator=(const FilePath& rhs) {
-    Set(rhs);
-    return *this;
   }
 
   void Set(const FilePath& rhs) {
@@ -173,6 +169,9 @@ class GTEST_API_ FilePath {
   bool IsAbsolutePath() const;
 
  private:
+  FilePath(const FilePath& rhs) = default;
+  FilePath& operator=(const FilePath& rhs) = default;
+
   // Replaces multiple consecutive separators with a single separator.
   // For example, "bar///foo" becomes "bar/foo". Does not eliminate other
   // redundancies that might be in a pathname involving "." or "..".

--- a/googletest/include/gtest/internal/gtest-filepath.h
+++ b/googletest/include/gtest/internal/gtest-filepath.h
@@ -69,10 +69,6 @@ class GTEST_API_ FilePath {
     Normalize();
   }
 
-  void Set(const FilePath& rhs) {
-    pathname_ = rhs.pathname_;
-  }
-
   const std::string& string() const { return pathname_; }
   const char* c_str() const { return pathname_.c_str(); }
 

--- a/googletest/src/gtest-filepath.cc
+++ b/googletest/src/gtest-filepath.cc
@@ -282,7 +282,7 @@ FilePath FilePath::GenerateUniqueFileName(const FilePath& directory,
   FilePath full_pathname;
   int number = 0;
   do {
-    full_pathname.Set(MakeFileName(directory, base_name, number++, extension));
+    full_pathname = MakeFileName(directory, base_name, number++, extension);
   } while (full_pathname.FileOrDirectoryExists());
   return full_pathname;
 }

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -690,7 +690,7 @@ class GTEST_API_ UnitTestImpl {
     // AddTestInfo(), which is called to register a TEST or TEST_F
     // before main() is reached.
     if (original_working_dir_.IsEmpty()) {
-      original_working_dir_.Set(FilePath::GetCurrentDir());
+      original_working_dir_ = FilePath::GetCurrentDir();
       GTEST_CHECK_(!original_working_dir_.IsEmpty())
           << "Failed to get the current working directory.";
     }

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -594,9 +594,9 @@ FilePath GetCurrentExecutableName() {
   FilePath result;
 
 #if GTEST_OS_WINDOWS || GTEST_OS_OS2
-  result.Set(FilePath(GetArgvs()[0]).RemoveExtension("exe"));
+  result = FilePath(GetArgvs()[0]).RemoveExtension("exe");
 #else
-  result.Set(FilePath(GetArgvs()[0]));
+  result = FilePath(GetArgvs()[0]);
 #endif  // GTEST_OS_WINDOWS
 
   return result.RemoveDirectoryName();

--- a/googletest/test/googletest-filepath-test.cc
+++ b/googletest/test/googletest-filepath-test.cc
@@ -455,15 +455,15 @@ TEST(NormalizeTest, MixAlternateSeparatorAtStringEnd) {
 class DirectoryCreationTest : public Test {
  protected:
   void SetUp() override {
-    testdata_path_.Set(FilePath(
+    testdata_path_ = FilePath(
         TempDir() + GetCurrentExecutableName().string() +
-        "_directory_creation" GTEST_PATH_SEP_ "test" GTEST_PATH_SEP_));
-    testdata_file_.Set(testdata_path_.RemoveTrailingPathSeparator());
+        "_directory_creation" GTEST_PATH_SEP_ "test" GTEST_PATH_SEP_);
+    testdata_file_ = testdata_path_.RemoveTrailingPathSeparator();
 
-    unique_file0_.Set(FilePath::MakeFileName(testdata_path_, FilePath("unique"),
-        0, "txt"));
-    unique_file1_.Set(FilePath::MakeFileName(testdata_path_, FilePath("unique"),
-        1, "txt"));
+    unique_file0_ = FilePath::MakeFileName(testdata_path_, FilePath("unique"),
+        0, "txt");
+    unique_file1_ = FilePath::MakeFileName(testdata_path_, FilePath("unique"),
+        1, "txt");
 
     remove(testdata_file_.c_str());
     remove(unique_file0_.c_str());
@@ -554,14 +554,6 @@ TEST(FilePathTest, CharAndMoveConstructor) {
 TEST(FilePathTest, StringConstructor) {
   const FilePath fp(std::string("cider"));
   EXPECT_EQ("cider", fp.string());
-}
-
-TEST(FilePathTest, Set) {
-  const FilePath apple("apple");
-  FilePath mac("mac");
-  mac.Set(apple);  // Implement Set() since overloading operator= is forbidden.
-  EXPECT_EQ("apple", mac.string());
-  EXPECT_EQ("apple", apple.string());
 }
 
 TEST(FilePathTest, ToString) {

--- a/googletest/test/googletest-filepath-test.cc
+++ b/googletest/test/googletest-filepath-test.cc
@@ -452,29 +452,6 @@ TEST(NormalizeTest, MixAlternateSeparatorAtStringEnd) {
 
 #endif
 
-TEST(AssignmentOperatorTest, DefaultAssignedToNonDefault) {
-  FilePath default_path;
-  FilePath non_default_path("path");
-  non_default_path = default_path;
-  EXPECT_EQ("", non_default_path.string());
-  EXPECT_EQ("", default_path.string());  // RHS var is unchanged.
-}
-
-TEST(AssignmentOperatorTest, NonDefaultAssignedToDefault) {
-  FilePath non_default_path("path");
-  FilePath default_path;
-  default_path = non_default_path;
-  EXPECT_EQ("path", default_path.string());
-  EXPECT_EQ("path", non_default_path.string());  // RHS var is unchanged.
-}
-
-TEST(AssignmentOperatorTest, ConstAssignedToNonConst) {
-  const FilePath const_default_path("const_path");
-  FilePath non_default_path("path");
-  non_default_path = const_default_path;
-  EXPECT_EQ("const_path", non_default_path.string());
-}
-
 class DirectoryCreationTest : public Test {
  protected:
   void SetUp() override {
@@ -566,12 +543,12 @@ TEST(FilePathTest, DefaultConstructor) {
   EXPECT_EQ("", fp.string());
 }
 
-TEST(FilePathTest, CharAndCopyConstructors) {
-  const FilePath fp("spicy");
+TEST(FilePathTest, CharAndMoveConstructor) {
+  FilePath fp("spicy");
   EXPECT_EQ("spicy", fp.string());
 
-  const FilePath fp_copy(fp);
-  EXPECT_EQ("spicy", fp_copy.string());
+  FilePath fp_move(std::move(fp));
+  EXPECT_EQ("spicy", fp_move.string());
 }
 
 TEST(FilePathTest, StringConstructor) {

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -6277,9 +6277,9 @@ class FlagfileTest : public ParseFlagsTest {
   void SetUp() override {
     ParseFlagsTest::SetUp();
 
-    testdata_path_.Set(internal::FilePath(
+    testdata_path_ = internal::FilePath(
         testing::TempDir() + internal::GetCurrentExecutableName().string() +
-        "_flagfile_test"));
+        "_flagfile_test");
     testing::internal::posix::RmDir(testdata_path_.c_str());
     EXPECT_TRUE(testdata_path_.CreateFolder());
   }


### PR DESCRIPTION
- Simplified FilePath constructors
- FilePath is MoveOnly class now
- FilePath::Set -> move assignment operator