### PR TITLE
Remove bazelbuild/rules_cc dependency

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -30,8 +30,6 @@
 #
 #   Bazel Build for Google C++ Testing Framework(Google Test)
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
-
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,13 +10,6 @@ http_archive(
 )
 
 http_archive(
-    name = "rules_cc",
-    sha256 = "1e19e9a3bc3d4ee91d7fcad00653485ee6c798efbbf9588d40b34cbfbded143d",
-    strip_prefix = "rules_cc-68cb652a71e7e7e2858c50593e5a9e3b94e5b9a9",
-    urls = ["https://github.com/bazelbuild/rules_cc/archive/68cb652a71e7e7e2858c50593e5a9e3b94e5b9a9.zip"],  # 2021-05-14T14:51:14Z
-)
-
-http_archive(
     name = "rules_python",
     sha256 = "98b3c592faea9636ac8444bfd9de7f3fb4c60590932d6e6ac5946e3f8dbd5ff6",
     strip_prefix = "rules_python-ed6cc8f2c3692a6a7f013ff8bc185ba77eb9b4d2",

--- a/docs/quickstart-bazel.md
+++ b/docs/quickstart-bazel.md
@@ -62,18 +62,6 @@ as a ZIP archive from GitHub. In the above example,
 GoogleTest version to use; we recommend updating the hash often to point to the
 latest version.
 
-Bazel also needs a dependency on the
-[`rules_cc` repository](https://github.com/bazelbuild/rules_cc) to build C++
-code, so add the following to the `WORKSPACE` file:
-
-```
-http_archive(
-  name = "rules_cc",
-  urls = ["https://github.com/bazelbuild/rules_cc/archive/40548a2974f1aea06215272d9c2b47a14a24e556.zip"],
-  strip_prefix = "rules_cc-40548a2974f1aea06215272d9c2b47a14a24e556",
-)
-```
-
 Now you're ready to build C++ code that uses GoogleTest.
 
 ## Create and run a binary
@@ -104,8 +92,6 @@ To build the code, create a file named `BUILD` in the same directory with the
 following contents:
 
 ```
-load("@rules_cc//cc:defs.bzl", "cc_test")
-
 cc_test(
   name = "hello_test",
   size = "small",

--- a/googlemock/test/BUILD.bazel
+++ b/googlemock/test/BUILD.bazel
@@ -30,7 +30,6 @@
 #
 #   Bazel Build for Google C++ Testing Framework(Google Test)-googlemock
 
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 licenses(["notice"])

--- a/googletest/test/BUILD.bazel
+++ b/googletest/test/BUILD.bazel
@@ -30,7 +30,6 @@
 #
 # Bazel BUILD for The Google C++ Testing Framework (Google Test)
 
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_test")
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 licenses(["notice"])


### PR DESCRIPTION
bazelbuild/rules_cc was put on hold
It seems the recommended way is now to use native cc rules

More info [here](https://github.com/bazelbuild/rules_go/pull/2950)