### PR TITLE
Fix broken link to documentation (docs/primer.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ release them together.
 ### Getting Started
 
 The information for **GoogleTest** is available in the
-[GoogleTest Primer](googletest/docs/primer.md) documentation.
+[GoogleTest Primer](docs/primer.md) documentation.
 
 **GoogleMock** is an extension to GoogleTest for writing and using C++ mock
 classes. See the separate [GoogleMock documentation](googlemock/README.md).


### PR DESCRIPTION
The provided "GoogleTest Primer" link was reported broken by github. I updated it so that instead of pointing to https://github.com/google/googletest/blob/master/googletest/docs/primer.md (not found), it now points to https://github.com/google/googletest/blob/master/docs/primer.md