### PR TITLE
Fix invalid characters in XML output

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -325,6 +325,15 @@ $env:Path = \"$project_bin;$env:Path\"
 
   cxx_executable(gtest_xml_outfile1_test_ test gtest_main)
   cxx_executable(gtest_xml_outfile2_test_ test gtest_main)
+  cxx_library(gtest_unsigned_char "${cxx_unsigned_char}" src/gtest-all.cc)
+  cxx_library(gtest_main_unsigned_char "${cxx_unsigned_char}" src/gtest_main.cc)
+  target_link_libraries(gtest_main_unsigned_char PUBLIC gtest_unsigned_char)
+  cxx_executable_with_flags(
+    gtest_xml_outfile3_test_
+    "${cxx_unsigned_char}"
+    gtest_main_unsigned_char
+    test/gtest_xml_outfile3_test_.cc
+  )
   py_test(gtest_xml_outfiles_test)
   py_test(googletest-json-outfiles-test)
 

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -81,12 +81,15 @@ macro(config_compiler_and_linker)
     # Suppress "unreachable code" warning
     # http://stackoverflow.com/questions/3232669 explains the issue.
     set(cxx_base_flags "${cxx_base_flags} -wd4702")
+    # Option -J is already given
+    set(cxx_unsigned_char "${cxx_base_flags}")
   elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(cxx_base_flags "-Wall -Wshadow -Werror -Wconversion")
     set(cxx_exception_flags "-fexceptions")
     set(cxx_no_exception_flags "-fno-exceptions")
     set(cxx_strict_flags "-W -Wpointer-arith -Wreturn-type -Wcast-qual -Wwrite-strings -Wswitch -Wunused-parameter -Wcast-align -Wchar-subscripts -Winline -Wredundant-decls")
     set(cxx_no_rtti_flags "-fno-rtti")
+    set(cxx_unsigned_char "${cxx_base_flags} -funsigned-char")
   elseif (CMAKE_COMPILER_IS_GNUCXX)
     set(cxx_base_flags "-Wall -Wshadow -Werror")
     if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0.0)
@@ -100,12 +103,14 @@ macro(config_compiler_and_linker)
     set(cxx_no_rtti_flags "-fno-rtti -DGTEST_HAS_RTTI=0")
     set(cxx_strict_flags
       "-Wextra -Wno-unused-parameter -Wno-missing-field-initializers")
+    set(cxx_unsigned_char "${cxx_base_flags} -funsigned-char")
   elseif (CMAKE_CXX_COMPILER_ID STREQUAL "SunPro")
     set(cxx_exception_flags "-features=except")
     # Sun Pro doesn't provide macros to indicate whether exceptions and
     # RTTI are enabled, so we define GTEST_HAS_* explicitly.
     set(cxx_no_exception_flags "-features=no%except -DGTEST_HAS_EXCEPTIONS=0")
     set(cxx_no_rtti_flags "-features=no%rtti -DGTEST_HAS_RTTI=0")
+    set(cxx_unsigned_char "${cxx_base_flags} -xchar=u")
   elseif (CMAKE_CXX_COMPILER_ID STREQUAL "VisualAge" OR
       CMAKE_CXX_COMPILER_ID STREQUAL "XL")
     # CMake 2.8 changes Visual Age's compiler ID to "XL".
@@ -115,12 +120,14 @@ macro(config_compiler_and_linker)
     # whether RTTI is enabled.  Therefore we define GTEST_HAS_RTTI
     # explicitly.
     set(cxx_no_rtti_flags "-qnortti -DGTEST_HAS_RTTI=0")
+    set(cxx_unsigned_char "${cxx_base_flags}" -qchars=unsigned)
   elseif (CMAKE_CXX_COMPILER_ID STREQUAL "HP")
     set(cxx_base_flags "-AA -mt")
     set(cxx_exception_flags "-DGTEST_HAS_EXCEPTIONS=1")
     set(cxx_no_exception_flags "+noeh -DGTEST_HAS_EXCEPTIONS=0")
     # RTTI can not be disabled in HP aCC compiler.
     set(cxx_no_rtti_flags "")
+    set(cxx_unsigned_char "${cxx_base_flags} -uc")
   endif()
 
   # The pthreads library is available and allowed?

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -3890,8 +3890,8 @@ class XmlUnitTestResultPrinter : public EmptyTestEventListener {
   }
 
   // May c appear in a well-formed XML document?
