### PR TITLE
Remove explicit function overloads of CmpHelper?? for BiggestInt arguments

### DIFF
--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1549,14 +1549,6 @@ AssertionResult CmpHelperEQ(const char* lhs_expression,
   return CmpHelperEQFailure(lhs_expression, rhs_expression, lhs, rhs);
 }
 
-// With this overloaded version, we allow anonymous enums to be used
-// in {ASSERT|EXPECT}_EQ when compiled with gcc 4, as anonymous enums
-// can be implicitly cast to BiggestInt.
-GTEST_API_ AssertionResult CmpHelperEQ(const char* lhs_expression,
-                                       const char* rhs_expression,
-                                       BiggestInt lhs,
-                                       BiggestInt rhs);
-
 class EqHelper {
  public:
   // This templatized version is for the general case.
@@ -1613,11 +1605,6 @@ AssertionResult CmpHelperOpFailure(const char* expr1, const char* expr2,
 // ASSERT_?? and EXPECT_??.  It is here just to avoid copy-and-paste
 // of similar code.
 //
-// For each templatized helper function, we also define an overloaded
-// version for BiggestInt in order to reduce code bloat and allow
-// anonymous enums to be used with {ASSERT|EXPECT}_?? when compiled
-// with gcc 4.
-//
 // INTERNAL IMPLEMENTATION - DO NOT USE IN A USER PROGRAM.
 
 #define GTEST_IMPL_CMP_HELPER_(op_name, op)\
@@ -1629,9 +1616,7 @@ AssertionResult CmpHelper##op_name(const char* expr1, const char* expr2, \
   } else {\
     return CmpHelperOpFailure(expr1, expr2, val1, val2, #op);\
   }\
-}\
-GTEST_API_ AssertionResult CmpHelper##op_name(\
-    const char* expr1, const char* expr2, BiggestInt val1, BiggestInt val2)
+}
 
 // INTERNAL IMPLEMENTATION - DO NOT USE IN A USER PROGRAM.
 

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -1603,57 +1603,6 @@ AssertionResult DoubleLE(const char* expr1, const char* expr2,
 
 namespace internal {
 
-// The helper function for {ASSERT|EXPECT}_EQ with int or enum
-// arguments.
-AssertionResult CmpHelperEQ(const char* lhs_expression,
-                            const char* rhs_expression,
-                            BiggestInt lhs,
-                            BiggestInt rhs) {
-  if (lhs == rhs) {
-    return AssertionSuccess();
-  }
-
-  return EqFailure(lhs_expression,
-                   rhs_expression,
-                   FormatForComparisonFailureMessage(lhs, rhs),
-                   FormatForComparisonFailureMessage(rhs, lhs),
-                   false);
-}
-
-// A macro for implementing the helper functions needed to implement
-// ASSERT_?? and EXPECT_?? with integer or enum arguments.  It is here
-// just to avoid copy-and-paste of similar code.
-#define GTEST_IMPL_CMP_HELPER_(op_name, op)\
-AssertionResult CmpHelper##op_name(const char* expr1, const char* expr2, \
-                                   BiggestInt val1, BiggestInt val2) {\
-  if (val1 op val2) {\
-    return AssertionSuccess();\
-  } else {\
-    return AssertionFailure() \
-        << "Expected: (" << expr1 << ") " #op " (" << expr2\
-        << "), actual: " << FormatForComparisonFailureMessage(val1, val2)\
-        << " vs " << FormatForComparisonFailureMessage(val2, val1);\
-  }\
-}
-
-// Implements the helper function for {ASSERT|EXPECT}_NE with int or
-// enum arguments.
-GTEST_IMPL_CMP_HELPER_(NE, !=)
-// Implements the helper function for {ASSERT|EXPECT}_LE with int or
-// enum arguments.
-GTEST_IMPL_CMP_HELPER_(LE, <=)
-// Implements the helper function for {ASSERT|EXPECT}_LT with int or
-// enum arguments.
-GTEST_IMPL_CMP_HELPER_(LT, < )
-// Implements the helper function for {ASSERT|EXPECT}_GE with int or
-// enum arguments.
-GTEST_IMPL_CMP_HELPER_(GE, >=)
-// Implements the helper function for {ASSERT|EXPECT}_GT with int or
-// enum arguments.
-GTEST_IMPL_CMP_HELPER_(GT, > )
-
-#undef GTEST_IMPL_CMP_HELPER_
-
 // The helper function for {ASSERT|EXPECT}_STREQ.
 AssertionResult CmpHelperSTREQ(const char* lhs_expression,
                                const char* rhs_expression,


### PR DESCRIPTION
Affects macros {ASSERT|EXPECT}_{EQ|NE|LE|LT|GE|GT}.

According to removed comments, these overloads were supposed to reduce code bloat and allow anonymous enums on GCC 4.

However, the way it works on GCC 4 and the latest GCC (10.2 by now) is that having:
```c++
template <typename T1, typename T2>
void foo(T1, T2);

using BiggestInt = long long;
void foo(BiggestInt, BiggestInt);
```
the template version takes precedence for almost every combination of integral types except for two long long integers - i.e. implicit promotion to long long is a worse match than generating a specific template function.

Tested on [GCC 4.8.1](https://ftp.gnu.org/gnu/gcc/gcc-4.8.1/) (as GoogleTest requires C++11 and this was [the first C++11 feature-complete release of GCC](https://gcc.gnu.org/projects/cxx-status.html#cxx11)), [GCC 4.8.5](https://ftp.gnu.org/gnu/gcc/gcc-4.8.5/) (last of 4.8.x series) and [the latest GCC](https://ftp.gnu.org/gnu/gcc/gcc-10.2.0/) (10.2.0).

---

You may also test it using Godbolt / manually compiled GCC 4.8.1:
```c++
#include <iostream>

template <typename T1, typename T2>
void foo(T1, T2)
{
  std::cout << "template function -> " << __PRETTY_FUNCTION__ << '\n';
}

void foo(long long, long long)
{
  std::cout << "normal function\n";
}

enum {ANONYMOUS1, ANONYMOUS2};

int main()
{
  // each combination of non-(long long, long long) invokes the template function
  foo(0, 0); // (int, int)
  foo(0l, 0l); // (long, long)
  foo(0, 0l); // (int, long)
  foo(0, 0ll); // (int, long long)

  // anonymous enum calls the template function too!
  foo(ANONYMOUS1, ANONYMOUS2);

  // only this calls the regular function
  foo(0ll, 0ll); // (long long, long long)
}
```

or using Dockerfile:
```Dockerfile
# no 4.8.1 tag available
FROM gcc:4.8.5
WORKDIR /google
COPY test.cpp .
```