### PR TITLE
Remove another GTEST_DISALLOW_ASSIGN_ that crept in

### DIFF
--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -1462,8 +1462,6 @@ class ConditionalMatcher {
   bool condition_;
   MatcherTrue matcher_true_;
   MatcherFalse matcher_false_;
-
-  GTEST_DISALLOW_ASSIGN_(ConditionalMatcher);
 };
 
 // Wrapper for implementation of Any/AllOfArray().


### PR DESCRIPTION
They were all removed in #2815, but it looks like this one got added
from a Google export which missed the update. See #2815 for reasons why
removing this is desirable.