### PR TITLE
Fix memory leak false alarm from windows CRT

### DIFF
--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -574,6 +574,9 @@ class ThreadLocalRegistryImpl {
     // defer the destruction of the ThreadLocalValueHolderBases.
     {
       MutexLock lock(&mutex_);
+#ifdef _MSC_VER
+      MemoryIsNotDeallocated memory_is_not_deallocated;
+#endif  // _MSC_VER        
       ThreadIdToThreadLocals* const thread_to_thread_locals =
           GetThreadLocalsMapLocked();
       for (ThreadIdToThreadLocals::iterator it =


### PR DESCRIPTION
The thread_to_thread_locals allocated from GetThreadLocalsMapLocked() function will be immortal, however windows CRT will report it as memory leak.
Propose this change to fix the false alarm from windows CRT.