### PR TITLE
Fix redundant redeclaration of ‘constexpr’ static data member

### DIFF
--- a/googlemock/include/gmock/internal/gmock-internal-utils.h
+++ b/googlemock/include/gmock/internal/gmock-internal-utils.h
@@ -446,8 +446,10 @@ struct Function<R(Args...)> {
   using MakeResultIgnoredValue = IgnoredValue(Args...);
 };
 
+#if __cplusplus <= 201703L
 template <typename R, typename... Args>
 constexpr size_t Function<R(Args...)>::ArgumentCount;
+#endif
 
 #ifdef _MSC_VER
 # pragma warning(pop)


### PR DESCRIPTION
Fix issue 3476
‘testing::internal::Function<R(Args ...)>::ArgumentCount'
Issue happening at least with gcc 11.1.1a and -std=gnu++20
include/gmock/internal/gmock-internal-utils.h:504:18: error: redundant redeclaration of ‘constexpr’ static data member ‘testing::internal::Function<R(Args ...)>::ArgumentCount’ [-Werror=deprecated]
  504 | constexpr size_t Function<R(Args...)>::ArgumentCount;
      |                  ^~~~~~~~~~~~~~~~~~~~
/data/mwrep/res/osp/Gmock/21-0-0-0/include/gmock/internal/gmock-internal-utils.h:493:27: note: previous declaration of ‘testing::internal::Function<R(Args ...)>::ArgumentCount’
  493 |   static constexpr size_t ArgumentCount = sizeof...(Args);
https://github.com/google/googletest/issues/3476