### PR TITLE
Restore GTEST_ATTRIBUTE_PRINTF_ on ColoredPrintf

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -3269,7 +3269,8 @@ bool ShouldUseColor(bool stdout_is_tty) {
 // This routine must actually emit the characters rather than return a string
 // that would be colored when printed, as can be done on Linux.
 
-static void ColoredPrintf(GTestColor color, const char* fmt, ...) {
+GTEST_ATTRIBUTE_PRINTF_(2, 3)
+static void ColoredPrintf(GTestColor color, const char *fmt, ...) {
   va_list args;
   va_start(args, fmt);
 


### PR DESCRIPTION
This fixes build issues with GoogleTest when built with -Wformat-nonliteral and unblocks updating GoogleTest in BoringSSL.

It was added in 53c478d639b8eebd2942e88266610ebc79c541f6, which caught some bugs. Then it was moved to the header and accidentally dropped in 482ac6ee63429af2aa9c44f4e6427873fb68fb1f.