### PR TITLE
CMake add gtest_enable_pic option

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -79,29 +79,6 @@ else()
 
 endif()
 
-include(CheckCXXCompilerFlag)
-function(add_flag_or_print_warning flag name)
-  check_cxx_compiler_flag("-Werror ${flag}" "CXX_SUPPORTS_${name}")
-  if (CXX_SUPPORTS_${name})
-    message(STATUS "Building with ${flag}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}" PARENT_SCOPE)
-  else()
-    message(WARNING "${flag} is not supported.")
-  endif()
-endfunction()
-
-if (gtest_enable_pic)
-  if (XCODE)
-    # Xcode has -mdynamic-no-pic on by default, which overrides -fPIC. I don't
-    # know how to disable this, so just force gtest_enable_pic off for now.
-    message(WARNING "-fPIC not supported with Xcode.")
-  elseif(WIN32 OR CYGWIN)
-    # On Windows all code is PIC. MinGW warns if -fPIC is used.
-  else()
-    add_flag_or_print_warning("-fPIC" FPIC)
-  endif()
-endif()
-
 
 if (gtest_hide_internal_symbols)
   set(CMAKE_CXX_VISIBILITY_PRESET hidden)
@@ -164,6 +141,12 @@ if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
     "$<BUILD_INTERFACE:${gtest_build_include_dirs}>"
     "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
 endif()
+
+if (gtest_enable_pic)
+  set_target_properties(gtest PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  set_target_properties(gtest_main PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
+
 target_link_libraries(gtest_main PUBLIC gtest)
 
 ########################################################################

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -26,6 +26,8 @@ option(
   "Build gtest with internal symbols hidden in shared libraries."
   OFF)
 
+option(gtest_enable_pic "Build with -fPIC flag." OFF)
+
 # Defines pre_project_set_up_hermetic_build() and set_up_hermetic_build().
 include(cmake/hermetic_build.cmake OPTIONAL)
 
@@ -72,8 +74,32 @@ else()
     gtest_build_tests
     gtest_build_samples
     gtest_disable_pthreads
-    gtest_hide_internal_symbols)
+    gtest_hide_internal_symbols
+    gtest_enable_pic)
 
+endif()
+
+include(CheckCXXCompilerFlag)
+function(add_flag_or_print_warning flag name)
+  check_cxx_compiler_flag("-Werror ${flag}" "CXX_SUPPORTS_${name}")
+  if (CXX_SUPPORTS_${name})
+    message(STATUS "Building with ${flag}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}" PARENT_SCOPE)
+  else()
+    message(WARNING "${flag} is not supported.")
+  endif()
+endfunction()
+
+if (gtest_enable_pic)
+  if (XCODE)
+    # Xcode has -mdynamic-no-pic on by default, which overrides -fPIC. I don't
+    # know how to disable this, so just force gtest_enable_pic off for now.
+    message(WARNING "-fPIC not supported with Xcode.")
+  elseif(WIN32 OR CYGWIN)
+    # On Windows all code is PIC. MinGW warns if -fPIC is used.
+  else()
+    add_flag_or_print_warning("-fPIC" FPIC)
+  endif()
 endif()
 
 


### PR DESCRIPTION
Hi, googletest developers

This Pull Request add an CMake option `gtest_enable_pic`, which default to `OFF` thus keep same behaviour as before.

The purpose of this PR is to fix issue #854. The original author of #854 provide an global-affecting patch, this PR provide a better implementation, only affect specific targets, thus won't affect other targets.

A practical scenario is: on Ubuntu system, compile googletest with Clang, but compile & linking own project to googletest with GCC, which gives same error as #854 reported. If same scenario, people can then specify `-Dgtest_enable_pic=ON` when building with CMake. Hope this helps.