### PR TITLE
Export Test - Do Not Merge

### DIFF
--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -1074,7 +1074,12 @@ struct MoveHelper {
   MOCK_METHOD1(Call, void(MoveOnly));
 };
 
+// Disable this test in VS 2015 (version 14), where it fails when SEH is enabled
+#if defined(_MSC_VER) && (_MSC_VER < 1910)
+TEST(ComparisonBaseTest, DISABLED_WorksWithMoveOnly) {
+#else
 TEST(ComparisonBaseTest, WorksWithMoveOnly) {
+#endif
   MoveOnly m{0};
   MoveHelper helper;
 


### PR DESCRIPTION
Export Test - Do Not Merge

Disable a gmock matcher test under MSVC 2015 (version 14) and earlier.  It interacts badly with Windows structured exceptions in a way we do not have the resources to investigate.  This test passes under MSVC 2017 and SEH.
