### PR TITLE
Initialize TestInfo member is_in_another_shard_ in constructor.

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -2724,6 +2724,7 @@ TestInfo::TestInfo(const std::string& a_test_suite_name,
       should_run_(false),
       is_disabled_(false),
       matches_filter_(false),
+      is_in_another_shard_(false),
       factory_(factory),
       result_() {}
 


### PR DESCRIPTION
Signed-off-by: Vinson Lee <vlee@freedesktop.org>