### PR TITLE
Export Test - Do Not Merge

### DIFF
--- a/googlemock/docs/cook_book.md
+++ b/googlemock/docs/cook_book.md
@@ -3078,7 +3078,7 @@ class MockFoo : public Foo {
   ...
   // Add the following two lines to the mock class.
   MOCK_METHOD(void, Die, ());
-  virtual ~MockFoo() { Die(); }
+  ~MockFoo() override { Die(); }
 };
 ```
 


### PR DESCRIPTION
Export Test - Do Not Merge


Use override instead of virtual for destructor

https://google.github.io/styleguide/cppguide.html says: "Explicitly annotate overrides of virtual functions or virtual destructors with exactly one of an override or (less frequently) final specifier. Do not use virtual when declaring an override". The mocked class _should_ have a virtual destructor most of the times.
