### PR TITLE
pkg-config: fix gtest.pc/gmock.pc library names for the debug build

### DIFF
--- a/googlemock/cmake/gmock.pc.in
+++ b/googlemock/cmake/gmock.pc.in
@@ -6,5 +6,5 @@ Description: GoogleMock (without main() function)
 Version: @PROJECT_VERSION@
 URL: https://github.com/google/googletest
 Requires: gtest = @PROJECT_VERSION@
-Libs: -L${libdir} -lgmock @CMAKE_THREAD_LIBS_INIT@
+Libs: -L${libdir} -lgmock@DEBUG_POSTFIX@ @CMAKE_THREAD_LIBS_INIT@
 Cflags: -I${includedir} @GTEST_HAS_PTHREAD_MACRO@

--- a/googletest/cmake/gtest.pc.in
+++ b/googletest/cmake/gtest.pc.in
@@ -5,5 +5,5 @@ Name: gtest
 Description: GoogleTest (without main() function)
 Version: @PROJECT_VERSION@
 URL: https://github.com/google/googletest
-Libs: -L${libdir} -lgtest @CMAKE_THREAD_LIBS_INIT@
+Libs: -L${libdir} -lgtest@DEBUG_POSTFIX@ @CMAKE_THREAD_LIBS_INIT@
 Cflags: -I${includedir} @GTEST_HAS_PTHREAD_MACRO@

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -335,6 +335,9 @@ function(install_project)
     # Configure and install pkgconfig files.
     foreach(t ${ARGN})
       set(configured_pc "${generated_dir}/${t}.pc")
+      if(CMAKE_BUILD_TYPE MATCHES Debug)
+        set(DEBUG_POSTFIX "d")
+      endif()
       configure_file("${PROJECT_SOURCE_DIR}/cmake/${t}.pc.in"
         "${configured_pc}" @ONLY)
       install(FILES "${configured_pc}"


### PR DESCRIPTION
In case CMAKE_BUILD_TYPE is set to Debug the gtest library is
name libgtestd.a but the link command returned from gtest.pc is
'-lgtest' (without the debug d) and so the linking of dependent
packages fails (see [1] for a buildroot failure example).

Enhance the gtest.pc ang gmock.pc generation to honour the debug 'd'.

[1] http://lists.busybox.net/pipermail/buildroot/2021-October/626382.html

Signed-off-by: Peter Seiderer <ps.report@gmx.net>