### PR TITLE
FIX #2174 -- remove `DEBUG_POSTFIX`

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -154,10 +154,6 @@ function(cxx_library_with_type name type cxx_flags)
   set_target_properties(${name}
     PROPERTIES
     COMPILE_FLAGS "${cxx_flags}")
-  # Generate debug library name with a postfix.
-  set_target_properties(${name}
-    PROPERTIES
-    DEBUG_POSTFIX "d")
   # Set the output directory for build artifacts
   set_target_properties(${name}
     PROPERTIES


### PR DESCRIPTION
While this is not synced with the pkg-config file, it only breaks things

Fix #2174

Signed-off-by: Ayush Joshi <ayush854032@gmail.com>