### PR TITLE
fix pedantic build by removing extra semicolons

### DIFF
--- a/googletest/include/gtest/gtest-death-test.h
+++ b/googletest/include/gtest/gtest-death-test.h
@@ -45,7 +45,7 @@
 // from the start, running only a single death test, or "fast",
 // meaning that the child process will execute the test logic immediately
 // after forking.
-GTEST_DECLARE_string_(death_test_style);
+GTEST_DECLARE_string_(death_test_style)
 
 namespace testing {
 

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -76,86 +76,86 @@ GTEST_DISABLE_MSC_WARNINGS_PUSH_(4251 \
 // Declares the flags.
 
 // This flag temporary enables the disabled tests.
-GTEST_DECLARE_bool_(also_run_disabled_tests);
+GTEST_DECLARE_bool_(also_run_disabled_tests)
 
 // This flag brings the debugger on an assertion failure.
-GTEST_DECLARE_bool_(break_on_failure);
+GTEST_DECLARE_bool_(break_on_failure)
 
 // This flag controls whether Google Test catches all test-thrown exceptions
 // and logs them as failures.
-GTEST_DECLARE_bool_(catch_exceptions);
+GTEST_DECLARE_bool_(catch_exceptions)
 
 // This flag enables using colors in terminal output. Available values are
 // "yes" to enable colors, "no" (disable colors), or "auto" (the default)
 // to let Google Test decide.
-GTEST_DECLARE_string_(color);
+GTEST_DECLARE_string_(color)
 
 // This flag controls whether the test runner should continue execution past
 // first failure.
-GTEST_DECLARE_bool_(fail_fast);
+GTEST_DECLARE_bool_(fail_fast)
 
 // This flag sets up the filter to select by name using a glob pattern
 // the tests to run. If the filter is not given all tests are executed.
-GTEST_DECLARE_string_(filter);
+GTEST_DECLARE_string_(filter)
 
 // This flag controls whether Google Test installs a signal handler that dumps
 // debugging information when fatal signals are raised.
-GTEST_DECLARE_bool_(install_failure_signal_handler);
+GTEST_DECLARE_bool_(install_failure_signal_handler)
 
 // This flag causes the Google Test to list tests. None of the tests listed
 // are actually run if the flag is provided.
-GTEST_DECLARE_bool_(list_tests);
+GTEST_DECLARE_bool_(list_tests)
 
 // This flag controls whether Google Test emits a detailed XML report to a file
 // in addition to its normal textual output.
-GTEST_DECLARE_string_(output);
+GTEST_DECLARE_string_(output)
 
 // This flags control whether Google Test prints only test failures.
-GTEST_DECLARE_bool_(brief);
+GTEST_DECLARE_bool_(brief)
 
 // This flags control whether Google Test prints the elapsed time for each
 // test.
-GTEST_DECLARE_bool_(print_time);
+GTEST_DECLARE_bool_(print_time)
 
 // This flags control whether Google Test prints UTF8 characters as text.
-GTEST_DECLARE_bool_(print_utf8);
+GTEST_DECLARE_bool_(print_utf8)
 
 // This flag specifies the random number seed.
-GTEST_DECLARE_int32_(random_seed);
+GTEST_DECLARE_int32_(random_seed)
 
 // This flag sets how many times the tests are repeated. The default value
 // is 1. If the value is -1 the tests are repeating forever.
-GTEST_DECLARE_int32_(repeat);
+GTEST_DECLARE_int32_(repeat)
 
 // This flag controls whether Google Test Environments are recreated for each
 // repeat of the tests. The default value is true. If set to false the global
 // test Environment objects are only set up once, for the first iteration, and
 // only torn down once, for the last.
-GTEST_DECLARE_bool_(recreate_environments_when_repeating);
+GTEST_DECLARE_bool_(recreate_environments_when_repeating)
 
 // This flag controls whether Google Test includes Google Test internal
 // stack frames in failure stack traces.
-GTEST_DECLARE_bool_(show_internal_stack_frames);
+GTEST_DECLARE_bool_(show_internal_stack_frames)
 
 // When this flag is specified, tests' order is randomized on every iteration.
-GTEST_DECLARE_bool_(shuffle);
+GTEST_DECLARE_bool_(shuffle)
 
 // This flag specifies the maximum number of stack frames to be
 // printed in a failure message.
-GTEST_DECLARE_int32_(stack_trace_depth);
+GTEST_DECLARE_int32_(stack_trace_depth)
 
 // When this flag is specified, a failed assertion will throw an
 // exception if exceptions are enabled, or exit the program with a
 // non-zero code otherwise. For use with an external test framework.
-GTEST_DECLARE_bool_(throw_on_failure);
+GTEST_DECLARE_bool_(throw_on_failure)
 
 // When this flag is set with a "host:port" string, on supported
 // platforms test results are streamed to the specified port on
 // the specified host machine.
-GTEST_DECLARE_string_(stream_result_to);
+GTEST_DECLARE_string_(stream_result_to)
 
 #if GTEST_USE_OWN_FLAGFILE_FLAG_
-GTEST_DECLARE_string_(flagfile);
+GTEST_DECLARE_string_(flagfile)
 #endif  // GTEST_USE_OWN_FLAGFILE_FLAG_
 
 namespace testing {

--- a/googletest/include/gtest/internal/gtest-death-test-internal.h
+++ b/googletest/include/gtest/internal/gtest-death-test-internal.h
@@ -42,7 +42,7 @@
 #include <stdio.h>
 #include <memory>
 
-GTEST_DECLARE_string_(internal_run_death_test);
+GTEST_DECLARE_string_(internal_run_death_test)
 
 namespace testing {
 namespace internal {

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -69,7 +69,7 @@ GTEST_DISABLE_MSC_WARNINGS_PUSH_(4251 \
 // We don't want the users to modify this flag in the code, but want
 // Google Test's own unit tests to be able to access it. Therefore we
 // declare it here as opposed to in gtest.h.
-GTEST_DECLARE_bool_(death_test_use_fork);
+GTEST_DECLARE_bool_(death_test_use_fork)
 
 namespace testing {
 namespace internal {


### PR DESCRIPTION
when the flag declarations were put into the `testing` namespace, the
existing callsites should have been updated to remove the extra semi-
colon. this patch does that.

fixes #3491