### PR TITLE
Link gtest to regex on QNX systems

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -138,6 +138,9 @@ if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
     "$<BUILD_INTERFACE:${gtest_build_include_dirs}>"
     "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
 endif()
+if(CMAKE_SYSTEM_NAME MATCHES "QNX")
+  target_link_libraries(gtest PUBLIC regex)
+endif()
 target_link_libraries(gtest_main PUBLIC gtest)
 
 ########################################################################


### PR DESCRIPTION
Similar to https://github.com/google/googletest/pull/3484 but when building with cmake. QNX requires linking against regex