### PR TITLE
EXPECT_EXIT_IF_SUPPORTED/ASSERT_EXIT_IF_SUPPORTED

### DIFF
--- a/googletest/include/gtest/gtest-death-test.h
+++ b/googletest/include/gtest/gtest-death-test.h
@@ -331,10 +331,18 @@ class GTEST_API_ KilledBySignal {
     EXPECT_DEATH(statement, regex)
 # define ASSERT_DEATH_IF_SUPPORTED(statement, regex) \
     ASSERT_DEATH(statement, regex)
+# define EXPECT_EXIT_IF_SUPPORTED(statement, predicate, regex) \
+    EXPECT_EXIT(statement, predicate, regex)
+# define ASSERT_EXIT_IF_SUPPORTED(statement, predicate, regex) \
+    ASSERT_EXIT(statement, predicate, regex)
 #else
 # define EXPECT_DEATH_IF_SUPPORTED(statement, regex) \
     GTEST_UNSUPPORTED_DEATH_TEST(statement, regex, )
 # define ASSERT_DEATH_IF_SUPPORTED(statement, regex) \
+    GTEST_UNSUPPORTED_DEATH_TEST(statement, regex, return)
+# define EXPECT_EXIT_IF_SUPPORTED(statement, predicate, regex) \
+    GTEST_UNSUPPORTED_DEATH_TEST(statement, regex, )
+# define ASSERT_EXIT_IF_SUPPORTED(statement, predicate, regex) \
     GTEST_UNSUPPORTED_DEATH_TEST(statement, regex, return)
 #endif
 


### PR DESCRIPTION
Currently I'm missing `*_DEATH_IF_SUPPORTED` equivalents for `*_EXIT` macros. It would be very helpful for codebases used in multiple platforms. In my case the test is failing to build, because iOS has no definition of `EXPECT_EXIT` an its predicate.
It's only a minimal change to get information if it's worth to continue working on this change?

What's missing:
- documentation update
- moving type declaration of the predicate types
- extend `GTEST_UNSUPPORTED_DEATH_TEST` to verify predicate correctness in a similar way it's done for statement and regex.