### PR TITLE
Export Test - Do Not Merge

### DIFF
--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -343,7 +343,7 @@ class MatcherCastImpl {
     // constructor from M (this usually happens when T has an implicit
     // constructor from any type).
     //
-    // It won't work to unconditionally implict_cast
+    // It won't work to unconditionally implicit_cast
     // polymorphic_matcher_or_value to Matcher<T> because it won't trigger
     // a user-defined conversion from M to T if one exists (assuming M is
     // a value).

--- a/googlemock/scripts/generator/cpp/ast.py
+++ b/googlemock/scripts/generator/cpp/ast.py
@@ -336,7 +336,7 @@ class Class(_GenericDeclaration):
     # TODO(nnorwitz): handle namespaces, etc.
     if self.bases:
       for token_list in self.bases:
-        # TODO(nnorwitz): bases are tokens, do name comparision.
+        # TODO(nnorwitz): bases are tokens, do name comparison.
         for token in token_list:
           if token.name == node.name:
             return True
@@ -379,7 +379,7 @@ class Function(_GenericDeclaration):
 
   def Requires(self, node):
     if self.parameters:
-      # TODO(nnorwitz): parameters are tokens, do name comparision.
+      # TODO(nnorwitz): parameters are tokens, do name comparison.
       for p in self.parameters:
         if p.name == node.name:
           return True
@@ -895,7 +895,7 @@ class AstBuilder(object):
         nesting -= 1
     return tokens, last_token
 
-  # TODO(nnorwitz): remove _IgnoreUpTo() it shouldn't be necesary.
+  # TODO(nnorwitz): remove _IgnoreUpTo() it shouldn't be necessary.
   def _IgnoreUpTo(self, token_type, token):
     unused_tokens = self._GetTokensUpTo(token_type, token)
 

--- a/googlemock/test/gmock-actions_test.cc
+++ b/googlemock/test/gmock-actions_test.cc
@@ -795,7 +795,7 @@ TEST(DoDefaultDeathTest, DiesIfUsedInCompositeAction) {
 }
 
 // Tests that DoDefault() returns the default value set by
-// DefaultValue<T>::Set() when it's not overriden by an ON_CALL().
+// DefaultValue<T>::Set() when it's not overridden by an ON_CALL().
 TEST(DoDefaultTest, ReturnsUserSpecifiedPerTypeDefaultValueWhenThereIsOne) {
   DefaultValue<int>::Set(1);
   MockClass mock;

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -673,7 +673,7 @@ class GTEST_API_ TestResult {
 
   // Protects mutable state of the property vector and of owned
   // properties, whose values may be updated.
-  internal::Mutex test_properites_mutex_;
+  internal::Mutex test_properties_mutex_;
 
   // The vector of TestPartResults
   std::vector<TestPartResult> test_part_results_;

--- a/googletest/include/gtest/internal/gtest-filepath.h
+++ b/googletest/include/gtest/internal/gtest-filepath.h
@@ -195,7 +195,7 @@ class GTEST_API_ FilePath {
 
   void Normalize();
 
-  // Returns a pointer to the last occurence of a valid path separator in
+  // Returns a pointer to the last occurrence of a valid path separator in
   // the FilePath. On Windows, for example, both '/' and '\' are valid path
   // separators. Returns NULL if no path separator was found.
   const char* FindLastPathSeparator() const;

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1495,7 +1495,7 @@ class NeverThrown {
 
 // Implements Boolean test assertions such as EXPECT_TRUE. expression can be
 // either a boolean expression or an AssertionResult. text is a textual
-// represenation of expression as it was passed into the EXPECT_TRUE.
+// representation of expression as it was passed into the EXPECT_TRUE.
 #define GTEST_TEST_BOOLEAN_(expression, text, actual, expected, fail) \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
   if (const ::testing::AssertionResult gtest_ar_ = \

--- a/googletest/scripts/release_docs.py
+++ b/googletest/scripts/release_docs.py
@@ -37,7 +37,7 @@ SYNOPSIS
        interlinked wiki files.  When we release a new version of
        Google Test or Google Mock, we need to branch the wiki files
        such that users of a specific version of Google Test/Mock can
-       look up documenation relevant for that version.  This script
+       look up documentation relevant for that version.  This script
        automates that process by:
 
          - branching the current wiki pages (which document the

--- a/googletest/src/gtest-death-test.cc
+++ b/googletest/src/gtest-death-test.cc
@@ -953,9 +953,9 @@ int FuchsiaDeathTest::Wait() {
 
   ReadAndInterpretStatusByte();
 
-  zx_info_process_v2_t buffer;
-  status_zx = child_process_.get_info(
-      ZX_INFO_PROCESS_V2, &buffer, sizeof(buffer), nullptr, nullptr);
+  zx_info_process_t buffer;
+  status_zx = child_process_.get_info(ZX_INFO_PROCESS, &buffer, sizeof(buffer),
+                                      nullptr, nullptr);
   GTEST_DEATH_TEST_CHECK_(status_zx == ZX_OK);
 
   GTEST_DEATH_TEST_CHECK_(buffer.flags & ZX_INFO_PROCESS_FLAG_EXITED);

--- a/googletest/src/gtest-death-test.cc
+++ b/googletest/src/gtest-death-test.cc
@@ -953,9 +953,9 @@ int FuchsiaDeathTest::Wait() {
 
   ReadAndInterpretStatusByte();
 
-  zx_info_process_t buffer;
-  status_zx = child_process_.get_info(ZX_INFO_PROCESS, &buffer, sizeof(buffer),
-                                      nullptr, nullptr);
+  zx_info_process_v2_t buffer;
+  status_zx = child_process_.get_info(
+      ZX_INFO_PROCESS_V2, &buffer, sizeof(buffer), nullptr, nullptr);
   GTEST_DEATH_TEST_CHECK_(status_zx == ZX_OK);
 
   GTEST_DEATH_TEST_CHECK_(buffer.flags & ZX_INFO_PROCESS_FLAG_EXITED);

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -1164,13 +1164,13 @@ class StreamingListener : public EmptyTestEventListener {
   }
 
   // Note that "event=TestCaseStart" is a wire format and has to remain
-  // "case" for compatibilty
+  // "case" for compatibility
   void OnTestCaseStart(const TestCase& test_case) override {
     SendLn(std::string("event=TestCaseStart&name=") + test_case.name());
   }
 
   // Note that "event=TestCaseEnd" is a wire format and has to remain
-  // "case" for compatibilty
+  // "case" for compatibility
   void OnTestCaseEnd(const TestCase& test_case) override {
     SendLn("event=TestCaseEnd&passed=" + FormatBool(test_case.Passed()) +
            "&elapsed_time=" + StreamableToString(test_case.elapsed_time()) +

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -2241,7 +2241,7 @@ void TestResult::RecordProperty(const std::string& xml_element,
   if (!ValidateTestProperty(xml_element, test_property)) {
     return;
   }
-  internal::MutexLock lock(&test_properites_mutex_);
+  internal::MutexLock lock(&test_properties_mutex_);
   const std::vector<TestProperty>::iterator property_with_matching_key =
       std::find_if(test_properties_.begin(), test_properties_.end(),
                    internal::TestPropertyKeyIs(test_property.key()));

--- a/googletest/test/googletest-output-test_.cc
+++ b/googletest/test/googletest-output-test_.cc
@@ -1029,7 +1029,7 @@ auto dynamic_test = (
         "BadDynamicFixture1", "TestBase", nullptr, nullptr, __FILE__, __LINE__,
         []() -> testing::Test* { return new DynamicTest<true>; }),
 
-    // Register two tests with the same fixture incorrectly by ommiting the
+    // Register two tests with the same fixture incorrectly by omitting the
     // return type.
     testing::RegisterTest(
         "BadDynamicFixture2", "FixtureBase", nullptr, nullptr, __FILE__,

--- a/googletest/test/googletest-param-test-test.cc
+++ b/googletest/test/googletest-param-test-test.cc
@@ -835,14 +835,14 @@ TEST(MacroNameing, LookupNames) {
     }
   }
 
-  // Check that the expected form of the test suit name actualy exists.
+  // Check that the expected form of the test suit name actually exists.
   EXPECT_NE(  //
       know_suite_names.find("FortyTwo/MacroNamingTest"),
       know_suite_names.end());
   EXPECT_NE(
       know_suite_names.find("MacroNamingTestNonParametrized"),
       know_suite_names.end());
-  // Check that the expected form of the test name actualy exists.
+  // Check that the expected form of the test name actually exists.
   EXPECT_NE(  //
       know_test_names.find("FortyTwo/MacroNamingTest.FooSomeTestName/0"),
       know_test_names.end());

--- a/googletest/test/googletest-printers-test.cc
+++ b/googletest/test/googletest-printers-test.cc
@@ -201,7 +201,7 @@ OutputStream& operator<<(OutputStream& os,
   return os;
 }
 
-// A user-defined streamable but recursivly-defined container type in
+// A user-defined streamable but recursively-defined container type in
 // a user namespace, it mimics therefore std::filesystem::path or
 // boost::filesystem::path.
 class PathLike {


### PR DESCRIPTION
Export Test - Do Not Merge


Merge 050b51751840837e9da6dad684c5ae0f87ab1f60 into 831bc03504b0946929bb05dcb323e3b2dc3d2bd5

Closes #3364

COPYBARA_INTEGRATE_REVIEW=https://github.com/google/googletest/pull/3364 from jbampton:fix-spelling 050b51751840837e9da6dad684c5ae0f87ab1f60
