### PR TITLE
[fuchsia] Use ZX_INFO_PROCESS_V2

### DIFF
--- a/googletest/src/gtest-death-test.cc
+++ b/googletest/src/gtest-death-test.cc
@@ -953,12 +953,12 @@ int FuchsiaDeathTest::Wait() {
 
   ReadAndInterpretStatusByte();
 
-  zx_info_process_t buffer;
+  zx_info_process_v2_t buffer;
   status_zx = child_process_.get_info(
-      ZX_INFO_PROCESS, &buffer, sizeof(buffer), nullptr, nullptr);
+      ZX_INFO_PROCESS_V2, &buffer, sizeof(buffer), nullptr, nullptr);
   GTEST_DEATH_TEST_CHECK_(status_zx == ZX_OK);
 
-  GTEST_DEATH_TEST_CHECK_(buffer.exited);
+  GTEST_DEATH_TEST_CHECK_(buffer.flags & ZX_INFO_PROCESS_FLAG_EXITED);
   set_status(buffer.return_code);
   return status();
 }


### PR DESCRIPTION
This is part of a soft transition over to having ZX_INFO_PROCESS
populate a new struct. See fxbug.dev/30751 for more details.