### PR TITLE
Add documentation for GTEST_SKIP()

### DIFF
--- a/googletest/docs/primer.md
+++ b/googletest/docs/primer.md
@@ -256,6 +256,7 @@ To create a test:
 3.  The test's result is determined by the assertions; if any assertion in the
     test fails (either fatally or non-fatally), or if the test crashes, the
     entire test fails. Otherwise, it succeeds.
+4.  To skip a test based on a runtime condition use the `GTEST_SKIP()` macro.
 
 ```c++
 TEST(TestSuiteName, TestName) {


### PR DESCRIPTION
xref https://github.com/google/googletest/pull/1544#issuecomment-431197802

#1544 added `GTEST_SKIP`. This PR adds an update to the documentation and a code sample.