-  static bool IsValidXmlCharacter(char c) {
-    return IsNormalizableWhitespace(c) || c >= 0x20;
+  static bool IsValidXmlCharacter(unsigned char c) {
+    return IsNormalizableWhitespace(c) || (c >= 0x20 && c < 0x80);
   }
 
   // Returns an XML-escaped copy of the input string str.  If

--- a/googletest/test/gtest_xml_outfile3_test_.cc
+++ b/googletest/test/gtest_xml_outfile3_test_.cc
@@ -1,0 +1,52 @@
+// Copyright 2008, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// gtest_xml_outfile3_test_ writes some xml via TestProperty used by
+// gtest_xml_outfiles_test.py using parameterized tests
+
+#include "gtest/gtest.h"
+
+class InvalidXMLTest : public testing::TestWithParam<const char*> {};
+
+TEST_P(InvalidXMLTest, testInvalids) {
+}
+
+const char* forbiddenInXML[] = {
+    "\xef\xbf\xbe", // forbidden non-character
+    "\xef\xbf\xbe", // forbidden non-character
+    "\xed\xa0\x80", // first high surrogate
+    "\xed\xad\xbf", // last high surrogate
+    "\xed\xb0\x80", // first low surrogate
+    "\xed\xbf\xbf", // last low surrogate
+    "\xed\xa9\x92", // some high surrogate
+    "\xed\xb8\x92" // some low surrogate
+};
+
+INSTANTIATE_TEST_SUITE_P(InvalidXMLTestInstance, InvalidXMLTest,
+                         ::testing::ValuesIn(forbiddenInXML));

--- a/googletest/test/gtest_xml_outfiles_test.py
+++ b/googletest/test/gtest_xml_outfiles_test.py
@@ -39,6 +39,7 @@ import gtest_xml_test_utils
 GTEST_OUTPUT_SUBDIR = "xml_outfiles"
 GTEST_OUTPUT_1_TEST = "gtest_xml_outfile1_test_"
 GTEST_OUTPUT_2_TEST = "gtest_xml_outfile2_test_"
+GTEST_OUTPUT_3_TEST = "gtest_xml_outfile3_test_"
 
 EXPECTED_XML_1 = """<?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="1" failures="0" disabled="0" errors="0" time="*" timestamp="*" name="AllTests">
@@ -68,6 +69,20 @@ EXPECTED_XML_2 = """<?xml version="1.0" encoding="UTF-8"?>
 </testsuites>
 """
 
+EXPECTED_XML_3 = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="8" failures="0" disabled="0" errors="0" time="*" timestamp="*" name="AllTests">
+  <testsuite name="InvalidXMLTestInstance/InvalidXMLTest" tests="8" failures="0" skipped="0" disabled="0" errors="0" time="*" timestamp="*">
+    <testcase name="testInvalids/0" value_param="&quot;\\xEF\\xBF\\xBE&quot;&#x0A;    As Text: &quot;&quot;" status="run" result="completed" time="*" timestamp="*" classname="InvalidXMLTestInstance/InvalidXMLTest" />
+    <testcase name="testInvalids/1" value_param="&quot;\\xEF\\xBF\\xBE&quot;&#x0A;    As Text: &quot;&quot;" status="run" result="completed" time="*" timestamp="*" classname="InvalidXMLTestInstance/InvalidXMLTest" />
+    <testcase name="testInvalids/2" value_param="&quot;\\xED\\xA0\\x80&quot;" status="run" result="completed" time="*" timestamp="*" classname="InvalidXMLTestInstance/InvalidXMLTest" />
+    <testcase name="testInvalids/3" value_param="&quot;\\xED\\xAD\\xBF&quot;" status="run" result="completed" time="*" timestamp="*" classname="InvalidXMLTestInstance/InvalidXMLTest" />
+    <testcase name="testInvalids/4" value_param="&quot;\\xED\\xB0\\x80&quot;" status="run" result="completed" time="*" timestamp="*" classname="InvalidXMLTestInstance/InvalidXMLTest" />
+    <testcase name="testInvalids/5" value_param="&quot;\\xED\\xBF\\xBF&quot;" status="run" result="completed" time="*" timestamp="*" classname="InvalidXMLTestInstance/InvalidXMLTest" />
+    <testcase name="testInvalids/6" value_param="&quot;\\xED\\xA9\\x92&quot;" status="run" result="completed" time="*" timestamp="*" classname="InvalidXMLTestInstance/InvalidXMLTest" />
+    <testcase name="testInvalids/7" value_param="&quot;\\xED\\xB8\\x92&quot;" status="run" result="completed" time="*" timestamp="*" classname="InvalidXMLTestInstance/InvalidXMLTest" />
+  </testsuite>
+</testsuites>
+"""
 
 class GTestXMLOutFilesTest(gtest_xml_test_utils.GTestXMLTestCase):
   """Unit test for Google Test's XML output functionality."""
@@ -93,6 +108,10 @@ class GTestXMLOutFilesTest(gtest_xml_test_utils.GTestXMLTestCase):
     except os.error:
       pass
     try:
+      os.remove(os.path.join(self.output_dir_, GTEST_OUTPUT_3_TEST + ".xml"))
+    except os.error:
+      pass
+    try:
       os.rmdir(self.output_dir_)
     except os.error:
       pass
@@ -102,6 +121,9 @@ class GTestXMLOutFilesTest(gtest_xml_test_utils.GTestXMLTestCase):
 
   def testOutfile2(self):
     self._TestOutFile(GTEST_OUTPUT_2_TEST, EXPECTED_XML_2)
+
+  def testOutfile3(self):
+    self._TestOutFile(GTEST_OUTPUT_3_TEST, EXPECTED_XML_3)
 
   def _TestOutFile(self, test_name, expected_xml):
     gtest_prog_path = gtest_test_utils.GetTestExecutablePath(test_name)


### PR DESCRIPTION
Issue: #2953

The characters U+FFFE and U+FFFF and surrogates are not allowed in
XML[1], but legal in UTF-8/-16. Parameterized tests e.g. for parsers
might print such characters in case the compiler flag is set. The reason
is that IsValidUTF8 implicitly relies on signed char behaviour.