### PR TITLE
Start a simple github actions CI

### DIFF
--- a/.github/workflows/gtest-ci.yml
+++ b/.github/workflows/gtest-ci.yml
@@ -1,0 +1,40 @@
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  Linux:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Tests
+      run: bazel test --test_output=errors //...
+
+  MacOs:
+    runs-on: macos-latest
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Tests
+      run: bazel test --test_output=errors //...
+
+
+  Windows:
+    runs-on: windows-latest
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Tests
+      run: bazel test --test_output=errors //...


### PR DESCRIPTION
Running on major platforms.

I'd like to contribute a starting point for a CI that can run on pushes and pull requests, which is in particular useful to make sure that things continue working on all platforms.

Note, the Windows run actually fails right now and it looks like it might actually be worthwhile looking into that. One test looks like a CR to CRLF mismatch. And there is some death test message that doesn't fit. I'll leave that to the googletest team to work out.