### PR TITLE
Update commit has to latest release

### DIFF
--- a/googletest/README.md
+++ b/googletest/README.md
@@ -94,7 +94,7 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   # Specify the commit you depend on and update it regularly.
-  URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+  URL https://github.com/google/googletest/archive/e2239ee6043f73722e7aa812a459f54a28552929.zip
 )
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
Update FetchContent git commit hash to latest stable release.

So even when people just copy / paste the example, it's at least up-to-date.