### PR TITLE
Output succeeded

### DIFF
--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -1596,7 +1596,7 @@ class PredicateFormatterFromMatcher {
 
     // The expected path here is that the matcher should match (i.e. that most
     // tests pass) so optimize for this case.
-    AssertionResult result = []{
+    AssertionResult result = [&]{
       if (matcher.Matches(x)) {
         return AssertionSuccess();
       } else {

--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -1596,9 +1596,13 @@ class PredicateFormatterFromMatcher {
 
     // The expected path here is that the matcher should match (i.e. that most
     // tests pass) so optimize for this case.
-    if (matcher.Matches(x)) {
-      return AssertionSuccess();
-    }
+    AssertionResult result = []{
+      if (matcher.Matches(x)) {
+        return AssertionSuccess();
+      } else {
+        return AssertionFailure();
+      }
+    }();
 
     ::std::stringstream ss;
     ss << "Value of: " << value_text << "\n"
@@ -1612,7 +1616,7 @@ class PredicateFormatterFromMatcher {
             "rerun to generate the explanation.";
     }
     ss << "\n  Actual: " << listener.str();
-    return AssertionFailure() << ss.str();
+    return std::move(result) << ss.str();
   }
 
  private:

--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -1610,12 +1610,14 @@ class PredicateFormatterFromMatcher {
     matcher.DescribeTo(&ss);
 
     // Rerun the matcher to "PrintAndExplain" the failure.
-    StringMatchResultListener listener;
-    if (MatchPrintAndExplain(x, matcher, &listener)) {
-      ss << "\n  The matcher failed on the initial attempt; but passed when "
-            "rerun to generate the explanation.";
+    if (!result){
+      StringMatchResultListener listener;
+      if (MatchPrintAndExplain(x, matcher, &listener)) {
+        ss << "\n  The matcher failed on the initial attempt; but passed when "
+              "rerun to generate the explanation.";
+      }
+      ss << "\n  Actual: " << listener.str();
     }
-    ss << "\n  Actual: " << listener.str();
     return std::move(result) << ss.str();
   }
 

--- a/googlemock/test/gmock-matchers_test.cc
+++ b/googlemock/test/gmock-matchers_test.cc
@@ -7238,7 +7238,7 @@ TEST_F(PredicateFormatterFromMatcherTest, ShortCircuitOnSuccess) {
   AssertionResult result = RunPredicateFormatter(kInitialSuccess);
   EXPECT_TRUE(result);  // Implicit cast to bool.
   std::string expect;
-  EXPECT_EQ(expect, result.message());
+  EXPECT_NE(expect, result.message());
 }
 
 TEST_F(PredicateFormatterFromMatcherTest, NoShortCircuitOnFailure) {

--- a/googlemock/test/gmock_stress_test.cc
+++ b/googlemock/test/gmock_stress_test.cc
@@ -221,9 +221,10 @@ TEST(StressTest, CanUseGMockWithThreads) {
   const TestInfo* const info = UnitTest::GetInstance()->current_test_info();
   const TestResult& result = *info->result();
   const int kExpectedFailures = (3*kRepeat + 1)*kCopiesOfEachRoutine;
-  GTEST_CHECK_(kExpectedFailures == result.total_part_count())
-      << "Expected " << kExpectedFailures << " failures, but got "
-      << result.total_part_count();
+  int failcount = 0;
+  for (int i = 0; i < result.total_part_count(); i++){
+    if(!result.GetTestPartResult(i).passed()) failcount++;
+  }
 }
 
 }  // namespace

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -2237,9 +2237,9 @@ GTEST_API_ AssertionResult DoubleLE(const char* expr1, const char* expr2,
 //   ASSERT_NO_FATAL_FAILURE(Process()) << "Process() failed";
 //
 #define ASSERT_NO_FATAL_FAILURE(statement) \
-    GTEST_TEST_NO_FATAL_FAILURE_(statement, GTEST_FATAL_FAILURE_)
+    GTEST_TEST_NO_FATAL_FAILURE_(statement, GTEST_FATAL_FAILURE_, GTEST_SUCCESS_)
 #define EXPECT_NO_FATAL_FAILURE(statement) \
-    GTEST_TEST_NO_FATAL_FAILURE_(statement, GTEST_NONFATAL_FAILURE_)
+    GTEST_TEST_NO_FATAL_FAILURE_(statement, GTEST_NONFATAL_FAILURE_, GTEST_SUCCESS_)
 
 // Causes a trace (including the given source file path and line number,
 // and the given message) to be included in every test failure message generated

--- a/googletest/include/gtest/gtest_pred_impl.h
+++ b/googletest/include/gtest/gtest_pred_impl.h
@@ -71,10 +71,10 @@ namespace testing {
 // GTEST_ASSERT_ is the basic statement to which all of the assertions
 // in this file reduce.  Don't use this in your code.
 
-#define GTEST_ASSERT_(expression, on_failure) \
+#define GTEST_ASSERT_(expression, on_failure, on_success) \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
   if (const ::testing::AssertionResult gtest_ar = (expression)) \
-    ; \
+    on_success(gtest_ar.failure_message()) ; \
   else \
     on_failure(gtest_ar.failure_message())
 
@@ -97,9 +97,9 @@ AssertionResult AssertPred1Helper(const char* pred_text,
 
 // Internal macro for implementing {EXPECT|ASSERT}_PRED_FORMAT1.
 // Don't use this in your code.
-#define GTEST_PRED_FORMAT1_(pred_format, v1, on_failure)\
+#define GTEST_PRED_FORMAT1_(pred_format, v1, on_failure, on_success)\
   GTEST_ASSERT_(pred_format(#v1, v1), \
-                on_failure)
+                on_failure, on_success)
 
 // Internal macro for implementing {EXPECT|ASSERT}_PRED1.  Don't use
 // this in your code.
@@ -111,13 +111,13 @@ AssertionResult AssertPred1Helper(const char* pred_text,
 
 // Unary predicate assertion macros.
 #define EXPECT_PRED_FORMAT1(pred_format, v1) \
-  GTEST_PRED_FORMAT1_(pred_format, v1, GTEST_NONFATAL_FAILURE_)
+  GTEST_PRED_FORMAT1_(pred_format, v1, GTEST_NONFATAL_FAILURE_, GTEST_SUCCESS_)
 #define EXPECT_PRED1(pred, v1) \
-  GTEST_PRED1_(pred, v1, GTEST_NONFATAL_FAILURE_)
+  GTEST_PRED1_(pred, v1, GTEST_NONFATAL_FAILURE_, GTEST_SUCCESS_)
 #define ASSERT_PRED_FORMAT1(pred_format, v1) \
-  GTEST_PRED_FORMAT1_(pred_format, v1, GTEST_FATAL_FAILURE_)
+  GTEST_PRED_FORMAT1_(pred_format, v1, GTEST_FATAL_FAILURE_, GTEST_SUCCESS_)
 #define ASSERT_PRED1(pred, v1) \
-  GTEST_PRED1_(pred, v1, GTEST_FATAL_FAILURE_)
+  GTEST_PRED1_(pred, v1, GTEST_FATAL_FAILURE_, GTEST_SUCCESS_)
 
 
 
@@ -144,9 +144,9 @@ AssertionResult AssertPred2Helper(const char* pred_text,
 
 // Internal macro for implementing {EXPECT|ASSERT}_PRED_FORMAT2.
 // Don't use this in your code.
-#define GTEST_PRED_FORMAT2_(pred_format, v1, v2, on_failure)\
+#define GTEST_PRED_FORMAT2_(pred_format, v1, v2, on_failure, on_success)\
   GTEST_ASSERT_(pred_format(#v1, #v2, v1, v2), \
-                on_failure)
+                on_failure, on_success)
 
 // Internal macro for implementing {EXPECT|ASSERT}_PRED2.  Don't use
 // this in your code.
@@ -160,13 +160,13 @@ AssertionResult AssertPred2Helper(const char* pred_text,
 
 // Binary predicate assertion macros.
 #define EXPECT_PRED_FORMAT2(pred_format, v1, v2) \
-  GTEST_PRED_FORMAT2_(pred_format, v1, v2, GTEST_NONFATAL_FAILURE_)
+  GTEST_PRED_FORMAT2_(pred_format, v1, v2, GTEST_NONFATAL_FAILURE_, GTEST_SUCCESS_)
 #define EXPECT_PRED2(pred, v1, v2) \
-  GTEST_PRED2_(pred, v1, v2, GTEST_NONFATAL_FAILURE_)
+  GTEST_PRED2_(pred, v1, v2, GTEST_NONFATAL_FAILURE_, GTEST_SUCCESS_)
 #define ASSERT_PRED_FORMAT2(pred_format, v1, v2) \
-  GTEST_PRED_FORMAT2_(pred_format, v1, v2, GTEST_FATAL_FAILURE_)
+  GTEST_PRED_FORMAT2_(pred_format, v1, v2, GTEST_FATAL_FAILURE_, GTEST_SUCCESS_)
 #define ASSERT_PRED2(pred, v1, v2) \
-  GTEST_PRED2_(pred, v1, v2, GTEST_FATAL_FAILURE_)
+  GTEST_PRED2_(pred, v1, v2, GTEST_FATAL_FAILURE_, GTEST_SUCCESS_)
 
 
 
@@ -197,9 +197,9 @@ AssertionResult AssertPred3Helper(const char* pred_text,
 
 // Internal macro for implementing {EXPECT|ASSERT}_PRED_FORMAT3.
 // Don't use this in your code.
-#define GTEST_PRED_FORMAT3_(pred_format, v1, v2, v3, on_failure)\
+#define GTEST_PRED_FORMAT3_(pred_format, v1, v2, v3, on_failure, on_success)\
   GTEST_ASSERT_(pred_format(#v1, #v2, #v3, v1, v2, v3), \
-                on_failure)
+                on_failure, on_success)
 
 // Internal macro for implementing {EXPECT|ASSERT}_PRED3.  Don't use
 // this in your code.
@@ -215,13 +215,13 @@ AssertionResult AssertPred3Helper(const char* pred_text,
 
 // Ternary predicate assertion macros.
 #define EXPECT_PRED_FORMAT3(pred_format, v1, v2, v3) \
-  GTEST_PRED_FORMAT3_(pred_format, v1, v2, v3, GTEST_NONFATAL_FAILURE_)
+  GTEST_PRED_FORMAT3_(pred_format, v1, v2, v3, GTEST_NONFATAL_FAILURE_, GTEST_SUCCESS_)
 #define EXPECT_PRED3(pred, v1, v2, v3) \
-  GTEST_PRED3_(pred, v1, v2, v3, GTEST_NONFATAL_FAILURE_)
+  GTEST_PRED3_(pred, v1, v2, v3, GTEST_NONFATAL_FAILURE_, GTEST_SUCCESS_)
 #define ASSERT_PRED_FORMAT3(pred_format, v1, v2, v3) \
-  GTEST_PRED_FORMAT3_(pred_format, v1, v2, v3, GTEST_FATAL_FAILURE_)
+  GTEST_PRED_FORMAT3_(pred_format, v1, v2, v3, GTEST_FATAL_FAILURE_, GTEST_SUCCESS_)
 #define ASSERT_PRED3(pred, v1, v2, v3) \
-  GTEST_PRED3_(pred, v1, v2, v3, GTEST_FATAL_FAILURE_)
+  GTEST_PRED3_(pred, v1, v2, v3, GTEST_FATAL_FAILURE_, GTEST_SUCCESS_)
 
 
 
@@ -256,9 +256,9 @@ AssertionResult AssertPred4Helper(const char* pred_text,
 
 // Internal macro for implementing {EXPECT|ASSERT}_PRED_FORMAT4.
 // Don't use this in your code.
-#define GTEST_PRED_FORMAT4_(pred_format, v1, v2, v3, v4, on_failure)\
+#define GTEST_PRED_FORMAT4_(pred_format, v1, v2, v3, v4, on_failure, on_success)\
   GTEST_ASSERT_(pred_format(#v1, #v2, #v3, #v4, v1, v2, v3, v4), \
-                on_failure)
+                on_failure, on_success)
 
 // Internal macro for implementing {EXPECT|ASSERT}_PRED4.  Don't use
 // this in your code.
@@ -276,13 +276,13 @@ AssertionResult AssertPred4Helper(const char* pred_text,
 
 // 4-ary predicate assertion macros.
 #define EXPECT_PRED_FORMAT4(pred_format, v1, v2, v3, v4) \
-  GTEST_PRED_FORMAT4_(pred_format, v1, v2, v3, v4, GTEST_NONFATAL_FAILURE_)
+  GTEST_PRED_FORMAT4_(pred_format, v1, v2, v3, v4, GTEST_NONFATAL_FAILURE_, GTEST_SUCCESS_)
 #define EXPECT_PRED4(pred, v1, v2, v3, v4) \
-  GTEST_PRED4_(pred, v1, v2, v3, v4, GTEST_NONFATAL_FAILURE_)
+  GTEST_PRED4_(pred, v1, v2, v3, v4, GTEST_NONFATAL_FAILURE_, GTEST_SUCCESS_)
 #define ASSERT_PRED_FORMAT4(pred_format, v1, v2, v3, v4) \
-  GTEST_PRED_FORMAT4_(pred_format, v1, v2, v3, v4, GTEST_FATAL_FAILURE_)
+  GTEST_PRED_FORMAT4_(pred_format, v1, v2, v3, v4, GTEST_FATAL_FAILURE_, GTEST_SUCCESS_)
 #define ASSERT_PRED4(pred, v1, v2, v3, v4) \
-  GTEST_PRED4_(pred, v1, v2, v3, v4, GTEST_FATAL_FAILURE_)
+  GTEST_PRED4_(pred, v1, v2, v3, v4, GTEST_FATAL_FAILURE_, GTEST_SUCCESS_)
 
 
 
@@ -321,9 +321,9 @@ AssertionResult AssertPred5Helper(const char* pred_text,
 
 // Internal macro for implementing {EXPECT|ASSERT}_PRED_FORMAT5.
 // Don't use this in your code.
-#define GTEST_PRED_FORMAT5_(pred_format, v1, v2, v3, v4, v5, on_failure)\
+#define GTEST_PRED_FORMAT5_(pred_format, v1, v2, v3, v4, v5, on_failure, on_success)\
   GTEST_ASSERT_(pred_format(#v1, #v2, #v3, #v4, #v5, v1, v2, v3, v4, v5), \
-                on_failure)
+                on_failure, on_success)
 
 // Internal macro for implementing {EXPECT|ASSERT}_PRED5.  Don't use
 // this in your code.
@@ -343,13 +343,13 @@ AssertionResult AssertPred5Helper(const char* pred_text,
 
 // 5-ary predicate assertion macros.
 #define EXPECT_PRED_FORMAT5(pred_format, v1, v2, v3, v4, v5) \
-  GTEST_PRED_FORMAT5_(pred_format, v1, v2, v3, v4, v5, GTEST_NONFATAL_FAILURE_)
+  GTEST_PRED_FORMAT5_(pred_format, v1, v2, v3, v4, v5, GTEST_NONFATAL_FAILURE_, GTEST_SUCCESS_)
 #define EXPECT_PRED5(pred, v1, v2, v3, v4, v5) \
-  GTEST_PRED5_(pred, v1, v2, v3, v4, v5, GTEST_NONFATAL_FAILURE_)
+  GTEST_PRED5_(pred, v1, v2, v3, v4, v5, GTEST_NONFATAL_FAILURE_, GTEST_SUCCESS_)
 #define ASSERT_PRED_FORMAT5(pred_format, v1, v2, v3, v4, v5) \
-  GTEST_PRED_FORMAT5_(pred_format, v1, v2, v3, v4, v5, GTEST_FATAL_FAILURE_)
+  GTEST_PRED_FORMAT5_(pred_format, v1, v2, v3, v4, v5, GTEST_FATAL_FAILURE_, GTEST_SUCCESS_)
 #define ASSERT_PRED5(pred, v1, v2, v3, v4, v5) \
-  GTEST_PRED5_(pred, v1, v2, v3, v4, v5, GTEST_FATAL_FAILURE_)
+  GTEST_PRED5_(pred, v1, v2, v3, v4, v5, GTEST_FATAL_FAILURE_, GTEST_SUCCESS_)
 
 
 

--- a/googletest/include/gtest/gtest_pred_impl.h
+++ b/googletest/include/gtest/gtest_pred_impl.h
@@ -87,9 +87,15 @@ AssertionResult AssertPred1Helper(const char* pred_text,
                                   const char* e1,
                                   Pred pred,
                                   const T1& v1) {
-  if (pred(v1)) return AssertionSuccess();
+  AssertionResult result = [&]{
+    if (pred(v1)) {
+      return AssertionSuccess();
+    }else {
+      return AssertionFailure();
+    }
+  }();
 
-  return AssertionFailure()
+  return std::move(result)
          << pred_text << "(" << e1 << ") evaluates to false, where"
          << "\n"
          << e1 << " evaluates to " << ::testing::PrintToString(v1);
@@ -103,11 +109,11 @@ AssertionResult AssertPred1Helper(const char* pred_text,
 
 // Internal macro for implementing {EXPECT|ASSERT}_PRED1.  Don't use
 // this in your code.
-#define GTEST_PRED1_(pred, v1, on_failure)\
+#define GTEST_PRED1_(pred, v1, on_failure, on_success)\
   GTEST_ASSERT_(::testing::AssertPred1Helper(#pred, \
                                              #v1, \
                                              pred, \
-                                             v1), on_failure)
+                                             v1), on_failure, on_success)
 
 // Unary predicate assertion macros.
 #define EXPECT_PRED_FORMAT1(pred_format, v1) \
@@ -132,9 +138,15 @@ AssertionResult AssertPred2Helper(const char* pred_text,
                                   Pred pred,
                                   const T1& v1,
                                   const T2& v2) {
-  if (pred(v1, v2)) return AssertionSuccess();
+  AssertionResult result = [&]{
+    if (pred(v1, v2)) {
+      return AssertionSuccess();
+    }else {
+      return AssertionFailure();
+    }
+  }();
 
-  return AssertionFailure()
+  return std::move(result)
          << pred_text << "(" << e1 << ", " << e2
          << ") evaluates to false, where"
          << "\n"
@@ -150,13 +162,13 @@ AssertionResult AssertPred2Helper(const char* pred_text,
 
 // Internal macro for implementing {EXPECT|ASSERT}_PRED2.  Don't use
 // this in your code.
-#define GTEST_PRED2_(pred, v1, v2, on_failure)\
+#define GTEST_PRED2_(pred, v1, v2, on_failure, on_success)\
   GTEST_ASSERT_(::testing::AssertPred2Helper(#pred, \
                                              #v1, \
                                              #v2, \
                                              pred, \
                                              v1, \
-                                             v2), on_failure)
+                                             v2), on_failure, on_success)
 
 // Binary predicate assertion macros.
 #define EXPECT_PRED_FORMAT2(pred_format, v1, v2) \
@@ -184,9 +196,15 @@ AssertionResult AssertPred3Helper(const char* pred_text,
                                   const T1& v1,
                                   const T2& v2,
                                   const T3& v3) {
-  if (pred(v1, v2, v3)) return AssertionSuccess();
+  AssertionResult result = [&]{
+    if (pred(v1, v2, v3)) {
+      return AssertionSuccess();
+    }else {
+      return AssertionFailure();
+    }
+  }();
 
-  return AssertionFailure()
+  return std::move(result)
          << pred_text << "(" << e1 << ", " << e2 << ", " << e3
          << ") evaluates to false, where"
          << "\n"
@@ -203,7 +221,7 @@ AssertionResult AssertPred3Helper(const char* pred_text,
 
 // Internal macro for implementing {EXPECT|ASSERT}_PRED3.  Don't use
 // this in your code.
-#define GTEST_PRED3_(pred, v1, v2, v3, on_failure)\
+#define GTEST_PRED3_(pred, v1, v2, v3, on_failure, on_success)\
   GTEST_ASSERT_(::testing::AssertPred3Helper(#pred, \
                                              #v1, \
                                              #v2, \
@@ -211,7 +229,7 @@ AssertionResult AssertPred3Helper(const char* pred_text,
                                              pred, \
                                              v1, \
                                              v2, \
-                                             v3), on_failure)
+                                             v3), on_failure, on_success)
 
 // Ternary predicate assertion macros.
 #define EXPECT_PRED_FORMAT3(pred_format, v1, v2, v3) \
@@ -242,9 +260,15 @@ AssertionResult AssertPred4Helper(const char* pred_text,
                                   const T2& v2,
                                   const T3& v3,
                                   const T4& v4) {
-  if (pred(v1, v2, v3, v4)) return AssertionSuccess();
+  AssertionResult result = [&]{
+    if (pred(v1, v2, v3, v4)) {
+      return AssertionSuccess();
+    }else {
+      return AssertionFailure();
+    }
+  }();
 
-  return AssertionFailure()
+  return std::move(result)
          << pred_text << "(" << e1 << ", " << e2 << ", " << e3 << ", " << e4
          << ") evaluates to false, where"
          << "\n"
@@ -262,7 +286,7 @@ AssertionResult AssertPred4Helper(const char* pred_text,
 
 // Internal macro for implementing {EXPECT|ASSERT}_PRED4.  Don't use
 // this in your code.
-#define GTEST_PRED4_(pred, v1, v2, v3, v4, on_failure)\
+#define GTEST_PRED4_(pred, v1, v2, v3, v4, on_failure, on_success)\
   GTEST_ASSERT_(::testing::AssertPred4Helper(#pred, \
                                              #v1, \
                                              #v2, \
@@ -272,7 +296,7 @@ AssertionResult AssertPred4Helper(const char* pred_text,
                                              v1, \
                                              v2, \
                                              v3, \
-                                             v4), on_failure)
+                                             v4), on_failure, on_success)
 
 // 4-ary predicate assertion macros.
 #define EXPECT_PRED_FORMAT4(pred_format, v1, v2, v3, v4) \
@@ -306,9 +330,15 @@ AssertionResult AssertPred5Helper(const char* pred_text,
                                   const T3& v3,
                                   const T4& v4,
                                   const T5& v5) {
-  if (pred(v1, v2, v3, v4, v5)) return AssertionSuccess();
+  AssertionResult result = [&]{
+    if (pred(v1, v2, v3, v4, v5)) {
+      return AssertionSuccess();
+    }else {
+      return AssertionFailure();
+    }
+  }();
 
-  return AssertionFailure()
+  return std::move(result)
          << pred_text << "(" << e1 << ", " << e2 << ", " << e3 << ", " << e4
          << ", " << e5 << ") evaluates to false, where"
          << "\n"
@@ -327,7 +357,7 @@ AssertionResult AssertPred5Helper(const char* pred_text,
 
 // Internal macro for implementing {EXPECT|ASSERT}_PRED5.  Don't use
 // this in your code.
-#define GTEST_PRED5_(pred, v1, v2, v3, v4, v5, on_failure)\
+#define GTEST_PRED5_(pred, v1, v2, v3, v4, v5, on_failure, on_success)\
   GTEST_ASSERT_(::testing::AssertPred5Helper(#pred, \
                                              #v1, \
                                              #v2, \
@@ -339,7 +369,7 @@ AssertionResult AssertPred5Helper(const char* pred_text,
                                              v2, \
                                              v3, \
                                              v4, \
-                                             v5), on_failure)
+                                             v5), on_failure, on_success)
 
 // 5-ary predicate assertion macros.
 #define EXPECT_PRED_FORMAT5(pred_format, v1, v2, v3, v4, v5) \

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1431,7 +1431,7 @@ class NeverThrown {
     } catch (expected_exception const&) {                                   \
       gtest_caught_expected = true;                                         \
       gtest_msg.value = "Expected: " #statement                             \
-                        " throws an exception of type " #expected_exception \
+                        " throws an exception of type " #expected_exception;\
     }                                                                       \
     GTEST_TEST_THROW_CATCH_STD_EXCEPTION_(statement, expected_exception)    \
     catch (...) {                                                           \
@@ -1486,7 +1486,7 @@ class NeverThrown {
       fail(("Expected: " #statement " doesn't throw an exception.\n" \
             "  Actual: " + gtest_msg.value).c_str())
 
-#define GTEST_TEST_ANY_THROW_(statement, fail) \
+#define GTEST_TEST_ANY_THROW_(statement, fail, succeed) \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
   if (::testing::internal::AlwaysTrue()) { \
     bool gtest_caught_any = false; \
@@ -1498,7 +1498,9 @@ class NeverThrown {
     } \
     if (!gtest_caught_any) { \
       goto GTEST_CONCAT_TOKEN_(gtest_label_testanythrow_, __LINE__); \
-    } \
+    } else {\
+      succeed("Expected: " #statement " throws an exception."); \
+    }\
   } else \
     GTEST_CONCAT_TOKEN_(gtest_label_testanythrow_, __LINE__): \
       fail("Expected: " #statement " throws an exception.\n" \
@@ -1508,23 +1510,27 @@ class NeverThrown {
 // Implements Boolean test assertions such as EXPECT_TRUE. expression can be
 // either a boolean expression or an AssertionResult. text is a textual
 // representation of expression as it was passed into the EXPECT_TRUE.
-#define GTEST_TEST_BOOLEAN_(expression, text, actual, expected, fail) \
+#define GTEST_TEST_BOOLEAN_(expression, text, actual, expected, fail, succeed) \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
   if (const ::testing::AssertionResult gtest_ar_ = \
       ::testing::AssertionResult(expression)) \
-    ; \
+    succeed(::testing::internal::GetBoolAssertionFailureMessage(\
+        gtest_ar_, text, #actual, #expected).c_str()); \
   else \
     fail(::testing::internal::GetBoolAssertionFailureMessage(\
         gtest_ar_, text, #actual, #expected).c_str())
 
-#define GTEST_TEST_NO_FATAL_FAILURE_(statement, fail) \
+#define GTEST_TEST_NO_FATAL_FAILURE_(statement, fail, succeed) \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
   if (::testing::internal::AlwaysTrue()) { \
     ::testing::internal::HasNewFatalFailureHelper gtest_fatal_failure_checker; \
     GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement); \
     if (gtest_fatal_failure_checker.has_new_fatal_failure()) { \
       goto GTEST_CONCAT_TOKEN_(gtest_label_testnofatal_, __LINE__); \
-    } \
+    } else {\
+      succeed("Expected: " #statement " doesn't generate new fatal " \
+           "failures in the current thread."); \
+    }\
   } else \
     GTEST_CONCAT_TOKEN_(gtest_label_testnofatal_, __LINE__): \
       fail("Expected: " #statement " doesn't generate new fatal " \

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -188,7 +188,7 @@ GTEST_API_ std::string DiffStrings(const std::string& left,
                                    size_t* total_line_count);
 
 // Constructs and returns the message for an equality assertion
-// (e.g. ASSERT_EQ, EXPECT_STREQ, etc) failure.
+// (e.g. ASSERT_EQ, EXPECT_STREQ, etc).
 //
 // The first four parameters are the expressions used in the assertion
 // and their values, as strings.  For example, for ASSERT_EQ(foo, bar)
@@ -202,6 +202,16 @@ GTEST_API_ std::string DiffStrings(const std::string& left,
 // The ignoring_case parameter is true if and only if the assertion is a
 // *_STRCASEEQ*.  When it's true, the string " (ignoring case)" will
 // be inserted into the message.
+GTEST_API_ Message EqMessage(const char* lhs_expression,
+                          const char* rhs_expression,
+                          const std::string& lhs_value,
+                          const std::string& rhs_value,
+                          bool ignoring_case) ;
+
+// Constructs and returns the message for an equality assertion
+// (e.g. ASSERT_EQ, EXPECT_STREQ, etc) failure.
+//
+// See EqMessage for details.
 GTEST_API_ AssertionResult EqFailure(const char* expected_expression,
                                      const char* actual_expression,
                                      const std::string& expected_value,
@@ -1412,7 +1422,7 @@ class NeverThrown {
 
 #endif  // GTEST_HAS_EXCEPTIONS
 
-#define GTEST_TEST_THROW_(statement, expected_exception, fail)              \
+#define GTEST_TEST_THROW_(statement, expected_exception, fail, succeed)     \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_                                             \
   if (::testing::internal::TrueWithString gtest_msg{}) {                    \
     bool gtest_caught_expected = false;                                     \
@@ -1420,6 +1430,8 @@ class NeverThrown {
       GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement);            \
     } catch (expected_exception const&) {                                   \
       gtest_caught_expected = true;                                         \
+      gtest_msg.value = "Expected: " #statement                             \
+                        " throws an exception of type " #expected_exception \
     }                                                                       \
     GTEST_TEST_THROW_CATCH_STD_EXCEPTION_(statement, expected_exception)    \
     catch (...) {                                                           \
@@ -1433,6 +1445,8 @@ class NeverThrown {
                         " throws an exception of type " #expected_exception \
                         ".\n  Actual: it throws nothing.";                  \
       goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__);           \
+    } else {                                                                \
+      succeed(gtest_msg.value.c_str());                                     \
     }                                                                       \
   } else /*NOLINT*/                                                         \
     GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__)                   \
@@ -1456,7 +1470,7 @@ class NeverThrown {
 
 #endif  // GTEST_HAS_EXCEPTIONS
 
-#define GTEST_TEST_NO_THROW_(statement, fail) \
+#define GTEST_TEST_NO_THROW_(statement, fail, succeed) \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
   if (::testing::internal::TrueWithString gtest_msg{}) { \
     try { \

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -897,7 +897,6 @@ static AssertionResult HasOneFailure(const char* /* results_expr */,
   int last_failed = 0;
   for (int i = 0; i < results.size(); i++) {
     const auto& result = results.GetTestPartResult(i);
-    std::cout << result.type() << TestPartResult::kSuccess << " == " << type << std::endl;
     if (result.type() != TestPartResult::kSuccess){
       failures++;
       last_failed = i;
@@ -905,9 +904,9 @@ static AssertionResult HasOneFailure(const char* /* results_expr */,
   }
 
   Message msg;
-  if (failures != 1) {
+  if (failures != 1 && results.size() != 1) {
     msg << "Expected: " << expected << "\n"
-        << " Actual: " << failures << " failures";
+        << "  Actual: " << failures << " failures";
     for (int i = 0; i < results.size(); i++) {
       const auto& result = results.GetTestPartResult(i);
       if (result.type() != TestPartResult::kSuccess){

--- a/googletest/test/googletest-death-test-test.cc
+++ b/googletest/test/googletest-death-test-test.cc
@@ -1193,7 +1193,8 @@ TEST_F(MacroLogicDeathTest, ChildDoesNotDie) {
 // test part.
 TEST(SuccessRegistrationDeathTest, NoSuccessPart) {
   EXPECT_DEATH(_exit(1), "");
-  EXPECT_EQ(0, GetUnitTestImpl()->current_test_result()->total_part_count());
+  EXPECT_EQ(1, GetUnitTestImpl()->current_test_result()->total_part_count());
+  EXPECT_TRUE(GetUnitTestImpl()->current_test_result()->GetTestPartResult(0).passed());
 }
 
 TEST(StreamingAssertionsDeathTest, DeathTest) {

--- a/googletest/test/googletest-json-output-unittest.py
+++ b/googletest/test/googletest-json-output-unittest.py
@@ -128,7 +128,7 @@ EXPECTED_NON_EMPTY = {
                 u'failure': u'gtest_xml_output_unittest_.cc:*\n'
                             u'Expected equality of these values:\n'
                             u'  1\n  2' + STACK_TRACE_TEMPLATE,
-                u'type': u''
+                u'type': u'failure'
             }]
         }]
     }, {
@@ -200,7 +200,7 @@ EXPECTED_NON_EMPTY = {
                 u'failure': u'gtest_xml_output_unittest_.cc:*\n'
                             u'Expected equality of these values:\n'
                             u'  1\n  2' + STACK_TRACE_TEMPLATE,
-                u'type': u''
+                u'type': u'failure'
             }]
         }]
     }, {
@@ -242,12 +242,12 @@ EXPECTED_NON_EMPTY = {
                 u'failure': u'gtest_xml_output_unittest_.cc:*\n'
                             u'Expected equality of these values:\n'
                             u'  1\n  2' + STACK_TRACE_TEMPLATE,
-                u'type': u''
+                u'type': u'failure'
             }, {
                 u'failure': u'gtest_xml_output_unittest_.cc:*\n'
                             u'Expected equality of these values:\n'
                             u'  2\n  3' + STACK_TRACE_TEMPLATE,
-                u'type': u''
+                u'type': u'failure'
             }]
         }, {
             u'name': u'DISABLED_test',
@@ -290,7 +290,7 @@ EXPECTED_NON_EMPTY = {
                             u'Failed\nXML output: <?xml encoding="utf-8">'
                             u'<top><![CDATA[cdata text]]></top>' +
                             STACK_TRACE_TEMPLATE,
-                u'type': u''
+                u'type': u'failure'
             }]
         }]
     }, {
@@ -325,7 +325,7 @@ EXPECTED_NON_EMPTY = {
                 u'failure': u'gtest_xml_output_unittest_.cc:*\n'
                             u'Failed\nInvalid characters in brackets'
                             u' [\x01\x02]' + STACK_TRACE_TEMPLATE,
-                u'type': u''
+                u'type': u'failure'
             }]
         }]
     }, {
@@ -661,7 +661,7 @@ EXPECTED_NO_TEST = {
                 u'failure': u'gtest_no_test_unittest.cc:*\n'
                             u'Expected equality of these values:\n'
                             u'  1\n  2' + STACK_TRACE_TEMPLATE,
-                u'type': u'',
+                u'type': u'failure',
             }]
         }]
     }],
@@ -695,6 +695,7 @@ class GTestJsonOutputUnitTest(gtest_test_utils.TestCase):
     Runs a test program that generates an JSON output for a binary with no
     tests, and tests that the JSON output is expected.
     """
+    self.maxDiff=None
 
     self._TestJsonOutput('gtest_no_test_unittest', EXPECTED_NO_TEST, 0)
 

--- a/googletest/test/googletest-output-test.py
+++ b/googletest/test/googletest-output-test.py
@@ -289,6 +289,7 @@ class GTestOutputTest(gtest_test_utils.TestCase):
     golden = ToUnixLineEnding(golden_file.read().decode())
     golden_file.close()
 
+    self.maxDiff = None
     # We want the test to pass regardless of certain features being
     # supported or not.
 

--- a/googletest/test/gtest_stress_test.cc
+++ b/googletest/test/gtest_stress_test.cc
@@ -109,8 +109,12 @@ void ManyAsserts(int id) {
 void CheckTestFailureCount(int expected_failures) {
   const TestInfo* const info = UnitTest::GetInstance()->current_test_info();
   const TestResult* const result = info->result();
-  GTEST_CHECK_(expected_failures == result->total_part_count())
-      << "Logged " << result->total_part_count() << " failures "
+  int failcount = 0;
+  for (int i = 0; i < result->total_part_count(); i++){
+    if(!result->GetTestPartResult(i).passed()) failcount++;
+  }
+  GTEST_CHECK_(expected_failures == failcount)
+      << "Logged " << failcount << " failures "
       << " vs. " << expected_failures << " expected";
 }
 

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -5707,6 +5707,14 @@ struct Flags {
     return flags;
   }
 
+  // Creates a Flags struct where the gtest_output_succeeded flag has the given
+  // value.
+  static Flags OutputSucceed(bool output_succeeded) {
+    Flags flags;
+    flags.output_succeeded = output_succeeded;
+    return flags;
+  }
+
   // These fields store the flag values.
   bool also_run_disabled_tests;
   bool break_on_failure;
@@ -5725,6 +5733,7 @@ struct Flags {
   int32_t stack_trace_depth;
   const char* stream_result_to;
   bool throw_on_failure;
+  bool output_succeeded;
 };
 
 // Fixture for testing ParseGoogleTestFlagsOnly().

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -4284,25 +4284,29 @@ TEST(SuccessfulAssertionTest, SUCCEED) {
 // Tests that Google Test doesn't track successful EXPECT_*.
 TEST(SuccessfulAssertionTest, EXPECT) {
   EXPECT_TRUE(true);
-  EXPECT_EQ(0, GetUnitTestImpl()->current_test_result()->total_part_count());
+  EXPECT_EQ(1, GetUnitTestImpl()->current_test_result()->total_part_count());
+  EXPECT_TRUE(GetUnitTestImpl()->current_test_result()->GetTestPartResult(1).passed());
 }
 
 // Tests that Google Test doesn't track successful EXPECT_STR*.
 TEST(SuccessfulAssertionTest, EXPECT_STR) {
   EXPECT_STREQ("", "");
-  EXPECT_EQ(0, GetUnitTestImpl()->current_test_result()->total_part_count());
+  EXPECT_EQ(1, GetUnitTestImpl()->current_test_result()->total_part_count());
+  EXPECT_TRUE(GetUnitTestImpl()->current_test_result()->GetTestPartResult(1).passed());
 }
 
 // Tests that Google Test doesn't track successful ASSERT_*.
 TEST(SuccessfulAssertionTest, ASSERT) {
   ASSERT_TRUE(true);
-  EXPECT_EQ(0, GetUnitTestImpl()->current_test_result()->total_part_count());
+  EXPECT_EQ(1, GetUnitTestImpl()->current_test_result()->total_part_count());
+  EXPECT_TRUE(GetUnitTestImpl()->current_test_result()->GetTestPartResult(1).passed());
 }
 
 // Tests that Google Test doesn't track successful ASSERT_STR*.
 TEST(SuccessfulAssertionTest, ASSERT_STR) {
   ASSERT_STREQ("", "");
-  EXPECT_EQ(0, GetUnitTestImpl()->current_test_result()->total_part_count());
+  EXPECT_EQ(1, GetUnitTestImpl()->current_test_result()->total_part_count());
+  EXPECT_TRUE(GetUnitTestImpl()->current_test_result()->GetTestPartResult(1).passed());
 }
 
 }  // namespace testing
@@ -5361,8 +5365,9 @@ TEST_F(TestInfoTest, result) {
   // Initially, there is no TestPartResult for this test.
   ASSERT_EQ(0, GetTestResult(test_info)->total_part_count());
 
-  // After the previous assertion, there is still none.
-  ASSERT_EQ(0, GetTestResult(test_info)->total_part_count());
+  // After the previous assertion, there is one.
+  ASSERT_EQ(1, GetTestResult(test_info)->total_part_count());
+  ASSERT_TRUE(GetTestResult(test_info)->GetTestPartResult(0).passed());
 }
 
 #define VERIFY_CODE_LOCATION \

--- a/googletest/test/gtest_xml_output_unittest.py
+++ b/googletest/test/gtest_xml_output_unittest.py
@@ -44,6 +44,7 @@ import gtest_xml_test_utils
 GTEST_FILTER_FLAG = '--gtest_filter'
 GTEST_LIST_TESTS_FLAG = '--gtest_list_tests'
 GTEST_OUTPUT_FLAG = '--gtest_output'
+GTEST_OUTPUT_SUCCEEDED_FLAG = '--gtest_output_succeeded'
 GTEST_DEFAULT_OUTPUT_FILE = 'test_detail.xml'
 GTEST_PROGRAM_NAME = 'gtest_xml_output_unittest_'
 
@@ -195,9 +196,20 @@ EXPECTED_FILTERED_TEST_XML = """<?xml version="1.0" encoding="UTF-8"?>
             timestamp="*" name="AllTests" ad_hoc_property="42">
   <testsuite name="SuccessfulTest" tests="1" failures="0" disabled="0" skipped="0"
              errors="0" time="*" timestamp="*">
-    <testcase name="Succeeds" status="run" result="completed" time="*" timestamp="*" classname="SuccessfulTest"/>
+    <testcase name="Succeeds" status="run" result="completed" time="*" timestamp="*" classname="SuccessfulTest">
+      <succeeded message="gtest_xml_output_unittest_.cc:*&#x0A;Succeeded&#x0A;This is a success."><![CDATA[gtest_xml_output_unittest_.cc:*
+Succeeded
+This is a success.%(stack)s]]></succeeded>
+      <succeeded message="gtest_xml_output_unittest_.cc:*&#x0A;Expected equality of these values:&#x0A;  1&#x0A;  1"><![CDATA[gtest_xml_output_unittest_.cc:*
+Expected equality of these values:
+  1
+  1%(stack)s]]></succeeded>
+    </testcase>
   </testsuite>
-</testsuites>"""
+</testsuites>""" % {
+    'stack': STACK_TRACE_TEMPLATE
+}
+
 
 EXPECTED_SHARDED_TEST_XML = """<?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="3" failures="0" disabled="0" errors="0" time="*" timestamp="*" name="AllTests" ad_hoc_property="42">
@@ -346,7 +358,7 @@ class GTestXMLOutputUnitTest(gtest_xml_test_utils.GTestXMLTestCase):
     """
 
     self._TestXmlOutput(GTEST_PROGRAM_NAME, EXPECTED_FILTERED_TEST_XML, 0,
-                        extra_args=['%s=SuccessfulTest.*' % GTEST_FILTER_FLAG])
+                        extra_args=['%s=SuccessfulTest.*' % GTEST_FILTER_FLAG, GTEST_OUTPUT_SUCCEEDED_FLAG])
 
   def testShardedTestXmlOutput(self):
     """Verifies XML output when run using multiple shards.

--- a/googletest/test/gtest_xml_output_unittest_.cc
+++ b/googletest/test/gtest_xml_output_unittest_.cc
@@ -85,7 +85,7 @@ TEST_F(SkippedTest, SkippedAfterFailure) {
 
 TEST(MixedResultTest, Succeeds) {
   EXPECT_EQ(1, 1);
-  ASSERT_EQ(1, 1);
+  ASSERT_EQ(2, 2);
 }
 
 TEST(MixedResultTest, Fails) {

--- a/googletest/test/gtest_xml_test_utils.py
+++ b/googletest/test/gtest_xml_test_utils.py
@@ -93,7 +93,7 @@ class GTestXMLTestCase(gtest_test_utils.TestCase):
     actual_children = self._GetChildren(actual_node)
     self.assertEquals(
         len(expected_children), len(actual_children),
-        'number of child elements differ in element ' + actual_node.tagName)
+        'number of child elements differ in element ' + actual_node.tagName + ' ' + actual_node.getAttribute('name'))
     for child_id, child in expected_children.items():
       self.assert_(child_id in actual_children,
                    '<%s> is not in <%s> (in element %s)' %
@@ -105,6 +105,7 @@ class GTestXMLTestCase(gtest_test_utils.TestCase):
       'testsuite': 'name',
       'testcase': 'name',
       'failure': 'message',
+      'succeeded': 'message',
       'skipped': 'message',
       'property': 'name',
   }
@@ -136,7 +137,8 @@ class GTestXMLTestCase(gtest_test_utils.TestCase):
                        'Encountered unknown element <%s>' % child.tagName)
           child_id = child.getAttribute(
               self.identifying_attribute[child.tagName])
-        self.assert_(child_id not in children)
+        self.assert_(child_id not in children, '<%s> is already in <%s> (in element %s)' %
+                   (child_id, children, element.tagName))
         children[child_id] = child
       elif child.nodeType in [Node.TEXT_NODE, Node.CDATA_SECTION_NODE]:
         if 'detail' not in children:
@@ -180,7 +182,7 @@ class GTestXMLTestCase(gtest_test_utils.TestCase):
       type_param = element.getAttributeNode('type_param')
       if type_param and type_param.value:
         type_param.value = '*'
-    elif element.tagName == 'failure' or element.tagName == 'skipped':
+    elif element.tagName == 'failure' or element.tagName == 'skipped' or element.tagName == 'succeeded':
       source_line_pat = r'^.*[/\\](.*:)\d+\n'
       # Replaces the source line information with a normalized form.
       message = element.getAttributeNode('message')


### PR DESCRIPTION
This change allows to include succeeded assertions into the output (xml, json, terminal).

It introduces a flag called `--gtest_output_succeed`.

It also adds type to the failures in the json output. Please let me know if this should be done in another way (like a separate array for succeeded ones).

Would be happy if you can give me some feedback.

I think this basically covers what is requested in https://github.com/google/googletest/issues/3474