### PR TITLE
Fix EXPECT_DEATH() and ASSERT_DEATH() triggering -Wcovered-switch-default

### DIFF
--- a/googletest/include/gtest/internal/gtest-death-test-internal.h
+++ b/googletest/include/gtest/internal/gtest-death-test-internal.h
@@ -236,8 +236,6 @@ inline Matcher<const ::std::string&> MakeDeathTestMatcher(
           gtest_dt->Abort(::testing::internal::DeathTest::TEST_DID_NOT_DIE);   \
           break;                                                               \
         }                                                                      \
-        default:                                                               \
-          break;                                                               \
       }                                                                        \
     }                                                                          \
   } else                                                                       \


### PR DESCRIPTION
EXPECT_DEATH() and ASSERT_DEATH() have a switch case where every
possible case is covered. This makes the default case unnecessary
and triggers -Wcovered-switch-default.
Due to these being macros, the lines are expanded in user code and
are thus subject to warnings of the target codebase.

Fixes #3456