### PR TITLE
Add CMake alias targets

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -150,6 +150,9 @@ function(cxx_library_with_type name type cxx_flags)
   # type can be either STATIC or SHARED to denote a static or shared library.
   # ARGN refers to additional arguments after 'cxx_flags'.
   add_library(${name} ${type} ${ARGN})
+  # Enable alias targets independent of using either find_package() or
+  # add_subdirectory() when consuming googletest
+  add_library(GTest::${name} ALIAS ${name})
   set_target_properties(${name}
     PROPERTIES
     COMPILE_FLAGS "${cxx_flags}")


### PR DESCRIPTION
Currently, projects may use `target_link_libraries(... GTest::gtest)` etc. when consuming googletest via `find_package()` and `target_link_libraries(... gtest)` when consuming it via `add_subdirectory()`.
This PR enables consuming projects to always refer to be using `GTest::gtest` etc. regardless of how this project was integrated.