### PR TITLE
Workaround for IAR chrono library

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -1044,7 +1044,7 @@ class Timer {
   }
 
  private:
-  std::chrono::time_point<std::chrono::steady_clock> start_;
+  std::chrono::steady_clock::time_point start_;
 };
 
 // Returns a timestamp as milliseconds since the epoch. Note this time may jump


### PR DESCRIPTION
The IAR compiler is popular on embedded systems because it produces very compact binaries. The C++ standard library is different. Therefore this patch is required.

* Use time_point from clock class instead of the template.

dlib uses the same time_point structure for all clocks. But the template specialisation would generate a new type for each clock. Compilation fails because of the type mismatches. 