### PR TITLE
Adding CMake interprocedural optimization policy setting

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -59,6 +59,10 @@ if (POLICY CMP0063) # Visibility
   cmake_policy(SET CMP0063 NEW)
 endif (POLICY CMP0063)
 
+if (POLICY CMP0069) # Interprocedural optimization
+  cmake_policy(SET CMP0069 NEW)
+endif (POLICY CMP0069)
+
 if (COMMAND set_up_hermetic_build)
   set_up_hermetic_build()
 endif()


### PR DESCRIPTION
This policy setting will silence a warning when using with a CMake's
interprocedural optimization setting (CMAKE_INTERPROCEDURAL_OPTIMIZATION).

The warning can be silence with a clear conscience as interprocedural
optimization (INTERPROCEDURAL_OPTIMIZATION) is not manually enabled on
any gtest targets and thus maybe relying on the old behaviour to only
enable this on Intel compilers on Linux.

Due to the forced `cmake_minimum_version`, policy settings in CMakeLists
calling this one (including the main CMakeLists) are lost, forcing the
change to be made here.