### PR TITLE
Use platforms instead of bazel_tools for windows constraint

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -40,7 +40,7 @@ exports_files(["LICENSE"])
 
 config_setting(
     name = "windows",
-    constraint_values = ["@bazel_tools//platforms:windows"],
+    constraint_values = ["@platforms//os:windows"],
 )
 
 config_setting(


### PR DESCRIPTION
Our projects are using the platforms API and our targets that use googletest were failing to build due to using `@bazel_tools//platforms`.

```
ERROR: C:/users/zekew/_bazel_zekew/5hhwqc6f/external/bazel_tools/platforms/BUILD:79:6: in alias rule @bazel_tools//platforms:windows: Constraints from @bazel_tools//platforms have been removed. Please use constraints from @platforms repository embedded in Bazel, or 
preferably declare dependency on https://github.com/bazelbuild/platforms. See https://github.com/bazelbuild/bazel/issues/8622 for details.
ERROR: While resolving configuration keys for @com_google_googletest//:gtest: Analysis of target '@bazel_tools//platforms:windows' failed
```