### PR TITLE
Applied C++ Core Guidelines Enum.2 Rule. Problem: switch statements s…

### DIFF
--- a/googlemock/src/gmock-spec-builders.cc
+++ b/googlemock/src/gmock-spec-builders.cc
@@ -300,6 +300,8 @@ void ReportUninterestingCall(CallReaction reaction, const std::string& msg) {
               "knowing-when-to-expect for details.\n",
           stack_frames_to_skip);
       break;
+    case kFail:
+      [[fallthrough]];
     default:  // FAIL
       Expect(false, nullptr, -1, msg);
   }

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -3254,6 +3254,8 @@ static const char* GetAnsiColorCode(GTestColor color) {
       return "2";
     case GTestColor::kYellow:
       return "3";
+    case GTestColor::kDefault:
+      [[fallthrough]];
     default:
       return nullptr;
   }
@@ -3502,6 +3504,12 @@ void PrettyUnitTestResultPrinter::OnTestPartResult(
     // If the test part succeeded, we don't need to do anything.
     case TestPartResult::kSuccess:
       return;
+    case TestPartResult::kNonFatalFailure:
+      [[fallthrough]];
+    case TestPartResult::kFatalFailure:
+      [[fallthrough]];
+    case TestPartResult::kSkip:
+      [[fallthrough]];
     default:
       // Print failure message from the assertion
       // (e.g. expected this and got that).
@@ -3719,6 +3727,12 @@ void BriefUnitTestResultPrinter::OnTestPartResult(
     // If the test part succeeded, we don't need to do anything.
     case TestPartResult::kSuccess:
       return;
+    case TestPartResult::kNonFatalFailure:
+      [[fallthrough]];
+    case TestPartResult::kFatalFailure:
+      [[fallthrough]];
+    case TestPartResult::kSkip:
+      [[fallthrough]];
     default:
       // Print failure message from the assertion
       // (e.g. expected this and got that).

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -146,6 +146,38 @@ TEST_F(StreamingListenerTest, OnTestPartResult) {
       *output());
 }
 
+TEST_F(StreamingListenerTest, OnTestPartResult) {
+  *output() = "";
+  streamer_.OnTestPartResult(TestPartResult(
+      TestPartResult::kNonFatalFailure, "foo.cc", 42, "failed=\n&%"));
+
+  // Meta characters in the failure message should be properly escaped.
+  EXPECT_EQ(
+      "event=TestPartResult&file=foo.cc&line=42&message=failed%3D%0A%26%25\n",
+      *output());
+}
+
+TEST_F(StreamingListenerTest, OnTestPartResult) {
+  *output() = "";
+  streamer_.OnTestPartResult(TestPartResult(
+      TestPartResult::kFatalFailure, "foo.cc", 42, "failed=\n&%"));
+
+  // Meta characters in the failure message should be properly escaped.
+  EXPECT_EQ(
+      "event=TestPartResult&file=foo.cc&line=42&message=failed%3D%0A%26%25\n",
+      *output());
+}
+
+TEST_F(StreamingListenerTest, OnTestPartResult) {
+  *output() = "";
+  streamer_.OnTestPartResult(TestPartResult(
+      TestPartResult::kSkip, "foo.cc", 42, "failed=\n&%"));
+
+  // Meta characters in the failure message should be properly escaped.
+  EXPECT_EQ(
+      "event=TestPartResult&file=foo.cc&line=42&message=failed%3D%0A%26%25\n",
+      *output());
+}
 #endif  // GTEST_CAN_STREAM_RESULTS_
 
 // Provides access to otherwise private parts of the TestEventListeners class


### PR DESCRIPTION
…hould cover all cases. Solution: Added missing enumerations in switch statements and added [[fallthrough]] attribute to denote that the default case is the desired case for these missing enumerations.

