### PR TITLE
Avoid 'implicit conversion changes signedness' warning

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -745,7 +745,9 @@ class UnitTestFilter {
     const auto exact_match_patterns_begin = std::partition(
         all_patterns.begin(), all_patterns.end(), &IsGlobPattern);
 
-    glob_patterns_.reserve(exact_match_patterns_begin - all_patterns.begin());
+    num_glob_patterns = static_cast<size_t>(
+        exact_match_patterns_begin - all_patterns.begin());
+    glob_patterns_.reserve(num_glob_patterns);
     std::move(all_patterns.begin(), exact_match_patterns_begin,
               std::inserter(glob_patterns_, glob_patterns_.begin()));
     std::move(

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -745,7 +745,7 @@ class UnitTestFilter {
     const auto exact_match_patterns_begin = std::partition(
         all_patterns.begin(), all_patterns.end(), &IsGlobPattern);
 
-    num_glob_patterns = static_cast<size_t>(
+    size_t num_glob_patterns = static_cast<size_t>(
         exact_match_patterns_begin - all_patterns.begin());
     glob_patterns_.reserve(num_glob_patterns);
     std::move(all_patterns.begin(), exact_match_patterns_begin,


### PR DESCRIPTION
```
implicit conversion changes signedness: 'typename __normal_iterator<basic_string<char> *, vector<basic_string<char>, allocator<basic_string<char> > > >::difference_type' (aka 'long') to 'std::vector::size_type' (aka 'unsigned long') [-Werror,-Wsign-conversion]
    glob_patterns_.reserve(exact_match_patterns_begin - all_patterns.begin());
                   ~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
```