### PR TITLE
Avoid need for user-provided ExcessiveArg constructor

### DIFF
--- a/googlemock/include/gmock/gmock-actions.h
+++ b/googlemock/include/gmock/gmock-actions.h
@@ -1520,7 +1520,7 @@ struct ActionImpl<R(Args...), Impl> : ImplBase<Impl>::type {
     // types instantiated.  Up to 10 of the args that are provided by the
     // args_type get passed, followed by a dummy of unspecified type for the
     // remainder up to 10 explicit args.
-    static const ExcessiveArg kExcessArg;
+    static const ExcessiveArg kExcessArg{};
     return static_cast<const Impl&>(*this).template gmock_PerformImpl<
         /*function_type=*/function_type, /*return_type=*/R,
         /*args_type=*/args_type,


### PR DESCRIPTION
This is an attempt to fix a build failure on XCode 8.1.
Issue #3128