### PR TITLE
FIX #3659 -- Use `__cpp_lib_char8_t` macro to support `UTF-8` code units

### DIFF
--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -383,7 +383,7 @@ GTEST_IMPL_FORMAT_C_STRING_AS_POINTER_(const char32_t);
 
 GTEST_IMPL_FORMAT_C_STRING_AS_STRING_(char, ::std::string);
 GTEST_IMPL_FORMAT_C_STRING_AS_STRING_(const char, ::std::string);
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
 GTEST_IMPL_FORMAT_C_STRING_AS_STRING_(char8_t, ::std::u8string);
 GTEST_IMPL_FORMAT_C_STRING_AS_STRING_(const char8_t, ::std::u8string);
 #endif
@@ -471,7 +471,7 @@ GTEST_API_ void PrintTo(char32_t c, ::std::ostream* os);
 inline void PrintTo(char16_t c, ::std::ostream* os) {
   PrintTo(ImplicitCast_<char32_t>(c), os);
 }
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
 inline void PrintTo(char8_t c, ::std::ostream* os) {
   PrintTo(ImplicitCast_<char32_t>(c), os);
 }
@@ -503,7 +503,7 @@ inline void PrintTo(const unsigned char* s, ::std::ostream* os) {
 inline void PrintTo(unsigned char* s, ::std::ostream* os) {
   PrintTo(ImplicitCast_<const void*>(s), os);
 }
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
 // Overloads for u8 strings.
 GTEST_API_ void PrintTo(const char8_t* s, ::std::ostream* os);
 inline void PrintTo(char8_t* s, ::std::ostream* os) {
@@ -555,7 +555,7 @@ inline void PrintTo(const ::std::string& s, ::std::ostream* os) {
 }
 
 // Overloads for ::std::u8string
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
 GTEST_API_ void PrintU8StringTo(const ::std::u8string& s, ::std::ostream* os);
 inline void PrintTo(const ::std::u8string& s, ::std::ostream* os) {
   PrintU8StringTo(s, os);
@@ -823,7 +823,7 @@ void UniversalPrintArray(const T* begin, size_t len, ::std::ostream* os) {
 GTEST_API_ void UniversalPrintArray(
     const char* begin, size_t len, ::std::ostream* os);
 
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
 // This overload prints a (const) char8_t array compactly.
 GTEST_API_ void UniversalPrintArray(const char8_t* begin, size_t len,
                                     ::std::ostream* os);
@@ -912,7 +912,7 @@ template <>
 class UniversalTersePrinter<char*> : public UniversalTersePrinter<const char*> {
 };
 
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
 template <>
 class UniversalTersePrinter<const char8_t*> {
  public:

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -1909,7 +1909,7 @@ inline bool IsUpper(char ch) {
 inline bool IsXDigit(char ch) {
   return isxdigit(static_cast<unsigned char>(ch)) != 0;
 }
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
 inline bool IsXDigit(char8_t ch) {
   return isxdigit(static_cast<unsigned char>(ch)) != 0;
 }

--- a/googletest/src/gtest-printers.cc
+++ b/googletest/src/gtest-printers.cc
@@ -225,7 +225,7 @@ static const char* GetCharWidthPrefix(unsigned char) {
   return "";
 }
 
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
 static const char* GetCharWidthPrefix(char8_t) {
   return "u8";
 }
@@ -249,7 +249,7 @@ static CharFormat PrintAsStringLiteralTo(char c, ostream* os) {
   return PrintAsStringLiteralTo(ToChar32(c), os);
 }
 
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
 static CharFormat PrintAsStringLiteralTo(char8_t c, ostream* os) {
   return PrintAsStringLiteralTo(ToChar32(c), os);
 }
@@ -416,7 +416,7 @@ void UniversalPrintArray(const char* begin, size_t len, ostream* os) {
   UniversalPrintCharArray(begin, len, os);
 }
 
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
 // Prints a (const) char8_t array of 'len' elements, starting at address
 // 'begin'.
 void UniversalPrintArray(const char8_t* begin, size_t len, ostream* os) {
@@ -459,7 +459,7 @@ void PrintCStringTo(const Char* s, ostream* os) {
 
 void PrintTo(const char* s, ostream* os) { PrintCStringTo(s, os); }
 
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
 void PrintTo(const char8_t* s, ostream* os) { PrintCStringTo(s, os); }
 #endif
 
@@ -553,7 +553,7 @@ void PrintStringTo(const ::std::string& s, ostream* os) {
   }
 }
 
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
 void PrintU8StringTo(const ::std::u8string& s, ostream* os) {
   PrintCharsAsStringTo(s.data(), s.size(), os);
 }

--- a/googletest/test/googletest-printers-test.cc
+++ b/googletest/test/googletest-printers-test.cc
@@ -369,7 +369,7 @@ TEST(PrintCharTest, Char32) {
   EXPECT_EQ("U+0041", Print(U'A'));
 }
 
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
 TEST(PrintCharTest, Char8) {
   EXPECT_EQ("U+0041", Print(u8'A'));
 }
@@ -424,7 +424,7 @@ TEST(PrintBuiltInTypeTest, Integer) {
             Print(std::numeric_limits<uint64_t>::max()));  // uint64
   EXPECT_EQ("-9223372036854775808",
             Print(std::numeric_limits<int64_t>::min()));  // int64
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
   EXPECT_EQ("U+0000",
             Print(std::numeric_limits<char8_t>::min()));  // char8_t
   EXPECT_EQ("U+00FF",
@@ -521,7 +521,7 @@ TEST(PrintCStringTest, EscapesProperly) {
             Print(p));
 }
 
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
 // const char8_t*.
 TEST(PrintU8StringTest, Const) {
   const char8_t* p = u8"界";
@@ -823,7 +823,7 @@ TEST(PrintArrayTest, CharArrayWithTerminatingNul) {
   EXPECT_EQ("\"\\0Hi\"", PrintArrayHelper(a));
 }
 
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
 // char_t array without terminating NUL.
 TEST(PrintArrayTest, Char8ArrayWithNoTerminatingNul) {
   // Array a contains '\0' in the middle and doesn't end with '\0'.
@@ -940,7 +940,7 @@ TEST(PrintWideStringTest, StringAmbiguousHex) {
 }
 #endif  // GTEST_HAS_STD_WSTRING
 
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
 TEST(PrintStringTest, U8String) {
   std::u8string str = u8"Hello, 世界";
   EXPECT_EQ(str, str);  // Verify EXPECT_EQ compiles with this type.


### PR DESCRIPTION
Since `__cpp_char8_t` does not guarantee to represent UTF-8 code units we should use `__cpp_lib_char8_t` macro instead to support UTF-8 code units otherwise use of `__cpp_char8_t` will lead to build failure.

Fixes https://github.com/google/googletest/issues/3659

For reference [see](https://en.cppreference.com/w/cpp/feature_test).

Signed-off-by: Ayush Joshi <ayush854032@gmail.com>