### PR TITLE
Don't link pthread on QNX

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -39,6 +39,11 @@ licenses(["notice"])
 exports_files(["LICENSE"])
 
 config_setting(
+    name = "qnx",
+    constraint_values = ["@platforms//os:qnx"],
+)
+
+config_setting(
     name = "windows",
     constraint_values = ["@platforms//os:windows"],
 )
@@ -86,6 +91,7 @@ cc_library(
         "googlemock/include/gmock/*.h",
     ]),
     copts = select({
+        ":qnx": [],
         ":windows": [],
         "//conditions:default": ["-pthread"],
     }),
@@ -104,6 +110,7 @@ cc_library(
         "googletest/include",
     ],
     linkopts = select({
+        ":qnx": [],
         ":windows": [],
         "//conditions:default": ["-pthread"],
     }),

--- a/googlemock/test/BUILD.bazel
+++ b/googlemock/test/BUILD.bazel
@@ -41,6 +41,7 @@ cc_test(
     size = "small",
     srcs = glob(include = ["gmock-*.cc"]),
     linkopts = select({
+        "//:qnx": [],
         "//:windows": [],
         "//conditions:default": ["-pthread"],
     }),

--- a/googletest/test/BUILD.bazel
+++ b/googletest/test/BUILD.bazel
@@ -95,6 +95,7 @@ cc_test(
         "googletest/test",
     ],
     linkopts = select({
+        "//:qnx": [],
         "//:windows": [],
         "//conditions:default": ["-pthread"],
     }),


### PR DESCRIPTION
On QNX, pthread is part of libc. There's no separate pthread library to link. See section "Library" in the [`pthread_create()`](https://www.qnx.com/developers/docs/7.1/index.html#com.qnx.doc.neutrino.lib_ref/topic/p/pthread_create.html) reference manual of QNX.

Resolves https://github.com/google/googletest/issues/3464