### PR TITLE
Typo in the queue test of the README

### DIFF
--- a/docs/primer.md
+++ b/docs/primer.md
@@ -274,8 +274,8 @@ First, define a fixture class. By convention, you should give it the name
 class QueueTest : public ::testing::Test {
  protected:
   void SetUp() override {
-     q1_.Enqueue(1);
-     q2_.Enqueue(2);
+     q0_.Enqueue(1);
+     q1_.Enqueue(2);
      q2_.Enqueue(3);
   }
 


### PR DESCRIPTION
Example contains

```bash
q1_
q2_
q2_
```

whereas it should be 

```bash
q0_
q1_
q2_
```