### PR TITLE
Silence warnings with Clang/Clang-Cl on Windows

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -2576,6 +2576,10 @@ template <class T, typename Result>
 Result HandleSehExceptionsInMethodIfSupported(
     T* object, Result (T::*method)(), const char* location) {
 #if GTEST_HAS_SEH
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wlanguage-extension-token"
+#endif
   __try {
     return (object->*method)();
   } __except (internal::UnitTestOptions::GTestShouldProcessSEH(  // NOLINT
@@ -2590,6 +2594,9 @@ Result HandleSehExceptionsInMethodIfSupported(
     delete exception_message;
     return static_cast<Result>(0);
   }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #else
   (void)location;
   return (object->*method)();


### PR DESCRIPTION
On Windows *Clang* and *Clang-Cl* (which both build against the MSVC ABI) complain about using Microsoft-specific extensions to C++. If warnings are treated as errors this can be problematic:

```
In file included from ...gtest-source/googletest/src/gtest-all.cc:41:
...gtest-source/googletest/src/gtest.cc:2591:3: error: extension used [-Werror,-Wlanguage-extension-token]
  __try {
  ^
1 error generated.
```

This PR silences these warnings and therefore prevents such problems.