### PR TITLE
Export Test - Do Not Merge

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -244,7 +244,13 @@ function(cxx_executable name dir libs)
 endfunction()
 
 # Sets PYTHONINTERP_FOUND and PYTHON_EXECUTABLE.
-find_package(PythonInterp)
+if ("${CMAKE_VERSION}" VERSION_LESS "3.12.0")
+  find_package(PythonInterp)
+else()
+  find_package(Python COMPONENTS Interpreter)
+  set(PYTHONINTERP_FOUND ${Python_Interpreter_FOUND})
+  set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
+endif()
 
 # cxx_test_with_flags(name cxx_flags libs srcs...)
 #

--- a/googletest/docs/faq.md
+++ b/googletest/docs/faq.md
@@ -217,6 +217,18 @@ particular, using it in googletest comparison assertions (`EXPECT_EQ`, etc) will
 generate an "undefined reference" linker error. The fact that "it used to work"
 doesn't mean it's valid. It just means that you were lucky. :-)
 
+If the declaration of the static data member is `constexpr` then it is
+implicitly an `inline` definition, and a separate definition in `foo.cc` is not
+needed:
+
+```c++
+// foo.h
+class Foo {
+  ...
+  static constexpr int kBar = 100;  // Defines kBar, no need to do it in foo.cc.
+};
+```
+
 ## Can I derive a test fixture from another?
 
 Yes.


### PR DESCRIPTION
Export Test - Do Not Merge


Merge 826e9f25a15e550d2a6992f5bee1f90b801178b2 into 9dce5e5d878176dc0054ef381f5c6e705f43ef99

Closes #3114

COPYBARA_INTEGRATE_REVIEW=https://github.com/google/googletest/pull/3114 from marbre:FindPython 826e9f25a15e550d2a6992f5bee1f90b801178b2
