### PR TITLE
Fix fuse_gmock_files.py

### DIFF
--- a/googlemock/scripts/fuse_gmock_files.py
+++ b/googlemock/scripts/fuse_gmock_files.py
@@ -66,8 +66,6 @@ import os
 import re
 import sys
 
-import fuse_gtest_files
-
 __author__ = 'wan@google.com (Zhanyong Wan)'
 
 # We assume that this file is in the scripts/ directory in the Google
@@ -76,6 +74,7 @@ DEFAULT_GMOCK_ROOT_DIR = os.path.join(os.path.dirname(__file__), '..')
 
 # We need to call into googletest/scripts/fuse_gtest_files.py.
 sys.path.append(os.path.join(DEFAULT_GMOCK_ROOT_DIR, '../googletest/scripts'))
+import fuse_gtest_files
 gtest = fuse_gtest_files
 
 # Regex for matching
@@ -130,7 +129,7 @@ def FuseGMockH(gmock_root, output_dir):
   """Scans folder gmock_root to generate gmock/gmock.h in output_dir."""
 
   output_file = open(os.path.join(output_dir, GMOCK_H_OUTPUT), 'w')
-  processed_files = frozenset()  # Holds all gmock headers we've processed.
+  processed_files = set()  # Holds all gmock headers we've processed.
 
   def ProcessFile(gmock_header_path):
     """Processes the given gmock header file."""
@@ -173,7 +172,7 @@ def FuseGMockH(gmock_root, output_dir):
 def FuseGMockAllCcToFile(gmock_root, output_file):
   """Scans folder gmock_root to fuse gmock-all.cc into output_file."""
 
-  processed_files = frozenset()
+  processed_files = set()
 
   def ProcessFile(gmock_source_file):
     """Processes the given gmock source file."""


### PR DESCRIPTION
Issue: #3063

After upgrade to python3 (72512aa89328f21fd18b636032c7a51d8d4ee068)
the script fails.

Module fuse_gtest_files can only be imported, after the path is added to
sys.path.

The processed_files cannot be frozen sets as add is called in
ProcessFile.