### PR TITLE
remove -Zi from MSVC compiler options

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -72,7 +72,7 @@ macro(config_compiler_and_linker)
   if (MSVC)
     # Newlines inside flags variables break CMake's NMake generator.
     # TODO(vladl@google.com): Add -RTCs and -RTCu to debug builds.
-    set(cxx_base_flags "-GS -W4 -WX -wd4251 -wd4275 -nologo -J -Zi")
+    set(cxx_base_flags "-GS -W4 -WX -wd4251 -wd4275 -nologo -J")
     set(cxx_base_flags "${cxx_base_flags} -D_UNICODE -DUNICODE -DWIN32 -D_WIN32")
     set(cxx_base_flags "${cxx_base_flags} -DSTRICT -DWIN32_LEAN_AND_MEAN")
     set(cxx_exception_flags "-EHsc -D_HAS_EXCEPTIONS=1")


### PR DESCRIPTION
This is incompatible with compiler caches such as sccache and
clcache. If a project including Google Test specifies /Z7 instead,
building fails with:

```
sccache C:\PROGRA~2\MICROS~1\2019\ENTERP~1\VC\Tools\MSVC\1428~1.293\bin\Hostx64\x64\cl.exe  /nologo /TP -D__SSE2__ -D__SSE__ -I..\lib\googletest-1.10.x\googlemock\include -I..\lib\googletest-1.10.x\googlemock -I..\lib\googletest-1.10.x\googletest\include -I..\lib\googletest-1.10.x\googletest /DWIN32 /D_WINDOWS /W4 /GR  /MD /Z7 /O2 /Ob1 /DNDEBUG -GS -W4 -WX -wd4251 -wd4275 -nologo -J -Zi -D_UNICODE -DUNICODE -DWIN32 -D_WIN32 -DSTRICT -DWIN32_LEAN_AND_MEAN -wd4702 -DGTEST_HAS_PTHREAD=0 -EHsc -D_HAS_EXCEPTIONS=1  /Gy /showIncludes /Folib\googletest-1.10.x\googlemock\CMakeFiles\gmock_main.dir\src\gmock-all.cc.obj /Fdbin\gmock_main.pdb /FS -c ..\lib\googletest-1.10.x\googlemock\src\gmock-all.cc
FAILED: lib/googletest-1.10.x/googlemock/CMakeFiles/gmock_main.dir/src/gmock-all.cc.obj
..\lib\googletest-1.10.x\googletest\src\gtest-all.cc: fatal error C1041: cannot open program database 'D:\a\mixxx\mixxx\build\bin\gmock_main.pdb'; if multiple CL.EXE write to the same .PDB file, please use /FS
cl : Command line warning D9025 : overriding '/Z7' with '/Zi'
```