### PR TITLE
Re #3637 Show Disabled Tests in testing output

### DIFF
--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1123,6 +1123,9 @@ class TestEventListener {
   // Fired before the test starts.
   virtual void OnTestStart(const TestInfo& test_info) = 0;
 
+  // Fired when skipping a test
+  virtual void OnTestSkipped(const TestInfo& test_info) = 0;
+
   // Fired after a failed assertion or a SUCCEED() invocation.
   // If you want to throw an exception from this function to skip to the next
   // TEST, it must be AssertionException defined above, or inherited from it.
@@ -1172,6 +1175,7 @@ class EmptyTestEventListener : public TestEventListener {
 #endif  //  GTEST_REMOVE_LEGACY_TEST_CASEAPI_
 
   void OnTestStart(const TestInfo& /*test_info*/) override {}
+  void OnTestSkipped(const TestInfo& /*test_info*/) override {}
   void OnTestPartResult(const TestPartResult& /*test_part_result*/) override {}
   void OnTestEnd(const TestInfo& /*test_info*/) override {}
   void OnTestSuiteEnd(const TestSuite& /*test_suite*/) override {}


### PR DESCRIPTION
A new flag is herein created, --gtest_print_disabled_test_names,
whose default value is false (so that by default, the behaviour
will not change).

The functionality is implemented by a new member function on the
TestEventListener interface (which is responsible for printing
testing output) which is called when a disabled test is encountered.

The PrettyUnitTestResultPrinter has the canonical implementation of this
added function. The BriefUnitTestResultPrinter and the
EmptyTestEventListener get a nullary implementation. The
JsonUnitTestResultPrinter and XmlUnitTestResultPrinter
inherit that trivial implementation from the EmptyTestEventListener.