### PR TITLE
Added support for stack trace printing using libunwind on Linux

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -33,6 +33,9 @@ if (COMMAND pre_project_set_up_hermetic_build)
   pre_project_set_up_hermetic_build()
 endif()
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+
 ########################################################################
 #
 # Project-wide settings
@@ -70,6 +73,10 @@ if(CMAKE_PROJECT_NAME STREQUAL "gtest" OR CMAKE_PROJECT_NAME STREQUAL "googletes
   # make it prominent in the GUI.
   option(BUILD_SHARED_LIBS "Build shared libraries (DLLs)." OFF)
 
+  option(GTEST_HAS_ABSL "Build against Google abseil" OFF)
+  option(GTEST_HAS_UNWIND "Build against libunwind for stack traces (Linux only)" OFF)
+  option(GTEST_HAS_DWARF "Build against DWARF libDW for file names in stack traces (Linux only)" OFF)
+
 else()
 
   mark_as_advanced(
@@ -91,6 +98,16 @@ endif()
 include(cmake/internal_utils.cmake)
 
 config_compiler_and_linker()  # Defined in internal_utils.cmake.
+
+if(GTEST_HAS_ABSL)
+  find_package(absl REQUIRED)
+endif()
+if(GTEST_HAS_UNWIND)
+  find_package(Libunwind REQUIRED)
+endif()
+if(GTEST_HAS_DWARF)
+  find_package(DWARF REQUIRED)
+endif()
 
 # Create the CMake package file descriptors.
 if (INSTALL_GTEST)
@@ -139,6 +156,21 @@ if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
   target_include_directories(gtest_main SYSTEM INTERFACE
     "$<BUILD_INTERFACE:${gtest_build_include_dirs}>"
     "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+endif()
+
+if(GTEST_HAS_ABSL)
+  target_compile_definitions(gtest PUBLIC GTEST_HAS_ABSL=1)
+  target_link_libraries(gtest PUBLIC absl::strings absl::stacktrace absl::symbolize absl::failure_signal_handler absl::base)
+endif()
+if(GTEST_HAS_UNWIND)
+  target_compile_definitions(gtest PUBLIC GTEST_HAS_UNWIND=1)
+  target_include_directories(gtest PRIVATE ${LIBUNWIND_INCLUDE_DIR})
+  target_link_libraries(gtest PUBLIC ${LIBUNWIND_LIBRARIES})
+endif()
+if(GTEST_HAS_DWARF)
+  target_compile_definitions(gtest PUBLIC GTEST_HAS_DWARF=1)
+  target_include_directories(gtest PRIVATE ${DWARF_INCLUDE_DIR} ${LIBDW_INCLUDE_DIR} ${ELF_INCLUDE_DIR})
+  target_link_libraries(gtest PUBLIC ${CMAKE_DL_LIBS} ${DWARF_LIBRARIES})
 endif()
 target_link_libraries(gtest_main PUBLIC gtest)
 

--- a/googletest/cmake/FindDWARF.cmake
+++ b/googletest/cmake/FindDWARF.cmake
@@ -1,0 +1,128 @@
+# - Find Dwarf
+# Find the dwarf.h header from elf utils
+#
+#  DWARF_INCLUDE_DIR - where to find dwarf.h, etc.
+#  DWARF_LIBRARIES   - List of libraries when using elf utils.
+#  DWARF_FOUND       - True if fdo found.
+
+message(STATUS "Checking availability of DWARF and ELF development libraries")
+
+INCLUDE(CheckLibraryExists)
+
+if (DWARF_INCLUDE_DIR AND ELF_INCLUDE_DIR
+    AND LIBDW_INCLUDE_DIR AND DWARF_LIBRARY AND ELF_LIBRARY)
+    # Already in cache, be silent
+    set(DWARF_FIND_QUIETLY TRUE)
+endif (DWARF_INCLUDE_DIR AND ELF_INCLUDE_DIR
+       AND LIBDW_INCLUDE_DIR AND DWARF_LIBRARY AND ELF_LIBRARY)
+
+if (DEFINED LIBDW_PATH)
+    set (USER_LIBDW_INCLUDE_PATH ${LIBDW_PATH}/include)
+    set (USER_LIBDW_LIB_PATH ${LIBDW_PATH})
+else ()
+    set (USER_LIBDW_INCLUDE_PATH "")
+    set (USER_LIBDW_LIB_PATH "")
+endif ()
+
+if (DEFINED LIBELF_PATH)
+    set (USER_LIBELF_INCLUDE_PATH ${LIBELF_PATH}/include)
+    set (USER_LIBELF_LIB_PATH ${LIBELF_PATH})
+else ()
+    set (USER_LIBELF_INCLUDE_PATH "")
+    set (USER_LIBELF_LIB_PATH "")
+endif ()
+
+find_path(DWARF_INCLUDE_DIR dwarf.h
+    HINTS ${USER_LIBDW_INCLUDE_PATH}
+)
+
+find_path(ELF_INCLUDE_DIR elf.h
+    HINTS ${USER_LIBELF_INCLUDE_PATH}
+)
+
+find_path(LIBDW_INCLUDE_DIR elfutils/libdw.h
+    HINTS ${USER_LIBDW_INCLUDE_PATH}
+)
+
+find_library(DWARF_LIBRARY
+    NAMES dw
+    HINTS ${USER_LIBDW_LIB_PATH}
+    PATH_SUFFIXES lib lib64
+)
+
+find_library(ELF_LIBRARY
+    NAMES elf
+    HINTS ${USER_LIBELF_LIB_PATH}
+    PATH_SUFFIXES lib lib64
+)
+
+if (DWARF_INCLUDE_DIR AND ELF_INCLUDE_DIR AND LIBDW_INCLUDE_DIR AND DWARF_LIBRARY AND ELF_LIBRARY)
+    set(DWARF_FOUND TRUE)
+    set(DWARF_LIBRARIES ${DWARF_LIBRARY} ${ELF_LIBRARY})
+
+    set(CMAKE_REQUIRED_LIBRARIES ${DWARF_LIBRARIES})
+    # check if libdw have the dwfl_module_build_id routine,
+    # i.e. if it supports the buildid mechanism to match binaries
+    # to detached debug info sections (the -debuginfo packages in
+    # distributions such as fedora). We do it against libelf
+    # because, IIRC, some distros include libdw linked statically
+    # into libelf.
+    check_library_exists(elf dwfl_module_build_id "" HAVE_DWFL_MODULE_BUILD_ID)
+else (DWARF_INCLUDE_DIR AND ELF_INCLUDE_DIR
+      AND LIBDW_INCLUDE_DIR AND DWARF_LIBRARY AND ELF_LIBRARY)
+    set(DWARF_FOUND FALSE)
+    set(DWARF_LIBRARIES)
+endif (DWARF_INCLUDE_DIR AND ELF_INCLUDE_DIR
+       AND LIBDW_INCLUDE_DIR AND DWARF_LIBRARY AND ELF_LIBRARY)
+
+if (DWARF_FOUND)
+    if (NOT DWARF_FIND_QUIETLY)
+        message(STATUS "Found dwarf.h header: ${DWARF_INCLUDE_DIR}")
+        message(STATUS "Found elf.h header: ${ELF_INCLUDE_DIR}")
+        message(STATUS "Found elfutils/libdw.h header: ${LIBDW_INCLUDE_DIR}")
+        message(STATUS "Found libdw library: ${DWARF_LIBRARY}")
+        message(STATUS "Found libelf library: ${ELF_LIBRARY}")
+    endif (NOT DWARF_FIND_QUIETLY)
+else (DWARF_FOUND)
+    if (DWARF_FIND_REQUIRED)
+        # Check if we are in a Red Hat (RHEL) or Fedora system to tell
+        # exactly which packages should be installed. Please send
+        # patches for other distributions.
+        find_path(FEDORA fedora-release /etc)
+        find_path(REDHAT redhat-release /etc)
+        if (FEDORA OR REDHAT)
+            if (NOT DWARF_INCLUDE_DIR OR NOT ELF_INCLUDE_DIR
+                OR NOT LIBDW_INCLUDE_DIR)
+                message(STATUS "Please install the elfutils-devel package")
+            endif (NOT DWARF_INCLUDE_DIR OR NOT ELF_INCLUDE_DIR
+                   OR NOT LIBDW_INCLUDE_DIR)
+            if (NOT DWARF_LIBRARY)
+                message(STATUS "Please install the elfutils-libs package")
+            endif (NOT DWARF_LIBRARY)
+            if (NOT ELF_LIBRARY)
+                message(STATUS "Please install the elfutils-libelf package")
+            endif (NOT ELF_LIBRARY)
+        else (FEDORA OR REDHAT)
+            if (NOT DWARF_INCLUDE_DIR)
+                message(STATUS "Could NOT find dwarf include dir")
+            endif (NOT DWARF_INCLUDE_DIR)
+            if (NOT ELF_INCLUDE_DIR)
+                message(STATUS "Could NOT find elf include dir")
+            endif (NOT ELF_INCLUDE_DIR)
+            if (NOT LIBDW_INCLUDE_DIR)
+                message(STATUS "Could NOT find libdw include dir")
+            endif (NOT LIBDW_INCLUDE_DIR)
+            if (NOT DWARF_LIBRARY)
+                message(STATUS "Could NOT find libdw library")
+            endif (NOT DWARF_LIBRARY)
+            if (NOT ELF_LIBRARY)
+                message(STATUS "Could NOT find libelf library")
+            endif (NOT ELF_LIBRARY)
+        endif (FEDORA OR REDHAT)
+        message(FATAL_ERROR "Could NOT find some ELF and DWARF libraries, please install the missing packages")
+    endif (DWARF_FIND_REQUIRED)
+endif (DWARF_FOUND)
+
+mark_as_advanced(DWARF_INCLUDE_DIR ELF_INCLUDE_DIR LIBDW_INCLUDE_DIR DWARF_LIBRARY ELF_LIBRARY)
+
+message(STATUS "Checking availability of DWARF and ELF development libraries - done")

--- a/googletest/cmake/FindLibunwind.cmake
+++ b/googletest/cmake/FindLibunwind.cmake
@@ -1,0 +1,18 @@
+#
+# - Find libunwind
+#
+# LIBUNWIND_INCLUDE_DIR - Path to libunwind.h
+# LIBUNWIND_LIBRARIES   - List of libraries for using libunwind
+# LIBUNWIND_FOUND       - True if libunwind was found
+
+if(LIBUNWIND_INCLUDE_DIR)
+  set(LIBUNWIND_FIND_QUIETLY true)
+endif()
+
+find_path(LIBUNWIND_INCLUDE_DIR libunwind.h)
+find_library(LIBUNWIND_LIBRARIES unwind)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Libunwind DEFAULT_MSG LIBUNWIND_LIBRARIES LIBUNWIND_INCLUDE_DIR)
+
+mark_as_advanced(LIBUNWIND_LIBRARIES LIBUNWIND_INCLUDE_DIR)

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -460,7 +460,7 @@ class OsStackTraceGetter : public OsStackTraceGetterInterface {
   void UponLeavingGTest() override;
 
  private:
-#if GTEST_HAS_ABSL
+#if GTEST_HAS_ABSL || GTEST_HAS_UNWIND
   Mutex mutex_;  // Protects all internal state.
 
   // We save the stack frame below the frame that calls user code.
@@ -468,7 +468,20 @@ class OsStackTraceGetter : public OsStackTraceGetterInterface {
   // the user code changes between the call to UponLeavingGTest()
   // and any calls to the stack trace code from within the user code.
   void* caller_frame_ = nullptr;
-#endif  // GTEST_HAS_ABSL
+
+  // Store stack trace information in this structure for better
+  // processing, like name demangling and file lookup
+  struct StackFrame {
+    void* frame_ = nullptr;
+    std::string proc_name_;
+#if GTEST_HAS_DWARF
+    std::string file_name_;
+    int line_number_ = -1;
+#endif
+  };
+
+  size_t UnwindGetStackTrace(std::vector<OsStackTraceGetter::StackFrame>& stack_trace, int max_depth, int skip_count, void* caller_frame = nullptr);
+#endif  // GTEST_HAS_ABSL || GTEST_HAS_UNWIND
 
   GTEST_DISALLOW_COPY_AND_ASSIGN_(OsStackTraceGetter);
 };


### PR DESCRIPTION
This is a draft PR to get feedback on some recent work we have been doing. We use Google test a lot, its really great. But there is one problem that is a large bottleneck in our work: when implementing test-methods that get called for various inputs, its often hard or impossible to see for which inputs a test failed. We used various workarounds in the past, like extensive logging or custom stack tracers. But these workarounds just alleviate parts of the pain.

This PR tries to aim at a full solution, in the sense that Google test can print stack traces with file and line references for failed assertions.

In our tests (currently Linux only) this is a huge step forward and makes virtually impossible workflows very accessible and simple.

As a side-effect, the printed stack traces work in common IDEs like Visual Studio, Visual Studio Code and possibly many others.

Feedback would be highly appreciated!