### PR TITLE
Protect against -Wundef

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,19 +22,19 @@ matrix:
     - os: linux
       dist: bionic
       compiler: gcc
-      env: BUILD_TYPE=Debug CXX_FLAGS="-std=c++11 -Wdeprecated"
+      env: BUILD_TYPE=Debug CXX_FLAGS="-std=c++11 -Wdeprecated -Wundef"
     - os: linux
       dist: bionic
       compiler: clang
-      env: BUILD_TYPE=Release CXX_FLAGS="-std=c++11 -Wdeprecated" NO_EXCEPTION=ON NO_RTTI=ON COMPILER_IS_GNUCXX=ON
+      env: BUILD_TYPE=Release CXX_FLAGS="-std=c++11 -Wdeprecated -Wundef" NO_EXCEPTION=ON NO_RTTI=ON COMPILER_IS_GNUCXX=ON
     - os: osx
       osx_image: xcode12.2
       compiler: gcc
-      env: BUILD_TYPE=Release CC=gcc-10 CXX=g++-10 CXX_FLAGS="-std=c++11 -Wdeprecated" HOMEBREW_LOGS=~/homebrew-logs HOMEBREW_TEMP=~/homebrew-temp
+      env: BUILD_TYPE=Release CC=gcc-10 CXX=g++-10 CXX_FLAGS="-std=c++11 -Wdeprecated -Wundef" HOMEBREW_LOGS=~/homebrew-logs HOMEBREW_TEMP=~/homebrew-temp
     - os: osx
       osx_image: xcode12.2
       compiler: clang
-      env: BUILD_TYPE=Release CXX_FLAGS="-std=c++11 -Wdeprecated" HOMEBREW_LOGS=~/homebrew-logs HOMEBREW_TEMP=~/homebrew-temp
+      env: BUILD_TYPE=Release CXX_FLAGS="-std=c++11 -Wdeprecated -Wundef" HOMEBREW_LOGS=~/homebrew-logs HOMEBREW_TEMP=~/homebrew-temp
 
 # These are the install and build (script) phases for the most common entries in the matrix.  They could be included
 # in each entry in the matrix, but that is just repetitive.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ include(GNUInstallDirs)
 option(BUILD_GMOCK "Builds the googlemock subproject" ON)
 option(INSTALL_GTEST "Enable installation of googletest. (Projects embedding googletest may want to turn this OFF.)" ON)
 
+add_compile_options(
+    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:-Wundef>
+)
+
 if(BUILD_GMOCK)
   add_subdirectory( googlemock )
 else()

--- a/googlemock/include/gmock/internal/gmock-internal-utils.h
+++ b/googlemock/include/gmock/internal/gmock-internal-utils.h
@@ -88,6 +88,7 @@ inline Element* GetRawPointer(Element* p) { return p; }
 // is a native type.
 #if defined(_MSC_VER) && !defined(_NATIVE_WCHAR_T_DEFINED)
 // wchar_t is a typedef.
+# define GMOCK_WCHAR_T_IS_NATIVE_ 0
 #else
 # define GMOCK_WCHAR_T_IS_NATIVE_ 1
 #endif

