### PR TITLE
Link -lregex on QNX

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -110,7 +110,7 @@ cc_library(
         "googletest/include",
     ],
     linkopts = select({
-        ":qnx": [],
+        ":qnx": ["-lregex"],
         ":windows": [],
         "//conditions:default": ["-pthread"],
     }),


### PR DESCRIPTION
According to the 2nd point on [1], `-lregex` is required on QNX. This is a follow-up PR for https://github.com/google/googletest/pull/3465.

[1] https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.ide.userguide/topic/writing_test_programs.html

Relates to https://github.com/google/googletest/pull/3484