### PR TITLE
cleanup: fix msan warnings with Clang 12

### DIFF
--- a/googletest/src/gtest-filepath.cc
+++ b/googletest/src/gtest-filepath.cc
@@ -210,7 +210,7 @@ bool FilePath::FileOrDirectoryExists() const {
   delete [] unicode;
   return attributes != kInvalidFileAttributes;
 #else
-  posix::StatStruct file_stat;
+  posix::StatStruct file_stat{};
   return posix::Stat(pathname_.c_str(), &file_stat) == 0;
 #endif  // GTEST_OS_WINDOWS_MOBILE
 }
@@ -237,7 +237,7 @@ bool FilePath::DirectoryExists() const {
     result = true;
   }
 #else
-  posix::StatStruct file_stat;
+  posix::StatStruct file_stat{};
   result = posix::Stat(path.c_str(), &file_stat) == 0 &&
       posix::IsDir(file_stat);
 #endif  // GTEST_OS_WINDOWS_MOBILE


### PR DESCRIPTION
Without these changes the MemorySanitizer fails with:

```
==12==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x7f1fcdff145b in testing::internal::FilePath::CreateDirectoriesRecursively() const /proc/self/cwd/external/com_google_googletest/googletest/src/gtest-filepath.cc:306:7
    #1 0x7f1fce03b8c1 in testing::internal::OpenFileForWriting(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:190:18
    #2 0x7f1fce03b5e2 in testing::internal::XmlUnitTestResultPrinter::OnTestIterationEnd(testing::UnitTest const&, int) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:3608:18
    #3 0x7f1fce03b2ca in testing::internal::TestEventRepeater::OnTestIterationEnd(testing::UnitTest const&, int) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:3507:26
    #4 0x7f1fce04d957 in testing::internal::UnitTestImpl::RunAllTests() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:5352:15

```
