### PR TITLE
Fix color output with MinGW build under Console

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -3167,8 +3167,7 @@ static void PrintTestPartResult(const TestPartResult& test_part_result) {
 
 // class PrettyUnitTestResultPrinter
 #if defined(GTEST_OS_WINDOWS) && !defined(GTEST_OS_WINDOWS_MOBILE) &&    \
-    !defined(GTEST_OS_WINDOWS_PHONE) && !defined(GTEST_OS_WINDOWS_RT) && \
-    !defined(GTEST_OS_WINDOWS_MINGW)
+    !defined(GTEST_OS_WINDOWS_PHONE) && !defined(GTEST_OS_WINDOWS_RT)
 
 // Returns the character attribute for the given color.
 static WORD GetColorAttribute(GTestColor color) {
@@ -3215,7 +3214,7 @@ static WORD GetNewColor(GTestColor color, WORD old_color_attrs) {
   return new_color;
 }
 
-#else
+#endif  // GTEST_OS_WINDOWS && !GTEST_OS_WINDOWS_MOBILE
 
 // Returns the ANSI color code for the given color. GTestColor::kDefault is
 // an invalid input.
@@ -3233,7 +3232,13 @@ static const char* GetAnsiColorCode(GTestColor color) {
   }
 }
 
-#endif  // GTEST_OS_WINDOWS && !GTEST_OS_WINDOWS_MOBILE
+static void EmitAnsiColorOutput(GTestColor color,
+                                const char* fmt,
+                                va_list args) {
+  printf("\033[0;3%sm", GetAnsiColorCode(color));
+  vprintf(fmt, args);
+  printf("\033[m");  // Resets the terminal to default.
+}
 
 // Returns true if and only if Google Test should use colors in the output.
 bool ShouldUseColor(bool stdout_is_tty) {
@@ -3241,7 +3246,7 @@ bool ShouldUseColor(bool stdout_is_tty) {
   const char* const gtest_color = c.c_str();
 
   if (String::CaseInsensitiveCStringEquals(gtest_color, "auto")) {
-#if defined(GTEST_OS_WINDOWS) && !defined(GTEST_OS_WINDOWS_MINGW)
+#if defined(GTEST_OS_WINDOWS)
     // On Windows the TERM variable is usually not set, but the
     // console there does support colors.
     return stdout_is_tty;
@@ -3281,11 +3286,12 @@ static void ColoredPrintf(GTestColor color, const char* fmt, ...) {
   va_list args;
   va_start(args, fmt);
 
-  static const bool in_color_mode =
 #if GTEST_HAS_FILE_SYSTEM
-      ShouldUseColor(posix::IsATTY(posix::FileNo(stdout)) != 0);
+  static const bool stdout_is_tty = posix::IsATTY(posix::FileNo(stdout)) != 0;
+  static const bool in_color_mode = ShouldUseColor(stdout_is_tty);
 #else
-      false;
+  static const bool stdout_is_tty = false;
+  static const bool in_color_mode = false;
 #endif  // GTEST_HAS_FILE_SYSTEM
 
   const bool use_color = in_color_mode && (color != GTestColor::kDefault);
@@ -3297,31 +3303,37 @@ static void ColoredPrintf(GTestColor color, const char* fmt, ...) {
   }
 
 #if defined(GTEST_OS_WINDOWS) && !defined(GTEST_OS_WINDOWS_MOBILE) &&    \
-    !defined(GTEST_OS_WINDOWS_PHONE) && !defined(GTEST_OS_WINDOWS_RT) && \
-    !defined(GTEST_OS_WINDOWS_MINGW)
-  const HANDLE stdout_handle = GetStdHandle(STD_OUTPUT_HANDLE);
+    !defined(GTEST_OS_WINDOWS_PHONE) && !defined(GTEST_OS_WINDOWS_RT)
+# if GTEST_OS_WINDOWS_MINGW
+  static const bool using_mingw = AlwaysTrue();
+# else
+  static const bool using_mingw = AlwaysFalse();
+# endif
+  if (!using_mingw || stdout_is_tty) {
+    const HANDLE stdout_handle = GetStdHandle(STD_OUTPUT_HANDLE);
 
-  // Gets the current text color.
-  CONSOLE_SCREEN_BUFFER_INFO buffer_info;
-  GetConsoleScreenBufferInfo(stdout_handle, &buffer_info);
-  const WORD old_color_attrs = buffer_info.wAttributes;
-  const WORD new_color = GetNewColor(color, old_color_attrs);
+    // Gets the current text color.
+    CONSOLE_SCREEN_BUFFER_INFO buffer_info;
+    GetConsoleScreenBufferInfo(stdout_handle, &buffer_info);
+    const WORD old_color_attrs = buffer_info.wAttributes;
+    const WORD new_color = GetNewColor(color, old_color_attrs);
 
-  // We need to flush the stream buffers into the console before each
-  // SetConsoleTextAttribute call lest it affect the text that is already
-  // printed but has not yet reached the console.
-  fflush(stdout);
-  SetConsoleTextAttribute(stdout_handle, new_color);
+    // We need to flush the stream buffers into the console before each
+    // SetConsoleTextAttribute call lest it affect the text that is already
+    // printed but has not yet reached the console.
+    fflush(stdout);
+    SetConsoleTextAttribute(stdout_handle, new_color);
 
-  vprintf(fmt, args);
+    vprintf(fmt, args);
 
-  fflush(stdout);
-  // Restores the text color.
-  SetConsoleTextAttribute(stdout_handle, old_color_attrs);
+    fflush(stdout);
+    // Restores the text color.
+    SetConsoleTextAttribute(stdout_handle, old_color_attrs);
+  } else if (using_mingw) {
+    EmitAnsiColorOutput(color, fmt, args);
+  }
 #else
-  printf("\033[0;3%sm", GetAnsiColorCode(color));
-  vprintf(fmt, args);
-  printf("\033[m");  // Resets the terminal to default.
+  EmitAnsiColorOutput(color, fmt, args);
 #endif  // GTEST_OS_WINDOWS && !GTEST_OS_WINDOWS_MOBILE
   va_end(args);
 }
@@ -6518,6 +6530,12 @@ static const char kColorEncodedHelpMessage[] =
     "  @G--" GTEST_FLAG_PREFIX_
     "color=@Y(@Gyes@Y|@Gno@Y|@Gauto@Y)@D\n"
     "      Enable/disable colored output. The default is @Gauto@D.\n"
+# if GTEST_OS_WINDOWS_MINGW
+    "      With MinGW builds, color output will use the Windows Console API\n"
+    "      only if stdout is a TTY, otherwise it uses ANSI escape sequences.\n"
+    "      This means under mintty you need @G--" GTEST_FLAG_PREFIX_
+    "color=yes@D for color.\n"
+# endif
     "  @G--" GTEST_FLAG_PREFIX_
     "brief=1@D\n"
     "      Only print test failures.\n"


### PR DESCRIPTION
When built with MinGW, Google Test emits ANSI escape sequences for color output like it does on non-Windows platforms. This works with MSYS2's terminal ([`mintty.exe`](https://mintty.github.io/)) that intercepts stdout with a pipe and then renders color itself, but not with the native Windows Console (i.e. [`conhost.exe` in Windows 7 onwards, and `csrss.exe` earlier](https://devblogs.microsoft.com/commandline/windows-command-line-inside-the-windows-console/#so-whats-inside-the-windows-console)) that expects the Windows Console API to be used. This is arguably incorrect as the MinGW toolchain is intended for building native Windows programs, independent of any POSIX-like environment.

Change the color-output behavior of MinGW-built Google Test to be conditional:

 - If stdout is a TTY, use the Windows Console API. (This happens with Windows Console and Windows Terminal, as well as most 3rd-party consoles that screen-scrape the Windows Console.)
 - If stdout is not a TTY but the user specified `--gtest_color=yes`, use ANSI escape sequences. (This happens with `mintty.exe` and other 3rd-party consoles that directly read our stdout with a pipe, e.g. Travis CI's Windows logger.)

Behavior when built with any other compiler is unaffected. So Windows desktop toolchains (MSVC, C++Builder, etc.) will continue to use the Windows Console API unconditionally, while Cygwin, MSYS (not MinGW) and all other non-Windows toolchains will continue to use ANSI escape sequences unconditionally.

Fixes: #2809