### PR TITLE
Make a matcher ElementsAreArray applicable for std ranges

### DIFF
--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -3527,8 +3527,8 @@ inline internal::ElementsAreArrayMatcher<T> ElementsAreArray(
 }
 
 template <typename Container>
-inline internal::ElementsAreArrayMatcher<typename Container::value_type>
-ElementsAreArray(const Container& container) {
+inline auto ElementsAreArray(const Container& container)
+    -> decltype(ElementsAreArray(container.begin(), container.end())) {
   return ElementsAreArray(container.begin(), container.end());
 }
 


### PR DESCRIPTION
Hi!
I propose to make a matcher ElementsAreArray applicable for std ranges.
It is small changes in the code but it allow to make assertions of containers easy.
Compilers gcc 5.0, clang 5.0, MSVC 2015 support 'auto' so you don't need to enhance requirements for compilers. And users with modern compillers can use modern features.