### PR TITLE
FIX #3719 -- Fix `clang` conversion warnings

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -4079,8 +4079,9 @@ std::string XmlUnitTestResultPrinter::EscapeXml(
           m << '"';
         break;
       default:
-        if (IsValidXmlCharacter(ch)) {
-          if (is_attribute && IsNormalizableWhitespace(ch))
+        if (IsValidXmlCharacter(static_cast<unsigned char>(ch))) {
+          if (is_attribute && IsNormalizableWhitespace(
+                                            static_cast<unsigned char>(ch)))
             m << "&#x" << String::FormatByte(static_cast<unsigned char>(ch))
               << ";";
           else
@@ -4101,7 +4102,7 @@ std::string XmlUnitTestResultPrinter::RemoveInvalidXmlCharacters(
   std::string output;
   output.reserve(str.size());
   for (std::string::const_iterator it = str.begin(); it != str.end(); ++it)
-    if (IsValidXmlCharacter(*it))
+    if (IsValidXmlCharacter(static_cast<unsigned char>(*it)))
       output.push_back(*it);
 
   return output;


### PR DESCRIPTION
We should perform an explicit type conversion to `unsigned char` before passing the `const char` data to `IsValidXmlCharacter()` and `IsNormalizableWhitespace()` functions in order to avoid compile time conversion warnings.

Fixes #3719 

Signed-off-by: Ayush Joshi <ayush854032@gmail.com>