### PR TITLE
fix docs/primer.md

### DIFF
--- a/docs/primer.md
+++ b/docs/primer.md
@@ -274,8 +274,8 @@ First, define a fixture class. By convention, you should give it the name
 class QueueTest : public ::testing::Test {
  protected:
   void SetUp() override {
-     q0_.Enqueue(1);
-     q1_.Enqueue(2);
+     q1_.Enqueue(1);
+     q2_.Enqueue(2);
      q2_.Enqueue(3);
   }
 


### PR DESCRIPTION
https://google.github.io/googletest/primer.html#same-data-multiple-tests

There is a wrong description on 'GoogleTest Primer' in the guide documentation. `QueueTest::SetUp` must be fixed like this PR for `DequeueWorks` test to succeed.

```C++
TEST_F(QueueTest, DequeueWorks) {
  int* n = q0_.Dequeue();
  EXPECT_EQ(n, nullptr);

  n = q1_.Dequeue();
  ASSERT_NE(n, nullptr);
  EXPECT_EQ(*n, 1);
  EXPECT_EQ(q1_.size(), 0);
  delete n;

  n = q2_.Dequeue();
  ASSERT_NE(n, nullptr);
  EXPECT_EQ(*n, 2);
  EXPECT_EQ(q2_.size(), 1);
  delete n;
}
```
