### PR TITLE
Fix gmock_gen.py generation of template type names

### DIFF
--- a/googlemock/scripts/generator/cpp/ast.py
+++ b/googlemock/scripts/generator/cpp/ast.py
@@ -38,6 +38,7 @@ except ImportError:
 
 import sys
 import traceback
+import collections
 
 from cpp import keywords
 from cpp import tokenize
@@ -1433,7 +1434,7 @@ class AstBuilder(object):
     pass  # Not needed yet.
 
   def _GetTemplatedTypes(self):
-    result = {}
+    result = collections.OrderedDict()
     tokens = list(self._GetMatchingChar('<', '>'))
     len_tokens = len(tokens) - 1    # Ignore trailing '>'.
     i = 0

--- a/googlemock/scripts/generator/cpp/gmock_class.py
+++ b/googlemock/scripts/generator/cpp/gmock_class.py
@@ -159,12 +159,9 @@ def _GenerateMocks(filename, source, ast_list, desired_class_names):
 
       # Add template args for templated classes.
       if class_node.templated_types:
-        # TODO(paulchang): The AST doesn't preserve template argument order,
-        # so we have to make up names here.
         # TODO(paulchang): Handle non-type template arguments (e.g.
         # template<typename T, int N>).
-        template_arg_count = len(class_node.templated_types.keys())
-        template_args = ['T%d' % n for n in range(template_arg_count)]
+        template_args = class_node.templated_types.keys()
         template_decls = ['typename ' + arg for arg in template_args]
         lines.append('template <' + ', '.join(template_decls) + '>')
         parent_name += '<' + ', '.join(template_args) + '>'

--- a/googlemock/scripts/generator/cpp/gmock_class_test.py
+++ b/googlemock/scripts/generator/cpp/gmock_class_test.py
@@ -428,8 +428,8 @@ class Test {
 };
 """
     expected = """\
-template <typename T0, typename T1>
-class MockTest : public Test<T0, T1> {
+template <typename S, typename T>
+class MockTest : public Test<S, T> {
 public:
 MOCK_METHOD(void, Foo, (), (override));
 };


### PR DESCRIPTION
When an interface includes template types, they get automatically
assigned a fixed name, i.e. T0, T1, T2 etc. This works fine as
long as the types are _not_ used in the signature of any of the
functions that need to be mocked.

Note the initial workaround would not have been if support for Python2
would be dropped. In Python 3.6 and later dictionaries are ordered
by default.

Fixes #3172