### PR TITLE
gtest-port.h - ifndef for disabling stream results

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -628,7 +628,9 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 // Determines whether test results can be streamed to a socket.
 #if GTEST_OS_LINUX || GTEST_OS_GNU_KFREEBSD || GTEST_OS_DRAGONFLY || \
     GTEST_OS_FREEBSD || GTEST_OS_NETBSD || GTEST_OS_OPENBSD
-# define GTEST_CAN_STREAM_RESULTS_ 1
+# ifndef GTEST_CAN_STREAM_RESULTS_
+#  define GTEST_CAN_STREAM_RESULTS_ 1
+# endif
 #endif
 
 // Defines some utility macros.


### PR DESCRIPTION
commit description:

```
only define GTEST_CAN_STREAM_RESULTS_ if not defined
Non GCC compilers can have issues with this (eg pgcc)
such errors may include:

/usr/include/x86_64-linux-gnu/bits/socket.h", line 282: error: incomplete type is not allowed
      __extension__ unsigned char __cmsg_data __flexarr; /* Ancillary data.  */
```

issue: https://github.com/google/googletest/issues/3390