### PR TITLE
Replace use of deprecated std::iterator

### DIFF
--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -5424,12 +5424,14 @@ class Streamlike {
   }
 
  private:
-  class ConstIter : public std::iterator<std::input_iterator_tag,
-                                         value_type,
-                                         ptrdiff_t,
-                                         const value_type*,
-                                         const value_type&> {
+  class ConstIter {
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = T;
+    using difference_type = ptrdiff_t;
+    using pointer = const value_type*;
+    using reference = const value_type&;
+
     ConstIter(const Streamlike* s,
               typename std::list<value_type>::iterator pos)
         : s_(s), pos_(pos) {}


### PR DESCRIPTION
This was deprecated by [P0174](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0174r2.html#2.1) in C++17.