### PR TITLE
isalnum -> IsAlNum for correct handling of signed chars

### DIFF
--- a/googletest/include/gtest/internal/gtest-param-util.h
+++ b/googletest/include/gtest/internal/gtest-param-util.h
@@ -654,7 +654,7 @@ class ParameterizedTestSuiteInfo : public ParameterizedTestSuiteInfoBase {
 
     // Check for invalid characters
     for (std::string::size_type index = 0; index < name.size(); ++index) {
-      if (!isalnum(name[index]) && name[index] != '_')
+      if (!IsAlNum(name[index]) && name[index] != '_')
         return false;
     }
 


### PR DESCRIPTION
I spotted this in https://github.com/assimp/assimp/pull/3880/commits/7dd7a053a91322fad88cdf958c6d0b3b7b91cb90 and figured I'd fix it here, too. 

If this is not the right thing to do, please lmk so I can undo it in assimp, too. Seems right, though. It's the only spot in gtest where a ctype call was made directly.