### PR TITLE
Use GTEST_DONT_DEFINE_TEST_F to guard TEST_F

### DIFF
--- a/googletest/README.md
+++ b/googletest/README.md
@@ -203,7 +203,9 @@ add
     -DGTEST_DONT_DEFINE_FOO=1
 
 to the compiler flags to tell GoogleTest to change the macro's name from `FOO`
-to `GTEST_FOO`. Currently `FOO` can be `FAIL`, `SUCCEED`, or `TEST`. For
+to `GTEST_FOO`. Currently `FOO` can be `ASSERT_EQ`, `ASSERT_FALSE`, `ASSERT_GE`,
+`ASSERT_GT`, `ASSERT_LE`, `ASSERT_LT`, `ASSERT_NE`, `ASSERT_TRUE`,
+`EXPECT_FALSE`, `EXPECT_TRUE`, `FAIL`, `SUCCEED`, `TEST`, or `TEST_F`. For
 example, with `-DGTEST_DONT_DEFINE_TEST=1`, you'll need to write
 
     GTEST_TEST(SomeTest, DoesThis) { ... }

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -2379,12 +2379,13 @@ constexpr bool StaticAssertTypeEq() noexcept {
 //     EXPECT_EQ(b_.size(), 1);
 //   }
 //
-// GOOGLETEST_CM0011 DO NOT DELETE
-#if !GTEST_DONT_DEFINE_TEST
-#define TEST_F(test_fixture, test_name)\
+#define GTEST_TEST_F(test_fixture, test_name)\
   GTEST_TEST_(test_fixture, test_name, test_fixture, \
               ::testing::internal::GetTypeId<test_fixture>())
-#endif  // !GTEST_DONT_DEFINE_TEST
+// GOOGLETEST_CM0011 DO NOT DELETE
+#if !GTEST_DONT_DEFINE_TEST_F
+#define TEST_F(test_fixture, test_name) GTEST_TEST_F(test_fixture, test_name)
+#endif
 
 // Returns a path to temporary directory.
 // Tries to determine an appropriate directory for the platform.

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -2379,10 +2379,10 @@ constexpr bool StaticAssertTypeEq() noexcept {
 //     EXPECT_EQ(b_.size(), 1);
 //   }
 //
+// GOOGLETEST_CM0011 DO NOT DELETE
 #define GTEST_TEST_F(test_fixture, test_name)\
   GTEST_TEST_(test_fixture, test_name, test_fixture, \
               ::testing::internal::GetTypeId<test_fixture>())
-// GOOGLETEST_CM0011 DO NOT DELETE
 #if !GTEST_DONT_DEFINE_TEST_F
 #define TEST_F(test_fixture, test_name) GTEST_TEST_F(test_fixture, test_name)
 #endif


### PR DESCRIPTION
The [documentation](https://github.com/google/googletest/blob/release-1.11.0/googletest/README.md#avoiding-macro-name-clashes) is clear that the FOO we'll be guarding always matches
the spelling of the DONT macro.  A single guard macro should not toggle
more than one implementation macro.

This fixes a regression in 7413280c52c1f759395572a384165023d24eeb57.

Relatedly, improve the documentation of the DONT macros to bring the
list of valid FOO values up to date.