### PR TITLE
[gmock_gen.py] Do not include void into mocked method arguments

### DIFF
--- a/googlemock/scripts/generator/cpp/gmock_class.py
+++ b/googlemock/scripts/generator/cpp/gmock_class.py
@@ -132,7 +132,8 @@ def _GenerateMethods(output_lines, source, class_node):
       args = []
       for p in node.parameters:
         arg = _GenerateArg(source[p.start:p.end])
-        args.append(_EscapeForMacro(arg))
+        if arg != 'void':
+          args.append(_EscapeForMacro(arg))
 
       # Create the mock method definition.
       output_lines.extend([

--- a/googlemock/scripts/generator/cpp/gmock_class_test.py
+++ b/googlemock/scripts/generator/cpp/gmock_class_test.py
@@ -156,7 +156,7 @@ class Foo {
 };
 """
     self.assertEqualIgnoreLeadingWhitespace(
-        'MOCK_METHOD(int, Bar, (void), (override));',
+        'MOCK_METHOD(int, Bar, (), (override));',
         self.GenerateMethodSource(source))
 
   def testStrangeNewlineInParameter(self):


### PR DESCRIPTION
If a function that takes no arguments explicitly states (void)
then do not include it in the mocked method argument list
since it triggers static assertions that expect no arguments
to be present.

Fixes #3261