--- a/googlemock/test/gmock-spec-builders_test.cc
+++ b/googlemock/test/gmock-spec-builders_test.cc
@@ -2760,6 +2760,9 @@ TEST(ParameterlessExpectationsTest,
 // Allows the user to define their own main and then invoke gmock_main
 // from it. This might be necessary on some platforms which require
 // specific setup and teardown.
+#ifndef GMOCK_RENAME_MAIN
+# define GMOCK_RENAME_MAIN 0
+#endif
 #if GMOCK_RENAME_MAIN
 int gmock_main(int argc, char **argv) {
 #else

--- a/googletest/README.md
+++ b/googletest/README.md
@@ -186,8 +186,8 @@ We list the most frequently used macros below. For a complete list, see file
 
 GoogleTest is thread-safe where the pthread library is available. After
 `#include "gtest/gtest.h"`, you can check the
-`GTEST_IS_THREADSAFE` macro to see whether this is the case (yes if the macro is
-`#defined` to 1, no if it's undefined.).
+`GTEST_IS_THREADSAFE` macro to see whether this is the case (yes if the macro
+evaluates to `1`, no if it evaluates to `0`.).
 
 If GoogleTest doesn't correctly detect whether pthread is available in your
 environment, you can force it with

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1924,6 +1924,9 @@ class TestWithParam : public Test, public WithParamInterface<T> {
 
 // Define this macro to 1 to omit the definition of FAIL(), which is a
 // generic name and clashes with some other libraries.
+#ifndef GTEST_DONT_DEFINE_FAIL
+# define GTEST_DONT_DEFINE_FAIL 0
+#endif
 #if !GTEST_DONT_DEFINE_FAIL
 # define FAIL() GTEST_FAIL()
 #endif
@@ -1933,6 +1936,9 @@ class TestWithParam : public Test, public WithParamInterface<T> {
 
 // Define this macro to 1 to omit the definition of SUCCEED(), which
 // is a generic name and clashes with some other libraries.
+#ifndef GTEST_DONT_DEFINE_SUCCEED
+# define GTEST_DONT_DEFINE_SUCCEED 0
+#endif
 #if !GTEST_DONT_DEFINE_SUCCEED
 # define SUCCEED() GTEST_SUCCEED()
 #endif
@@ -2069,26 +2075,44 @@ class TestWithParam : public Test, public WithParamInterface<T> {
 // Define macro GTEST_DONT_DEFINE_ASSERT_XY to 1 to omit the definition of
 // ASSERT_XY(), which clashes with some users' own code.
 
+#ifndef GTEST_DONT_DEFINE_ASSERT_EQ
+# define GTEST_DONT_DEFINE_ASSERT_EQ 0
+#endif
 #if !GTEST_DONT_DEFINE_ASSERT_EQ
 # define ASSERT_EQ(val1, val2) GTEST_ASSERT_EQ(val1, val2)
 #endif
 
+#ifndef GTEST_DONT_DEFINE_ASSERT_NE
+# define GTEST_DONT_DEFINE_ASSERT_NE 0
+#endif
 #if !GTEST_DONT_DEFINE_ASSERT_NE
 # define ASSERT_NE(val1, val2) GTEST_ASSERT_NE(val1, val2)
 #endif
 
+#ifndef GTEST_DONT_DEFINE_ASSERT_LE
+# define GTEST_DONT_DEFINE_ASSERT_LE 0
+#endif
 #if !GTEST_DONT_DEFINE_ASSERT_LE
 # define ASSERT_LE(val1, val2) GTEST_ASSERT_LE(val1, val2)
 #endif
 
+#ifndef GTEST_DONT_DEFINE_ASSERT_LT
+# define GTEST_DONT_DEFINE_ASSERT_LT 0
+#endif
 #if !GTEST_DONT_DEFINE_ASSERT_LT
 # define ASSERT_LT(val1, val2) GTEST_ASSERT_LT(val1, val2)
 #endif
 
+#ifndef GTEST_DONT_DEFINE_ASSERT_GE
+# define GTEST_DONT_DEFINE_ASSERT_GE 0
+#endif
 #if !GTEST_DONT_DEFINE_ASSERT_GE
 # define ASSERT_GE(val1, val2) GTEST_ASSERT_GE(val1, val2)
 #endif
 
+#ifndef GTEST_DONT_DEFINE_ASSERT_GT
+# define GTEST_DONT_DEFINE_ASSERT_GT 0
+#endif
 #if !GTEST_DONT_DEFINE_ASSERT_GT
 # define ASSERT_GT(val1, val2) GTEST_ASSERT_GT(val1, val2)
 #endif
@@ -2349,6 +2373,9 @@ constexpr bool StaticAssertTypeEq() noexcept {
 
 // Define this macro to 1 to omit the definition of TEST(), which
 // is a generic name and clashes with some other libraries.
+#ifndef GTEST_DONT_DEFINE_TEST
+# define GTEST_DONT_DEFINE_TEST 0
+#endif
 #if !GTEST_DONT_DEFINE_TEST
 #define TEST(test_suite_name, test_name) GTEST_TEST(test_suite_name, test_name)
 #endif

--- a/googletest/include/gtest/internal/gtest-port-arch.h
+++ b/googletest/include/gtest/internal/gtest-port-arch.h
@@ -111,4 +111,89 @@
 #define GTEST_OS_XTENSA 1
 #endif  // __CYGWIN__
 
+#ifndef GTEST_OS_CYGWIN
+# define GTEST_OS_CYGWIN 0
+#endif
+#ifndef GTEST_OS_WINDOWS_MINGW
+# define GTEST_OS_WINDOWS_MINGW 0
+#endif
+#ifndef GTEST_OS_WINDOWS
+# define GTEST_OS_WINDOWS 0
+#endif
+#ifndef GTEST_OS_WINDOWS_MOBILE
+# define GTEST_OS_WINDOWS_MOBILE 0
+#endif
+#ifndef GTEST_OS_WINDOWS_DESKTOP
+# define GTEST_OS_WINDOWS_DESKTOP 0
+#endif
+#ifndef GTEST_OS_WINDOWS_PHONE
+# define GTEST_OS_WINDOWS_PHONE 0
+#endif
+#ifndef GTEST_OS_WINDOWS_RT
+# define GTEST_OS_WINDOWS_RT 0
+#endif
+#ifndef GTEST_OS_WINDOWS_TV_TITLE
+# define GTEST_OS_WINDOWS_TV_TITLE 0
+#endif
+#ifndef GTEST_OS_OS2
+# define GTEST_OS_OS2 0
+#endif
+#ifndef GTEST_OS_MAC
+# define GTEST_OS_MAC 0
+#endif
+#ifndef GTEST_OS_IOS
+# define GTEST_OS_IOS 0
+#endif
+#ifndef GTEST_OS_DRAGONFLY
+# define GTEST_OS_DRAGONFLY 0
+#endif
+#ifndef GTEST_OS_FREEBSD
+# define GTEST_OS_FREEBSD 0
+#endif
+#ifndef GTEST_OS_FUCHSIA
+# define GTEST_OS_FUCHSIA 0
+#endif
+#ifndef GTEST_OS_GNU_KFREEBSD
+# define GTEST_OS_GNU_KFREEBSD 0
+#endif
+#ifndef GTEST_OS_LINUX
+# define GTEST_OS_LINUX 0
+#endif
+#ifndef GTEST_OS_LINUX_ANDROID
+# define GTEST_OS_LINUX_ANDROID 0
+#endif
+#ifndef GTEST_OS_ZOS
+# define GTEST_OS_ZOS 0
+#endif
+#ifndef GTEST_OS_SOLARIS
+# define GTEST_OS_SOLARIS 0
+#endif
+#ifndef GTEST_OS_AIX
+# define GTEST_OS_AIX 0
+#endif
+#ifndef GTEST_OS_HPUX
+# define GTEST_OS_HPUX 0
+#endif
+#ifndef GTEST_OS_NACL
+# define GTEST_OS_NACL 0
+#endif
+#ifndef GTEST_OS_NETBSD
+# define GTEST_OS_NETBSD 0
+#endif
+#ifndef GTEST_OS_OPENBSD
+# define GTEST_OS_OPENBSD 0
+#endif
+#ifndef GTEST_OS_QNX
+# define GTEST_OS_QNX 0
+#endif
+#ifndef GTEST_OS_HAIKU
+# define GTEST_OS_HAIKU 0
+#endif
+#ifndef GTEST_OS_ESP8266
+# define GTEST_OS_ESP8266 0
+#endif
+#ifndef GTEST_OS_ESP32
+# define GTEST_OS_ESP32 0
+#endif
+
 #endif  // GOOGLETEST_INCLUDE_GTEST_INTERNAL_GTEST_PORT_ARCH_H_

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -5912,6 +5912,9 @@ bool UnitTestImpl::RunAllTests() {
         "() before calling RUN_ALL_TESTS(). This is INVALID. Soon " GTEST_NAME_
         " will start to enforce the valid usage. "
         "Please fix it ASAP, or IT WILL START TO FAIL.\n");  // NOLINT
+#ifndef GTEST_FOR_GOOGLE_
+# define GTEST_FOR_GOOGLE_ 0
+#endif
 #if GTEST_FOR_GOOGLE_
     ColoredPrintf(GTestColor::kRed,
                   "For more details, see http://wiki/Main/ValidGUnitMain.\n");

--- a/googletest/test/googletest-output-test_.cc
+++ b/googletest/test/googletest-output-test_.cc
@@ -39,7 +39,7 @@
 
 #include <stdlib.h>
 
-#if _MSC_VER
+#ifdef _MSC_VER
 GTEST_DISABLE_MSC_WARNINGS_PUSH_(4127 /* conditional expression is constant */)
 #endif  //  _MSC_VER
 
@@ -1101,7 +1101,7 @@ int main(int argc, char **argv) {
   // are registered, and torn down in the reverse order.
   testing::AddGlobalTestEnvironment(new FooEnvironment);
   testing::AddGlobalTestEnvironment(new BarEnvironment);
-#if _MSC_VER
+#ifdef _MSC_VER
 GTEST_DISABLE_MSC_WARNINGS_POP_()  //  4127
 #endif  //  _MSC_VER
   return RunAllTests();

--- a/googletest/test/googletest-printers-test.cc
+++ b/googletest/test/googletest-printers-test.cc
@@ -1827,7 +1827,7 @@ TEST(UniversalPrintTest, SmartPointers) {
   std::shared_ptr<int> p3(new int(1979));
   EXPECT_EQ("(ptr = " + PrintPointer(p3.get()) + ", value = 1979)",
             PrintToString(p3));
-#if __cpp_lib_shared_ptr_arrays >= 201611L
+#if defined(__cpp_lib_shared_ptr_arrays) && __cpp_lib_shared_ptr_arrays >= 201611L
   std::shared_ptr<int[]> p4(new int[2]);
   EXPECT_EQ("(" + PrintPointer(p4.get()) + ")", PrintToString(p4));
 #endif
@@ -1846,7 +1846,7 @@ TEST(UniversalPrintTest, SmartPointers) {
   EXPECT_EQ("(nullptr)", PrintToString(std::shared_ptr<const int>()));
   EXPECT_EQ("(nullptr)", PrintToString(std::shared_ptr<volatile int>()));
   EXPECT_EQ("(nullptr)", PrintToString(std::shared_ptr<volatile const int>()));
-#if __cpp_lib_shared_ptr_arrays >= 201611L
+#if defined(__cpp_lib_shared_ptr_arrays) && __cpp_lib_shared_ptr_arrays >= 201611L
   EXPECT_EQ("(nullptr)", PrintToString(std::shared_ptr<int[]>()));
   EXPECT_EQ("(nullptr)", PrintToString(std::shared_ptr<const int[]>()));
   EXPECT_EQ("(nullptr)", PrintToString(std::shared_ptr<volatile int[]>()));

--- a/googletest/test/gtest-typed-test_test.cc
+++ b/googletest/test/gtest-typed-test_test.cc
@@ -36,7 +36,7 @@
 
 #include "gtest/gtest.h"
 
-#if _MSC_VER
+#ifdef _MSC_VER
 GTEST_DISABLE_MSC_WARNINGS_PUSH_(4127 /* conditional expression is constant */)
 #endif  //  _MSC_VER
 

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -461,7 +461,7 @@ class FormatEpochTimeInMillisAsIso8601Test : public Test {
     // tzset() distinguishes between the TZ variable being present and empty
     // and not being present, so we have to consider the case of time_zone
     // being NULL.
-#if _MSC_VER || GTEST_OS_WINDOWS_MINGW
+#if defined(_MSC_VER) || GTEST_OS_WINDOWS_MINGW
     // ...Unless it's MSVC, whose standard library's _putenv doesn't
     // distinguish between an empty and a missing variable.
     const std::string env_var =


### PR DESCRIPTION
`-Wundef` detects cases where an undefined symbol is evaluated in the context of `#if` and defaults to `0`. While this default behavior could sometimes be a nice shortcut it can also hide issues like lack of proper configuration or a misspelled macro.

Furthermore, clients adding the library by CMake `add_subdirectory` might be hit by the problem of `-Wundef` triggered in the library itself. Protecting against it also simplifies client scenarios by not requiring the client to disable the flag in the library builds.

For "detection macros" this is done by either adding proper `#else` cases (in simplest scenarios) or by appending a block:
```C
#ifndef <VAR>
# define <VAR> 0
#endif
```
which avoids complexity while ensuring the macro is always defined.

For "configuration macros" this is done by adding a similar block prior to the first use to ensure it is always defined.