### PR TITLE
Export Test - Do Not Merge

### DIFF
--- a/docs/gmock_cook_book.md
+++ b/docs/gmock_cook_book.md
@@ -3618,6 +3618,9 @@ Expected: is divisible by 7
   Actual: 23 (the remainder is 2)
 ```
 
+Tip: for convenience, `MatchAndExplain()` can take a `MatchResultListener*`
+instead of `std::ostream*`.
+
 ### Writing New Polymorphic Matchers
 
 Expanding what we learned above to *polymorphic* matchers is now just as simple

--- a/googletest/include/gtest/gtest-matchers.h
+++ b/googletest/include/gtest/gtest-matchers.h
@@ -67,6 +67,7 @@ namespace testing {
 //   1. a class FooMatcherMatcher that implements the matcher interface:
 //     using is_gtest_matcher = void;
 //     bool MatchAndExplain(const T&, std::ostream*);
+//       (MatchResultListener* can also be used instead of std::ostream*)
 //     void DescribeTo(std::ostream*);
 //     void DescribeNegationTo(std::ostream*);
 //

--- a/googletest/include/gtest/gtest-typed-test.h
+++ b/googletest/include/gtest/gtest-typed-test.h
@@ -175,8 +175,6 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
 
 // Implements typed tests.
 
-#if GTEST_HAS_TYPED_TEST
-
 // INTERNAL IMPLEMENTATION - DO NOT USE IN USER CODE.
 //
 // Expands to the name of the typedef for the type parameters of the
@@ -230,11 +228,7 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
   TYPED_TEST_SUITE
 #endif  // GTEST_REMOVE_LEGACY_TEST_CASEAPI_
 
-#endif  // GTEST_HAS_TYPED_TEST
-
 // Implements type-parameterized tests.
-
-#if GTEST_HAS_TYPED_TEST_P
 
 // INTERNAL IMPLEMENTATION - DO NOT USE IN USER CODE.
 //
@@ -331,7 +325,5 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
       ::testing::internal::InstantiateTypedTestCase_P_IsDeprecated(), ""); \
   INSTANTIATE_TYPED_TEST_SUITE_P
 #endif  // GTEST_REMOVE_LEGACY_TEST_CASEAPI_
-
-#endif  // GTEST_HAS_TYPED_TEST_P
 
 #endif  // GTEST_INCLUDE_GTEST_GTEST_TYPED_TEST_H_

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1616,7 +1616,8 @@ AssertionResult CmpHelper##op_name(const char* expr1, const char* expr2, \
   } else {\
     return CmpHelperOpFailure(expr1, expr2, val1, val2, #op);\
   }\
-}
+}\
+static_assert(true, "Consume semicolon.")
 
 // INTERNAL IMPLEMENTATION - DO NOT USE IN A USER PROGRAM.
 

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -590,8 +590,6 @@ GTEST_API_ TestInfo* MakeAndRegisterTestInfo(
 // and returns false.  None of pstr, *pstr, and prefix can be NULL.
 GTEST_API_ bool SkipPrefix(const char* prefix, const char** pstr);
 
-#if GTEST_HAS_TYPED_TEST || GTEST_HAS_TYPED_TEST_P
-
 GTEST_DISABLE_MSC_WARNINGS_PUSH_(4251 \
 /* class A needs to have dll-interface to be used by clients of class B */)
 
@@ -822,8 +820,6 @@ class TypeParameterizedTestSuite<Fixture, internal::None, Types> {
     return true;
   }
 };
-
-#endif  // GTEST_HAS_TYPED_TEST || GTEST_HAS_TYPED_TEST_P
 
 // Returns the current OS stack trace as an std::string.
 //

--- a/googletest/include/gtest/internal/gtest-type-util.h
+++ b/googletest/include/gtest/internal/gtest-type-util.h
@@ -98,8 +98,6 @@ std::string GetTypeName() {
 #endif  // GTEST_HAS_RTTI
 }
 
-#if GTEST_HAS_TYPED_TEST || GTEST_HAS_TYPED_TEST_P
-
 // A unique type indicating an empty node
 struct None {};
 
@@ -174,8 +172,6 @@ struct GenerateTypeList {
  public:
   using type = typename proxy::type;
 };
-
-#endif  // GTEST_HAS_TYPED_TEST || GTEST_HAS_TYPED_TEST_P
 
 }  // namespace internal
 

--- a/googletest/samples/sample6_unittest.cc
+++ b/googletest/samples/sample6_unittest.cc
@@ -73,8 +73,6 @@ class PrimeTableTest : public testing::Test {
   PrimeTable* const table_;
 };
 
-#if GTEST_HAS_TYPED_TEST
-
 using testing::Types;
 
 // Google Test offers two ways for reusing tests for different types.
@@ -133,10 +131,6 @@ TYPED_TEST(PrimeTableTest, CanGetNextPrime) {
 // That's it!  Google Test will repeat each TYPED_TEST for each type
 // in the type list specified in TYPED_TEST_SUITE.  Sit back and be
 // happy that you don't have to define them multiple times.
-
-#endif  // GTEST_HAS_TYPED_TEST
-
-#if GTEST_HAS_TYPED_TEST_P
 
 using testing::Types;
 
@@ -220,5 +214,4 @@ INSTANTIATE_TYPED_TEST_SUITE_P(OnTheFlyAndPreCalculated,    // Instance name
                                PrimeTableTest2,             // Test case name
                                PrimeTableImplementations);  // Type list
 
-#endif  // GTEST_HAS_TYPED_TEST_P
 }  // namespace

--- a/googletest/src/gtest-typed-test.cc
+++ b/googletest/src/gtest-typed-test.cc
@@ -35,8 +35,6 @@
 namespace testing {
 namespace internal {
 
-#if GTEST_HAS_TYPED_TEST_P
-
 // Skips to the first non-space char in str. Returns an empty string if str
 // contains only whitespace characters.
 static const char* SkipSpaces(const char* str) {
@@ -104,8 +102,6 @@ const char* TypedTestSuitePState::VerifyRegisteredTestNames(
 
   return registered_tests;
 }
-
-#endif  // GTEST_HAS_TYPED_TEST_P
 
 }  // namespace internal
 }  // namespace testing

--- a/googletest/test/googletest-output-test_.cc
+++ b/googletest/test/googletest-output-test_.cc
@@ -744,9 +744,6 @@ TEST_P(DetectNotInstantiatedTest, Used) { }
 // This would make the test failure from the above go away.
 // INSTANTIATE_TEST_SUITE_P(Fix, DetectNotInstantiatedTest, testing::Values(1));
 
-// This #ifdef block tests the output of typed tests.
-#if GTEST_HAS_TYPED_TEST
-
 template <typename T>
 class TypedTest : public testing::Test {
 };
@@ -782,11 +779,6 @@ TYPED_TEST_SUITE(TypedTestWithNames, TypesForTestWithNames, TypedTestNames);
 TYPED_TEST(TypedTestWithNames, Success) {}
 
 TYPED_TEST(TypedTestWithNames, Failure) { FAIL(); }
-
-#endif  // GTEST_HAS_TYPED_TEST
-
-// This #ifdef block tests the output of type-parameterized tests.
-#if GTEST_HAS_TYPED_TEST_P
 
 template <typename T>
 class TypedTestP : public testing::Test {
@@ -838,8 +830,6 @@ REGISTER_TYPED_TEST_SUITE_P(DetectNotInstantiatedTypesTest, Used);
 // typedef ::testing::Types<char, int, unsigned int> MyTypes;
 // INSTANTIATE_TYPED_TEST_SUITE_P(All, DetectNotInstantiatedTypesTest, MyTypes);
 
-#endif  // GTEST_HAS_TYPED_TEST_P
-
 #if GTEST_HAS_DEATH_TEST
 
 // We rely on the golden file to verify that tests whose test case
@@ -847,8 +837,6 @@ REGISTER_TYPED_TEST_SUITE_P(DetectNotInstantiatedTypesTest, Used);
 
 TEST(ADeathTest, ShouldRunFirst) {
 }
-
-# if GTEST_HAS_TYPED_TEST
 
 // We rely on the golden file to verify that typed tests whose test
 // case name ends with DeathTest are run first.
@@ -862,10 +850,6 @@ TYPED_TEST_SUITE(ATypedDeathTest, NumericTypes);
 
 TYPED_TEST(ATypedDeathTest, ShouldRunFirst) {
 }
-
-# endif  // GTEST_HAS_TYPED_TEST
-
-# if GTEST_HAS_TYPED_TEST_P
 
 
 // We rely on the golden file to verify that type-parameterized tests
@@ -883,8 +867,6 @@ TYPED_TEST_P(ATypeParamDeathTest, ShouldRunFirst) {
 REGISTER_TYPED_TEST_SUITE_P(ATypeParamDeathTest, ShouldRunFirst);
 
 INSTANTIATE_TYPED_TEST_SUITE_P(My, ATypeParamDeathTest, NumericTypes);
-
-# endif  // GTEST_HAS_TYPED_TEST_P
 
 #endif  // GTEST_HAS_DEATH_TEST
 

--- a/googletest/test/googletest-port-test.cc
+++ b/googletest/test/googletest-port-test.cc
@@ -373,8 +373,6 @@ TEST(RegexEngineSelectionTest, SelectsCorrectRegexEngine) {
 
 #if GTEST_USES_POSIX_RE
 
-# if GTEST_HAS_TYPED_TEST
-
 template <typename Str>
 class RETest : public ::testing::Test {};
 
@@ -429,8 +427,6 @@ TYPED_TEST(RETest, PartialMatchWorks) {
   EXPECT_TRUE(RE::PartialMatch(TypeParam("azy"), re));
   EXPECT_FALSE(RE::PartialMatch(TypeParam("zza"), re));
 }
-
-# endif  // GTEST_HAS_TYPED_TEST
 
 #elif GTEST_USES_SIMPLE_RE
 

--- a/googletest/test/gtest-typed-test2_test.cc
+++ b/googletest/test/gtest-typed-test2_test.cc
@@ -33,12 +33,8 @@
 #include "test/gtest-typed-test_test.h"
 #include "gtest/gtest.h"
 
-#if GTEST_HAS_TYPED_TEST_P
-
 // Tests that the same type-parameterized test case can be
 // instantiated in different translation units linked together.
 // (ContainerTest is also instantiated in gtest-typed-test_test.cc.)
 INSTANTIATE_TYPED_TEST_SUITE_P(Vector, ContainerTest,
                                testing::Types<std::vector<int> >);
-
-#endif  // GTEST_HAS_TYPED_TEST_P

--- a/googletest/test/gtest-typed-test_test.cc
+++ b/googletest/test/gtest-typed-test_test.cc
@@ -88,9 +88,6 @@ class CommonTest : public Test {
 template <typename T>
 T* CommonTest<T>::shared_ = nullptr;
 
-// This #ifdef block tests typed tests.
-#if GTEST_HAS_TYPED_TEST
-
 using testing::Types;
 
 // Tests that SetUpTestSuite()/TearDownTestSuite(), fixture ctor/dtor,
@@ -203,11 +200,6 @@ TYPED_TEST(TypedTestWithNames, TestSuiteName) {
                  "TypedTestWithNames/int1");
   }
 }
-
-#endif  // GTEST_HAS_TYPED_TEST
-
-// This #ifdef block tests type-parameterized tests.
-#if GTEST_HAS_TYPED_TEST_P
 
 using testing::Types;
 using testing::internal::TypedTestSuitePState;
@@ -443,20 +435,3 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, TrimmedTest, TrimTypes);
 
 }  // namespace library2
 
-#endif  // GTEST_HAS_TYPED_TEST_P
-
-#if !defined(GTEST_HAS_TYPED_TEST) && !defined(GTEST_HAS_TYPED_TEST_P)
-
-// Google Test may not support type-parameterized tests with some
-// compilers. If we use conditional compilation to compile out all
-// code referring to the gtest_main library, MSVC linker will not link
-// that library at all and consequently complain about missing entry
-// point defined in that library (fatal error LNK1561: entry point
-// must be defined). This dummy test keeps gtest_main linked in.
-TEST(DummyTest, TypedTestsAreNotSupportedOnThisPlatform) {}
-
-#if _MSC_VER
-GTEST_DISABLE_MSC_WARNINGS_POP_()  //  4127
-#endif                             //  _MSC_VER
-
-#endif  // #if !defined(GTEST_HAS_TYPED_TEST) && !defined(GTEST_HAS_TYPED_TEST_P)

--- a/googletest/test/gtest-typed-test_test.h
+++ b/googletest/test/gtest-typed-test_test.h
@@ -33,8 +33,6 @@
 
 #include "gtest/gtest.h"
 
-#if GTEST_HAS_TYPED_TEST_P
-
 using testing::Test;
 
 // For testing that the same type-parameterized test case can be
@@ -59,7 +57,5 @@ TYPED_TEST_P(ContainerTest, InitialSizeIsZero) {
 
 REGISTER_TYPED_TEST_SUITE_P(ContainerTest,
                             CanBeDefaultConstructed, InitialSizeIsZero);
-
-#endif  // GTEST_HAS_TYPED_TEST_P
 
 #endif  // GTEST_TEST_GTEST_TYPED_TEST_TEST_H_

--- a/googletest/test/gtest-unittest-api_test.cc
+++ b/googletest/test/gtest-unittest-api_test.cc
@@ -95,17 +95,12 @@ class UnitTestHelper {
   }
 };
 
-#if GTEST_HAS_TYPED_TEST
 template <typename T> class TestSuiteWithCommentTest : public Test {};
 TYPED_TEST_SUITE(TestSuiteWithCommentTest, Types<int>);
 TYPED_TEST(TestSuiteWithCommentTest, Dummy) {}
 
 const int kTypedTestSuites = 1;
 const int kTypedTests = 1;
-#else
-const int kTypedTestSuites = 0;
-const int kTypedTests = 0;
-#endif  // GTEST_HAS_TYPED_TEST
 
 // We can only test the accessors that do not change value while tests run.
 // Since tests can be run in any order, the values the accessors that track
@@ -123,9 +118,7 @@ TEST(ApiTest, UnitTestImmutableAccessorsWork) {
 
   EXPECT_STREQ("ApiTest", test_suites[0]->name());
   EXPECT_STREQ("DISABLED_Test", test_suites[1]->name());
-#if GTEST_HAS_TYPED_TEST
   EXPECT_STREQ("TestSuiteWithCommentTest/0", test_suites[2]->name());
-#endif  // GTEST_HAS_TYPED_TEST
 
   delete[] test_suites;
 
@@ -183,7 +176,6 @@ TEST(ApiTest, TestSuiteImmutableAccessorsWork) {
   delete[] tests;
   tests = nullptr;
 
-#if GTEST_HAS_TYPED_TEST
   test_suite = UnitTestHelper::FindTestSuite("TestSuiteWithCommentTest/0");
   ASSERT_TRUE(test_suite != nullptr);
 
@@ -203,7 +195,6 @@ TEST(ApiTest, TestSuiteImmutableAccessorsWork) {
   EXPECT_TRUE(tests[0]->should_run());
 
   delete[] tests;
-#endif  // GTEST_HAS_TYPED_TEST
 }
 
 TEST(ApiTest, TestSuiteDisabledAccessorsWork) {
@@ -263,7 +254,6 @@ class FinalSuccessChecker : public Environment {
     EXPECT_EQ(0, test_suites[1]->successful_test_count());
     EXPECT_EQ(0, test_suites[1]->failed_test_count());
 
-#if GTEST_HAS_TYPED_TEST
     EXPECT_STREQ("TestSuiteWithCommentTest/0", test_suites[2]->name());
     EXPECT_STREQ(GetTypeName<Types<int>>().c_str(),
                  test_suites[2]->type_param());
@@ -274,7 +264,6 @@ class FinalSuccessChecker : public Environment {
     EXPECT_EQ(0, test_suites[2]->failed_test_count());
     EXPECT_TRUE(test_suites[2]->Passed());
     EXPECT_FALSE(test_suites[2]->Failed());
-#endif  // GTEST_HAS_TYPED_TEST
 
     const TestSuite* test_suite = UnitTestHelper::FindTestSuite("ApiTest");
     const TestInfo** tests = UnitTestHelper::GetSortedTests(test_suite);
@@ -311,7 +300,6 @@ class FinalSuccessChecker : public Environment {
 
     delete[] tests;
 
-#if GTEST_HAS_TYPED_TEST
     test_suite = UnitTestHelper::FindTestSuite("TestSuiteWithCommentTest/0");
     tests = UnitTestHelper::GetSortedTests(test_suite);
 
@@ -324,7 +312,6 @@ class FinalSuccessChecker : public Environment {
     EXPECT_EQ(0, tests[0]->result()->test_property_count());
 
     delete[] tests;
-#endif  // GTEST_HAS_TYPED_TEST
     delete[] test_suites;
   }
 };

--- a/googletest/test/gtest_list_output_unittest.py
+++ b/googletest/test/gtest_list_output_unittest.py
@@ -56,20 +56,20 @@ EXPECTED_XML = """<\?xml version="1.0" encoding="UTF-8"\?>
     <testcase name="Test4" file=".*gtest_list_output_unittest_.cc" line="49" />
   </testsuite>
   <testsuite name="TypedTest/0" tests="2">
-    <testcase name="Test7" type_param="int" file=".*gtest_list_output_unittest_.cc" line="61" />
-    <testcase name="Test8" type_param="int" file=".*gtest_list_output_unittest_.cc" line="62" />
+    <testcase name="Test7" type_param="int" file=".*gtest_list_output_unittest_.cc" line="60" />
+    <testcase name="Test8" type_param="int" file=".*gtest_list_output_unittest_.cc" line="61" />
   </testsuite>
   <testsuite name="TypedTest/1" tests="2">
-    <testcase name="Test7" type_param="bool" file=".*gtest_list_output_unittest_.cc" line="61" />
-    <testcase name="Test8" type_param="bool" file=".*gtest_list_output_unittest_.cc" line="62" />
+    <testcase name="Test7" type_param="bool" file=".*gtest_list_output_unittest_.cc" line="60" />
+    <testcase name="Test8" type_param="bool" file=".*gtest_list_output_unittest_.cc" line="61" />
   </testsuite>
   <testsuite name="Single/TypeParameterizedTestSuite/0" tests="2">
-    <testcase name="Test9" type_param="int" file=".*gtest_list_output_unittest_.cc" line="69" />
-    <testcase name="Test10" type_param="int" file=".*gtest_list_output_unittest_.cc" line="70" />
+    <testcase name="Test9" type_param="int" file=".*gtest_list_output_unittest_.cc" line="66" />
+    <testcase name="Test10" type_param="int" file=".*gtest_list_output_unittest_.cc" line="67" />
   </testsuite>
   <testsuite name="Single/TypeParameterizedTestSuite/1" tests="2">
-    <testcase name="Test9" type_param="bool" file=".*gtest_list_output_unittest_.cc" line="69" />
-    <testcase name="Test10" type_param="bool" file=".*gtest_list_output_unittest_.cc" line="70" />
+    <testcase name="Test9" type_param="bool" file=".*gtest_list_output_unittest_.cc" line="66" />
+    <testcase name="Test10" type_param="bool" file=".*gtest_list_output_unittest_.cc" line="67" />
   </testsuite>
   <testsuite name="ValueParam/ValueParamTest" tests="4">
     <testcase name="Test5/0" value_param="33" file=".*gtest_list_output_unittest_.cc" line="52" />
@@ -124,13 +124,13 @@ EXPECTED_JSON = """{
           "name": "Test7",
           "type_param": "int",
           "file": ".*gtest_list_output_unittest_.cc",
-          "line": 61
+          "line": 60
         },
         {
           "name": "Test8",
           "type_param": "int",
           "file": ".*gtest_list_output_unittest_.cc",
-          "line": 62
+          "line": 61
         }
       \]
     },
@@ -142,13 +142,13 @@ EXPECTED_JSON = """{
           "name": "Test7",
           "type_param": "bool",
           "file": ".*gtest_list_output_unittest_.cc",
-          "line": 61
+          "line": 60
         },
         {
           "name": "Test8",
           "type_param": "bool",
           "file": ".*gtest_list_output_unittest_.cc",
-          "line": 62
+          "line": 61
         }
       \]
     },
@@ -160,13 +160,13 @@ EXPECTED_JSON = """{
           "name": "Test9",
           "type_param": "int",
           "file": ".*gtest_list_output_unittest_.cc",
-          "line": 69
+          "line": 66
         },
         {
           "name": "Test10",
           "type_param": "int",
           "file": ".*gtest_list_output_unittest_.cc",
-          "line": 70
+          "line": 67
         }
       \]
     },
@@ -178,13 +178,13 @@ EXPECTED_JSON = """{
           "name": "Test9",
           "type_param": "bool",
           "file": ".*gtest_list_output_unittest_.cc",
-          "line": 69
+          "line": 66
         },
         {
           "name": "Test10",
           "type_param": "bool",
           "file": ".*gtest_list_output_unittest_.cc",
-          "line": 70
+          "line": 67
         }
       \]
     },

--- a/googletest/test/gtest_list_output_unittest_.cc
+++ b/googletest/test/gtest_list_output_unittest_.cc
@@ -53,16 +53,13 @@ TEST_P(ValueParamTest, Test5) {}
 TEST_P(ValueParamTest, Test6) {}
 INSTANTIATE_TEST_SUITE_P(ValueParam, ValueParamTest, ::testing::Values(33, 42));
 
-#if GTEST_HAS_TYPED_TEST
 template <typename T>
 class TypedTest : public ::testing::Test {};
 typedef testing::Types<int, bool> TypedTestTypes;
 TYPED_TEST_SUITE(TypedTest, TypedTestTypes);
 TYPED_TEST(TypedTest, Test7) {}
 TYPED_TEST(TypedTest, Test8) {}
-#endif
 
-#if GTEST_HAS_TYPED_TEST_P
 template <typename T>
 class TypeParameterizedTestSuite : public ::testing::Test {};
 TYPED_TEST_SUITE_P(TypeParameterizedTestSuite);
@@ -72,7 +69,6 @@ REGISTER_TYPED_TEST_SUITE_P(TypeParameterizedTestSuite, Test9, Test10);
 typedef testing::Types<int, bool> TypeParameterizedTestSuiteTypes;  // NOLINT
 INSTANTIATE_TYPED_TEST_SUITE_P(Single, TypeParameterizedTestSuite,
                                TypeParameterizedTestSuiteTypes);
-#endif
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -3187,8 +3187,6 @@ TEST_F(DisabledTestsTest, DISABLED_TestShouldNotRun_2) {
 
 // Tests that disabled typed tests aren't run.
 
-#if GTEST_HAS_TYPED_TEST
-
 template <typename T>
 class TypedTest : public Test {
 };
@@ -3210,11 +3208,7 @@ TYPED_TEST(DISABLED_TypedTest, ShouldNotRun) {
   FAIL() << "Unexpected failure: Disabled typed test should not run.";
 }
 
-#endif  // GTEST_HAS_TYPED_TEST
-
 // Tests that disabled type-parameterized tests aren't run.
-
-#if GTEST_HAS_TYPED_TEST_P
 
 template <typename T>
 class TypedTestP : public Test {
@@ -3245,8 +3239,6 @@ TYPED_TEST_P(DISABLED_TypedTestP, ShouldNotRun) {
 REGISTER_TYPED_TEST_SUITE_P(DISABLED_TypedTestP, ShouldNotRun);
 
 INSTANTIATE_TYPED_TEST_SUITE_P(My, DISABLED_TypedTestP, NumericTypes);
-
-#endif  // GTEST_HAS_TYPED_TEST_P
 
 // Tests that assertion macros evaluate their arguments exactly once.
 

--- a/googletest/test/gtest_xml_output_unittest_.cc
+++ b/googletest/test/gtest_xml_output_unittest_.cc
@@ -163,16 +163,13 @@ TEST_P(ValueParamTest, HasValueParamAttribute) {}
 TEST_P(ValueParamTest, AnotherTestThatHasValueParamAttribute) {}
 INSTANTIATE_TEST_SUITE_P(Single, ValueParamTest, Values(33, 42));
 
-#if GTEST_HAS_TYPED_TEST
 // Verifies that the type parameter name is output in the 'type_param'
 // XML attribute for typed tests.
 template <typename T> class TypedTest : public Test {};
 typedef testing::Types<int, long> TypedTestTypes;
 TYPED_TEST_SUITE(TypedTest, TypedTestTypes);
 TYPED_TEST(TypedTest, HasTypeParamAttribute) {}
-#endif
 
-#if GTEST_HAS_TYPED_TEST_P
 // Verifies that the type parameter name is output in the 'type_param'
 // XML attribute for type-parameterized tests.
 template <typename T>
@@ -183,7 +180,6 @@ REGISTER_TYPED_TEST_SUITE_P(TypeParameterizedTestSuite, HasTypeParamAttribute);
 typedef testing::Types<int, long> TypeParameterizedTestSuiteTypes;  // NOLINT
 INSTANTIATE_TYPED_TEST_SUITE_P(Single, TypeParameterizedTestSuite,
                                TypeParameterizedTestSuiteTypes);
-#endif
 
 int main(int argc, char** argv) {
   InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Export Test - Do Not Merge

Remove uses of GTEST_HAS_TYPED_TEST_P and GTEST_HAS_TYPED_TEST.
