### PR TITLE
Update a stale reference to the Google C++ style guide

### DIFF
--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1992,11 +1992,11 @@ class TestWithParam : public Test, public WithParamInterface<T> {
 // Note:
 //
 //   1. It is possible to make a user-defined type work with
-//   {ASSERT|EXPECT}_??(), but that requires overloading the
-//   comparison operators and is thus discouraged by the Google C++
-//   Usage Guide.  Therefore, you are advised to use the
-//   {ASSERT|EXPECT}_TRUE() macro to assert that two objects are
-//   equal.
+//   {ASSERT|EXPECT}_??() by overloading the comparison operators. Note
+//   that these macros rely on argument-dependent lookup to find the
+//   comparison operators, so the operators must be defined in the same
+//   namespace as the types being compared (or at least one of the
+//   types if they are from different namespaces).
 //
 //   2. The {ASSERT|EXPECT}_??() macros do pointer comparisons on
 //   pointers (in particular, C strings).  Therefore, if you use it


### PR DESCRIPTION
In the comment to `EXPECT_EQ` macro, there's a reference to the Google C++ style guide discouraging operator overloading. I believe this refers to an older version of the style guide and is no longer relevant. The current style guide doesn't prohibit operator overloading but only advises doing so ["judiciously"](https://google.github.io/styleguide/cppguide.html#Operator_Overloading). It specifically mentions overloading `operator==`:
> Don't go out of your way to avoid defining operator overloads. For example, prefer to define `==`, `=`, and `<<`, rather than `Equals()`, `CopyFrom()`, and `PrintTo()`.

As it stands, points 1 and 3 are contradictory -- point 3 recommends using `EXPECT_EQ` over `EXPECT_TRUE` because of the better error messages, but point 1 recommends using `EXPECT_TRUE` over `EXPECT_EQ`, citing the style guide.

I have also added a brief mention of ADL, but this is less important -- I'm okay to remove that bit.