### PR TITLE
Export Test - Do Not Merge

### DIFF
--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -1717,9 +1717,6 @@ class FloatingEqMatcher {
   // The following 3 type conversion operators allow FloatEq(expected) and
   // NanSensitiveFloatEq(expected) to be used as a Matcher<float>, a
   // Matcher<const float&>, or a Matcher<float&>, but nothing else.
-  // (While Google's C++ coding style doesn't allow arguments passed
-  // by non-const reference, we may see them in code not conforming to
-  // the style.  Therefore Google Mock needs to support them.)
   operator Matcher<FloatType>() const {
     return MakeMatcher(
         new Impl<FloatType>(expected_, nan_eq_nan_, max_abs_error_));


### PR DESCRIPTION
Export Test - Do Not Merge


Remove obsolete comment about non-const references.

They used to be banned by the C++ style guide, but positions shifted, and this comment is no longer up to date.

There's another reference (heh) on lines 816-819 to how gmock is a "general framework", with the possible implication that support for non-const references was weird in some way and only there to be "general", but I left it alone because I don't really feel I understand what it's saying.
