### PR TITLE
Fixed typo in gmock-spec-builder.h

### DIFF
--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -890,7 +890,7 @@ class GTEST_API_ ExpectationBase {
   mutable Mutex mutex_;  // Protects action_count_checked_.
 };  // class ExpectationBase
 
-// Impements an expectation for the given function type.
+// Implements an expectation for the given function type.
 template <typename F>
 class TypedExpectation : public ExpectationBase {
  public:


### PR DESCRIPTION
I just found a little typo in comment section.