### PR TITLE
Activate CMP0077 to prevent overwrite by option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ cmake_minimum_required(VERSION 2.8.8)
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif (POLICY CMP0048)
+if (POLICY CMP0077) # prevent option overrides BUILD_GMOCK when used using FetchContent
+  cmake_policy(SET CMP0077 NEW)
+endif (POLICY CMP0077)
 
 project(googletest-distribution)
 set(GOOGLETEST_VERSION 1.10.0)


### PR DESCRIPTION
When integrating googletest into another CMake project using FetchContent, external build variables are ignored during the first run. Instead CMake prints the following warning.
> CMake Warning (dev) at build/_deps/googletest-src/CMakeLists.txt:25 (option):
> Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
> --help-policy CMP0077" for policy details.  Use the cmake_policy command to
> set the policy and suppress this warning.
> 
> For compatibility with older versions of CMake, option is clearing the
> normal variable 'BUILD_GMOCK'.
> This warning is for project developers.  Use -Wno-dev to suppress it.
> 
> CMake Warning (dev) at build/_deps/googletest-src/googletest/CMakeLists.txt:13 (option):
> Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
> --help-policy CMP0077" for policy details.  Use the cmake_policy command to
> set the policy and suppress this warning.
> 
> For compatibility with older versions of CMake, option is clearing the
> normal variable 'gtest_force_shared_crt'.
> This warning is for project developers.  Use -Wno-dev to suppress it.

And indeed as the warning says the varialbes are ignored. Only after the second CMake run variables set externally are respected.
This can easily be fixed by activating CMP0077 in the CMake lists, which this change does.

Please find below the CMake code I used to include googletest in my project.
> include(FetchContent)
> FetchContent_Declare(
>   googletest
>   GIT_REPOSITORY https://github.com/google/googletest.git
> )
> FetchContent_GetProperties(googletest)
> if(NOT googletest_POPULATED)
>     FetchContent_Populate(googletest)
>     cmake_policy(SET CMP0077 NEW) # setting this policy here is also ignored inside the googletest file
>     set (BUILD_GMOCK OFF)
>     set (BUILD_SHARED_LIBS OFF)
>     set (gtest_force_shared_crt ON)
>     add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
> endif()



