### PR TITLE
Do not include char with negative value in invalid XML characters

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -3929,7 +3929,7 @@ class XmlUnitTestResultPrinter : public EmptyTestEventListener {
 
   // May c appear in a well-formed XML document?
   static bool IsValidXmlCharacter(char c) {
-    return IsNormalizableWhitespace(c) || c >= 0x20;
+    return IsNormalizableWhitespace(c) || !((0x00 <= c) && (c < 0x20));
   }
 
   // Returns an XML-escaped copy of the input string str.  If


### PR DESCRIPTION
When `char` is `signed`, depending on compiler implementation, some non-ASCII characters are treated as invalid (e.g. alpha α = 0xCE = 206 = -50)

cf.
* When `char` is `signed` https://wandbox.org/permlink/Lq0kDiowEPZYqXv2
* When `char` is `unsigned` https://wandbox.org/permlink/hu2G0X9ld2YW2Ajd
* https://en.cppreference.com/w/c/language/arithmetic_types#Character_types

Related issue
* #1931
* #2932
