### PR TITLE
Fix BUILD_GMOCK and INSTALL_GTEST options when using CMake FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif (POLICY CMP0048)
 
+if (POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif (POLICY CMP0077)
+
 project(googletest-distribution)
 set(GOOGLETEST_VERSION 1.11.0)
 


### PR DESCRIPTION
INSTALL_GTEST cannot be set to OFF due to CMake Policy CMP0077 when using FetchContent, for example:

include(FetchContent)

set(INSTALL_GTEST OFF)

FetchContent_Declare(
  googletest
  GIT_REPOSITORY https://github.com/google/googletest.git
  GIT_TAG        release-1.11.0
)
FetchContent_MakeAvailable(googletest)

Setting the policy to new fixes this.