### PR TITLE
Add .md extension to links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,17 +5,17 @@
 GoogleTest is Google's C++ testing and mocking framework. This user's guide has
 the following contents:
 
-*   [GoogleTest Primer](primer) - Teaches you how to write simple tests using
+*   [GoogleTest Primer](primer.md) - Teaches you how to write simple tests using
     GoogleTest. Read this first if you are new to GoogleTest.
-*   [GoogleTest Advanced](advanced) - Read this when you've finished the Primer
+*   [GoogleTest Advanced](advanced.md) - Read this when you've finished the Primer
     and want to utilize GoogleTest to its full potential.
-*   [GoogleTest Samples](samples) - Describes some GoogleTest samples.
-*   [GoogleTest FAQ](faq) - Have a question? Want some tips? Check here first.
-*   [Mocking for Dummies](gmock_for_dummies) - Teaches you how to create mock
+*   [GoogleTest Samples](samples.md) - Describes some GoogleTest samples.
+*   [GoogleTest FAQ](faq.md) - Have a question? Want some tips? Check here first.
+*   [Mocking for Dummies](gmock_for_dummies.md) - Teaches you how to create mock
     objects and use them in tests.
-*   [Mocking Cookbook](gmock_cook_book) - Includes tips and approaches to common
+*   [Mocking Cookbook](gmock_cook_book.md) - Includes tips and approaches to common
     mocking use cases.
-*   [Mocking Cheat Sheet](gmock_cheat_sheet) - A handy reference for matchers,
+*   [Mocking Cheat Sheet](gmock_cheat_sheet.md) - A handy reference for matchers,
     actions, invariants, and more.
-*   [Mocking FAQ](gmock_faq) - Contains answers to some mocking-specific
+*   [Mocking FAQ](gmock_faq.md) - Contains answers to some mocking-specific
     questions.


### PR DESCRIPTION
Add .md extension to links make them work in the Github web interface (otherwise following the link will result in a 404)