### PR TITLE
googletest/src/gtest-port.cc: Added GetLastError() on Windows

### DIFF
--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -629,7 +629,8 @@ class ThreadLocalRegistryImpl {
         &ThreadLocalRegistryImpl::WatcherThreadFunc,
         reinterpret_cast<LPVOID>(new ThreadIdAndHandle(thread_id, thread)),
         CREATE_SUSPENDED, &watcher_thread_id);
-    GTEST_CHECK_(watcher_thread != nullptr);
+    GTEST_CHECK_(watcher_thread != nullptr)
+      << "CreateThread failed with error " << ::GetLastError() << ".";
     // Give the watcher thread the same priority as ours to avoid being
     // blocked by it.
     ::SetThreadPriority(watcher_thread,


### PR DESCRIPTION
Added GetLastError() on Windows for CreateThread().

This is in relation to #3629. It does not close the issue but may be very helpful to isolate problems. The change is minimal, and has been copied from another location in the same file, so it should be easy to review.

See for reference
https://github.com/google/googletest/blob/5a93ce124714287ab78c92da6db986be7fdb791c/googletest/src/gtest-port.cc#L460

Thanks for your consideration!