### PR TITLE
Source file location and line number in xml and json output

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -839,7 +839,7 @@ will output XML like this:
 
 ```xml
   ...
-    <testcase name="MinAndMaxWidgets" status="run" time="0.006" classname="WidgetUsageTest" MaximumWidgets="12" MinimumWidgets="9" />
+    <testcase name="MinAndMaxWidgets" file="test.cpp" line="1" status="run" time="0.006" classname="WidgetUsageTest" MaximumWidgets="12" MinimumWidgets="9" />
   ...
 ```
 
@@ -2082,15 +2082,15 @@ could generate this report:
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="3" failures="1" errors="0" time="0.035" timestamp="2011-10-31T18:52:42" name="AllTests">
   <testsuite name="MathTest" tests="2" failures="1" errors="0" time="0.015">
-    <testcase name="Addition" status="run" time="0.007" classname="">
+    <testcase name="Addition" file="test.cpp" line="1" status="run" time="0.007" classname="">
       <failure message="Value of: add(1, 1)&#x0A;  Actual: 3&#x0A;Expected: 2" type="">...</failure>
       <failure message="Value of: add(1, -1)&#x0A;  Actual: 1&#x0A;Expected: 0" type="">...</failure>
     </testcase>
-    <testcase name="Subtraction" status="run" time="0.005" classname="">
+    <testcase name="Subtraction" file="test.cpp" line="2" status="run" time="0.005" classname="">
     </testcase>
   </testsuite>
   <testsuite name="LogicTest" tests="1" failures="0" errors="0" time="0.005">
-    <testcase name="NonContradiction" status="run" time="0.005" classname="">
+    <testcase name="NonContradiction" file="test.cpp" line="3" status="run" time="0.005" classname="">
     </testcase>
   </testsuite>
 </testsuites>
@@ -2107,6 +2107,8 @@ Things to note:
 
 *   The `timestamp` attribute records the local date and time of the test
     execution.
+
+*   The `file` and `line` attributes record the source file location, where the test was defined.
 
 *   Each `<failure>` element corresponds to a single failed googletest
     assertion.
@@ -2147,6 +2149,8 @@ The report format conforms to the following JSON Schema:
       "type": "object",
       "properties": {
         "name": { "type": "string" },
+        "file": { "type": "string" },
+        "line": { "type": "integer" },
         "status": {
           "type": "string",
           "enum": ["RUN", "NOTRUN"]
@@ -2224,6 +2228,8 @@ message TestCase {
 
 message TestInfo {
   string name = 1;
+  string file = 6;
+  int32 line = 7;
   enum Status {
     RUN = 0;
     NOTRUN = 1;
@@ -2267,6 +2273,8 @@ could generate this report:
       "testsuite": [
         {
           "name": "Addition",
+          "file": "test.cpp",
+          "line": 1,
           "status": "RUN",
           "time": "0.007s",
           "classname": "",
@@ -2283,6 +2291,8 @@ could generate this report:
         },
         {
           "name": "Subtraction",
+          "file": "test.cpp",
+          "line": 2,
           "status": "RUN",
           "time": "0.005s",
           "classname": ""
@@ -2298,6 +2308,8 @@ could generate this report:
       "testsuite": [
         {
           "name": "NonContradiction",
+          "file": "test.cpp",
+          "line": 3,
           "status": "RUN",
           "time": "0.005s",
           "classname": ""

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -518,8 +518,8 @@ Logs a property for the current test, test suite, or entire invocation of the
 test program. Only the last value for a given key is logged.
 
 The key must be a valid XML attribute name, and cannot conflict with the ones
-already used by GoogleTest (`name`, `status`, `time`, `classname`, `type_param`,
-and `value_param`).
+already used by GoogleTest (`name`, `file`, `line`, `status`, `time`, `classname`,
+`type_param`, and `value_param`).
 
 `RecordProperty` is `public static` so it can be called from utility functions
 that are not members of the test fixture.

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -4286,10 +4286,11 @@ void XmlUnitTestResultPrinter::OutputXmlTestInfo(::std::ostream* stream,
     OutputXmlAttribute(stream, kTestsuite, "type_param",
                        test_info.type_param());
   }
+
+  OutputXmlAttribute(stream, kTestsuite, "file", test_info.file());
+  OutputXmlAttribute(stream, kTestsuite, "line",
+                     StreamableToString(test_info.line()));
   if (GTEST_FLAG_GET(list_tests)) {
-    OutputXmlAttribute(stream, kTestsuite, "file", test_info.file());
-    OutputXmlAttribute(stream, kTestsuite, "line",
-                       StreamableToString(test_info.line()));
     *stream << " />\n";
     return;
   }
@@ -4744,11 +4745,14 @@ void JsonUnitTestResultPrinter::OutputJsonTestInfo(::std::ostream* stream,
     OutputJsonKey(stream, kTestsuite, "type_param", test_info.type_param(),
                   kIndent);
   }
+
+  OutputJsonKey(stream, kTestsuite, "file", test_info.file(), kIndent);
+  OutputJsonKey(stream, kTestsuite, "line", test_info.line(), kIndent, false);
   if (GTEST_FLAG_GET(list_tests)) {
-    OutputJsonKey(stream, kTestsuite, "file", test_info.file(), kIndent);
-    OutputJsonKey(stream, kTestsuite, "line", test_info.line(), kIndent, false);
     *stream << "\n" << Indent(8) << "}";
     return;
+  } else {
+    *stream << ",\n";
   }
 
   OutputJsonKey(stream, kTestsuite, "status",

--- a/googletest/test/googletest-json-outfiles-test.py
+++ b/googletest/test/googletest-json-outfiles-test.py
@@ -71,6 +71,8 @@ EXPECTED_1 = {
             u'*',
         u'testsuite': [{
             u'name': u'TestSomeProperties',
+            u'file': u'gtest_xml_outfile1_test_.cc',
+            u'line': 41,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'time': u'*',
@@ -115,6 +117,8 @@ EXPECTED_2 = {
             u'*',
         u'testsuite': [{
             u'name': u'TestSomeProperties',
+            u'file': u'gtest_xml_outfile2_test_.cc',
+            u'line': 41,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'timestamp': u'*',

--- a/googletest/test/googletest-json-output-unittest.py
+++ b/googletest/test/googletest-json-output-unittest.py
@@ -90,6 +90,8 @@ EXPECTED_NON_EMPTY = {
             u'*',
         u'testsuite': [{
             u'name': u'Succeeds',
+            u'file': u'gtest_xml_output_unittest_.cc',
+            u"line": 51,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'time': u'*',
@@ -114,6 +116,10 @@ EXPECTED_NON_EMPTY = {
         u'testsuite': [{
             u'name':
                 u'Fails',
+            u'file':
+                u'gtest_xml_output_unittest_.cc',
+            u'line':
+                59,
             u'status':
                 u'RUN',
             u'result':
@@ -148,6 +154,8 @@ EXPECTED_NON_EMPTY = {
             u'*',
         u'testsuite': [{
             u'name': u'DISABLED_test_not_run',
+            u'file': u'gtest_xml_output_unittest_.cc',
+            u'line': 66,
             u'status': u'NOTRUN',
             u'result': u'SUPPRESSED',
             u'time': u'*',
@@ -171,6 +179,8 @@ EXPECTED_NON_EMPTY = {
             u'*',
         u'testsuite': [{
             u'name': u'Skipped',
+            u'file': 'gtest_xml_output_unittest_.cc',
+            u'line': 73,
             u'status': u'RUN',
             u'result': u'SKIPPED',
             u'time': u'*',
@@ -178,6 +188,8 @@ EXPECTED_NON_EMPTY = {
             u'classname': u'SkippedTest'
         }, {
             u'name': u'SkippedWithMessage',
+            u'file': 'gtest_xml_output_unittest_.cc',
+            u'line': 77,
             u'status': u'RUN',
             u'result': u'SKIPPED',
             u'time': u'*',
@@ -186,6 +198,10 @@ EXPECTED_NON_EMPTY = {
         }, {
             u'name':
                 u'SkippedAfterFailure',
+            u'file':
+                'gtest_xml_output_unittest_.cc',
+            u'line':
+                81,
             u'status':
                 u'RUN',
             u'result':
@@ -220,6 +236,8 @@ EXPECTED_NON_EMPTY = {
             u'*',
         u'testsuite': [{
             u'name': u'Succeeds',
+            u'file': 'gtest_xml_output_unittest_.cc',
+            u'line': 86,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'time': u'*',
@@ -228,6 +246,10 @@ EXPECTED_NON_EMPTY = {
         }, {
             u'name':
                 u'Fails',
+            u'file':
+                u'gtest_xml_output_unittest_.cc',
+            u'line':
+                91,
             u'status':
                 u'RUN',
             u'result':
@@ -251,6 +273,8 @@ EXPECTED_NON_EMPTY = {
             }]
         }, {
             u'name': u'DISABLED_test',
+            u'file': u'gtest_xml_output_unittest_.cc',
+            u'line': 96,
             u'status': u'NOTRUN',
             u'result': u'SUPPRESSED',
             u'time': u'*',
@@ -275,6 +299,10 @@ EXPECTED_NON_EMPTY = {
         u'testsuite': [{
             u'name':
                 u'OutputsCData',
+            u'file':
+                u'gtest_xml_output_unittest_.cc',
+            u'line':
+                100,
             u'status':
                 u'RUN',
             u'result':
@@ -311,6 +339,10 @@ EXPECTED_NON_EMPTY = {
         u'testsuite': [{
             u'name':
                 u'InvalidCharactersInMessage',
+            u'file':
+                u'gtest_xml_output_unittest_.cc',
+            u'line':
+                107,
             u'status':
                 u'RUN',
             u'result':
@@ -349,6 +381,8 @@ EXPECTED_NON_EMPTY = {
             u'aye',
         u'testsuite': [{
             u'name': u'OneProperty',
+            u'file': u'gtest_xml_output_unittest_.cc',
+            u'line': 119,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'time': u'*',
@@ -357,6 +391,8 @@ EXPECTED_NON_EMPTY = {
             u'key_1': u'1'
         }, {
             u'name': u'IntValuedProperty',
+            u'file': u'gtest_xml_output_unittest_.cc',
+            u'line': 123,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'time': u'*',
@@ -365,6 +401,8 @@ EXPECTED_NON_EMPTY = {
             u'key_int': u'1'
         }, {
             u'name': u'ThreeProperties',
+            u'file': u'gtest_xml_output_unittest_.cc',
+            u'line': 127,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'time': u'*',
@@ -375,6 +413,8 @@ EXPECTED_NON_EMPTY = {
             u'key_3': u'3'
         }, {
             u'name': u'TwoValuesForOneKeyUsesLastValue',
+            u'file': u'gtest_xml_output_unittest_.cc',
+            u'line': 133,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'time': u'*',
@@ -399,6 +439,8 @@ EXPECTED_NON_EMPTY = {
             u'*',
         u'testsuite': [{
             u'name': u'RecordProperty',
+            u'file': u'gtest_xml_output_unittest_.cc',
+            u'line': 138,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'time': u'*',
@@ -407,6 +449,8 @@ EXPECTED_NON_EMPTY = {
             u'key': u'1'
         }, {
             u'name': u'ExternalUtilityThatCallsRecordIntValuedProperty',
+            u'file': u'gtest_xml_output_unittest_.cc',
+            u'line': 151,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'time': u'*',
@@ -415,6 +459,8 @@ EXPECTED_NON_EMPTY = {
             u'key_for_utility_int': u'1'
         }, {
             u'name': u'ExternalUtilityThatCallsRecordStringValuedProperty',
+            u'file': u'gtest_xml_output_unittest_.cc',
+            u'line': 155,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'time': u'*',
@@ -440,6 +486,8 @@ EXPECTED_NON_EMPTY = {
         u'testsuite': [{
             u'name': u'HasTypeParamAttribute',
             u'type_param': u'int',
+            u'file': u'gtest_xml_output_unittest_.cc',
+            u'line': 171,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'time': u'*',
@@ -464,6 +512,8 @@ EXPECTED_NON_EMPTY = {
         u'testsuite': [{
             u'name': u'HasTypeParamAttribute',
             u'type_param': u'long',
+            u'file': u'gtest_xml_output_unittest_.cc',
+            u'line': 171,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'time': u'*',
@@ -488,6 +538,8 @@ EXPECTED_NON_EMPTY = {
         u'testsuite': [{
             u'name': u'HasTypeParamAttribute',
             u'type_param': u'int',
+            u'file': u'gtest_xml_output_unittest_.cc',
+            u'line': 178,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'time': u'*',
@@ -512,6 +564,8 @@ EXPECTED_NON_EMPTY = {
         u'testsuite': [{
             u'name': u'HasTypeParamAttribute',
             u'type_param': u'long',
+            u'file': u'gtest_xml_output_unittest_.cc',
+            u'line': 178,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'time': u'*',
@@ -536,6 +590,8 @@ EXPECTED_NON_EMPTY = {
         u'testsuite': [{
             u'name': u'HasValueParamAttribute/0',
             u'value_param': u'33',
+            u'file': u'gtest_xml_output_unittest_.cc',
+            u'line': 162,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'time': u'*',
@@ -544,6 +600,8 @@ EXPECTED_NON_EMPTY = {
         }, {
             u'name': u'HasValueParamAttribute/1',
             u'value_param': u'42',
+            u'file': u'gtest_xml_output_unittest_.cc',
+            u'line': 162,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'time': u'*',
@@ -552,6 +610,8 @@ EXPECTED_NON_EMPTY = {
         }, {
             u'name': u'AnotherTestThatHasValueParamAttribute/0',
             u'value_param': u'33',
+            u'file': u'gtest_xml_output_unittest_.cc',
+            u'line': 163,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'time': u'*',
@@ -560,6 +620,8 @@ EXPECTED_NON_EMPTY = {
         }, {
             u'name': u'AnotherTestThatHasValueParamAttribute/1',
             u'value_param': u'42',
+            u'file': u'gtest_xml_output_unittest_.cc',
+            u'line': 163,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'time': u'*',
@@ -603,6 +665,8 @@ EXPECTED_FILTERED = {
             u'*',
         u'testsuite': [{
             u'name': u'Succeeds',
+            u'file': u'gtest_xml_output_unittest_.cc',
+            u"line": 51,
             u'status': u'RUN',
             u'result': u'COMPLETED',
             u'time': u'*',

--- a/googletest/test/gtest_json_test_utils.py
+++ b/googletest/test/gtest_json_test_utils.py
@@ -50,6 +50,8 @@ def normalize(obj):
     elif key == 'failure':
       value = re.sub(r'^.*[/\\](.*:)\d+\n', '\\1*\n', value)
       return re.sub(r'Stack trace:\n(.|\n)*', 'Stack trace:\n*', value)
+    elif key == 'file':
+      return re.sub(r'^.*[/\\](.*)', '\\1', value)
     else:
       return normalize(value)
   if isinstance(obj, dict):

--- a/googletest/test/gtest_xml_outfiles_test.py
+++ b/googletest/test/gtest_xml_outfiles_test.py
@@ -43,7 +43,7 @@ GTEST_OUTPUT_2_TEST = "gtest_xml_outfile2_test_"
 EXPECTED_XML_1 = """<?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="1" failures="0" disabled="0" errors="0" time="*" timestamp="*" name="AllTests">
   <testsuite name="PropertyOne" tests="1" failures="0" skipped="0" disabled="0" errors="0" time="*" timestamp="*">
-    <testcase name="TestSomeProperties" status="run" result="completed" time="*" timestamp="*" classname="PropertyOne">
+    <testcase name="TestSomeProperties" file="gtest_xml_outfile1_test_.cc" line="41" status="run" result="completed" time="*" timestamp="*" classname="PropertyOne">
       <properties>
         <property name="SetUpProp" value="1"/>
         <property name="TestSomeProperty" value="1"/>
@@ -57,7 +57,7 @@ EXPECTED_XML_1 = """<?xml version="1.0" encoding="UTF-8"?>
 EXPECTED_XML_2 = """<?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="1" failures="0" disabled="0" errors="0" time="*" timestamp="*" name="AllTests">
   <testsuite name="PropertyTwo" tests="1" failures="0" skipped="0" disabled="0" errors="0" time="*" timestamp="*">
-    <testcase name="TestSomeProperties" status="run" result="completed" time="*" timestamp="*" classname="PropertyTwo">
+    <testcase name="TestSomeProperties" file="gtest_xml_outfile2_test_.cc" line="41" status="run" result="completed" time="*" timestamp="*" classname="PropertyTwo">
       <properties>
         <property name="SetUpProp" value="2"/>
         <property name="TestSomeProperty" value="2"/>

--- a/googletest/test/gtest_xml_output_unittest.py
+++ b/googletest/test/gtest_xml_output_unittest.py
@@ -67,10 +67,10 @@ else:
 EXPECTED_NON_EMPTY_XML = """<?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="26" failures="5" disabled="2" errors="0" time="*" timestamp="*" name="AllTests" ad_hoc_property="42">
   <testsuite name="SuccessfulTest" tests="1" failures="0" disabled="0" skipped="0" errors="0" time="*" timestamp="*">
-    <testcase name="Succeeds" status="run" result="completed" time="*" timestamp="*" classname="SuccessfulTest"/>
+    <testcase name="Succeeds" file="gtest_xml_output_unittest_.cc" line="51" status="run" result="completed" time="*" timestamp="*" classname="SuccessfulTest"/>
   </testsuite>
   <testsuite name="FailedTest" tests="1" failures="1" disabled="0" skipped="0" errors="0" time="*" timestamp="*">
-    <testcase name="Fails" status="run" result="completed" time="*" timestamp="*" classname="FailedTest">
+    <testcase name="Fails" file="gtest_xml_output_unittest_.cc" line="59" status="run" result="completed" time="*" timestamp="*" classname="FailedTest">
       <failure message="gtest_xml_output_unittest_.cc:*&#x0A;Expected equality of these values:&#x0A;  1&#x0A;  2" type=""><![CDATA[gtest_xml_output_unittest_.cc:*
 Expected equality of these values:
   1
@@ -78,8 +78,8 @@ Expected equality of these values:
     </testcase>
   </testsuite>
   <testsuite name="MixedResultTest" tests="3" failures="1" disabled="1" skipped="0" errors="0" time="*" timestamp="*">
-    <testcase name="Succeeds" status="run" result="completed" time="*" timestamp="*" classname="MixedResultTest"/>
-    <testcase name="Fails" status="run" result="completed" time="*" timestamp="*" classname="MixedResultTest">
+    <testcase name="Succeeds" file="gtest_xml_output_unittest_.cc" line="86" status="run" result="completed" time="*" timestamp="*" classname="MixedResultTest"/>
+    <testcase name="Fails" file="gtest_xml_output_unittest_.cc" line="91" status="run" result="completed" time="*" timestamp="*" classname="MixedResultTest">
       <failure message="gtest_xml_output_unittest_.cc:*&#x0A;Expected equality of these values:&#x0A;  1&#x0A;  2" type=""><![CDATA[gtest_xml_output_unittest_.cc:*
 Expected equality of these values:
   1
@@ -89,35 +89,35 @@ Expected equality of these values:
   2
   3%(stack)s]]></failure>
     </testcase>
-    <testcase name="DISABLED_test" status="notrun" result="suppressed" time="*" timestamp="*" classname="MixedResultTest"/>
+    <testcase name="DISABLED_test" file="gtest_xml_output_unittest_.cc" line="96" status="notrun" result="suppressed" time="*" timestamp="*" classname="MixedResultTest"/>
   </testsuite>
   <testsuite name="XmlQuotingTest" tests="1" failures="1" disabled="0" skipped="0" errors="0" time="*" timestamp="*">
-    <testcase name="OutputsCData" status="run" result="completed" time="*" timestamp="*" classname="XmlQuotingTest">
+    <testcase name="OutputsCData" file="gtest_xml_output_unittest_.cc" line="100" status="run" result="completed" time="*" timestamp="*" classname="XmlQuotingTest">
       <failure message="gtest_xml_output_unittest_.cc:*&#x0A;Failed&#x0A;XML output: &lt;?xml encoding=&quot;utf-8&quot;&gt;&lt;top&gt;&lt;![CDATA[cdata text]]&gt;&lt;/top&gt;" type=""><![CDATA[gtest_xml_output_unittest_.cc:*
 Failed
 XML output: <?xml encoding="utf-8"><top><![CDATA[cdata text]]>]]&gt;<![CDATA[</top>%(stack)s]]></failure>
     </testcase>
   </testsuite>
   <testsuite name="InvalidCharactersTest" tests="1" failures="1" disabled="0" skipped="0" errors="0" time="*" timestamp="*">
-    <testcase name="InvalidCharactersInMessage" status="run" result="completed" time="*" timestamp="*" classname="InvalidCharactersTest">
+    <testcase name="InvalidCharactersInMessage" file="gtest_xml_output_unittest_.cc" line="107" status="run" result="completed" time="*" timestamp="*" classname="InvalidCharactersTest">
       <failure message="gtest_xml_output_unittest_.cc:*&#x0A;Failed&#x0A;Invalid characters in brackets []" type=""><![CDATA[gtest_xml_output_unittest_.cc:*
 Failed
 Invalid characters in brackets []%(stack)s]]></failure>
     </testcase>
   </testsuite>
   <testsuite name="DisabledTest" tests="1" failures="0" disabled="1" skipped="0" errors="0" time="*" timestamp="*">
-    <testcase name="DISABLED_test_not_run" status="notrun" result="suppressed" time="*" timestamp="*" classname="DisabledTest"/>
+    <testcase name="DISABLED_test_not_run" file="gtest_xml_output_unittest_.cc" line="66" status="notrun" result="suppressed" time="*" timestamp="*" classname="DisabledTest"/>
   </testsuite>
   <testsuite name="SkippedTest" tests="3" failures="1" disabled="0" skipped="2" errors="0" time="*" timestamp="*">
-    <testcase name="Skipped" status="run" result="skipped" time="*" timestamp="*" classname="SkippedTest">
+    <testcase name="Skipped" status="run" file="gtest_xml_output_unittest_.cc" line="73" result="skipped" time="*" timestamp="*" classname="SkippedTest">
       <skipped message="gtest_xml_output_unittest_.cc:*&#x0A;"><![CDATA[gtest_xml_output_unittest_.cc:*
 %(stack)s]]></skipped>
     </testcase>
-    <testcase name="SkippedWithMessage" status="run" result="skipped" time="*" timestamp="*" classname="SkippedTest">
+    <testcase name="SkippedWithMessage" file="gtest_xml_output_unittest_.cc" line="77" status="run" result="skipped" time="*" timestamp="*" classname="SkippedTest">
       <skipped message="gtest_xml_output_unittest_.cc:*&#x0A;It is good practice to tell why you skip a test."><![CDATA[gtest_xml_output_unittest_.cc:*
 It is good practice to tell why you skip a test.%(stack)s]]></skipped>
     </testcase>
-    <testcase name="SkippedAfterFailure" status="run" result="completed" time="*" timestamp="*" classname="SkippedTest">
+    <testcase name="SkippedAfterFailure" file="gtest_xml_output_unittest_.cc" line="81" status="run" result="completed" time="*" timestamp="*" classname="SkippedTest">
       <failure message="gtest_xml_output_unittest_.cc:*&#x0A;Expected equality of these values:&#x0A;  1&#x0A;  2" type=""><![CDATA[gtest_xml_output_unittest_.cc:*
 Expected equality of these values:
   1
@@ -128,63 +128,63 @@ It is good practice to tell why you skip a test.%(stack)s]]></skipped>
 
   </testsuite>
   <testsuite name="PropertyRecordingTest" tests="4" failures="0" disabled="0" skipped="0" errors="0" time="*" timestamp="*" SetUpTestSuite="yes" TearDownTestSuite="aye">
-    <testcase name="OneProperty" status="run" result="completed" time="*" timestamp="*" classname="PropertyRecordingTest">
+    <testcase name="OneProperty" file="gtest_xml_output_unittest_.cc" line="119" status="run" result="completed" time="*" timestamp="*" classname="PropertyRecordingTest">
       <properties>
         <property name="key_1" value="1"/>
       </properties>
     </testcase>
-    <testcase name="IntValuedProperty" status="run" result="completed" time="*" timestamp="*" classname="PropertyRecordingTest">
+    <testcase name="IntValuedProperty" file="gtest_xml_output_unittest_.cc" line="123" status="run" result="completed" time="*" timestamp="*" classname="PropertyRecordingTest">
       <properties>
         <property name="key_int" value="1"/>
       </properties>
     </testcase>
-    <testcase name="ThreeProperties" status="run" result="completed" time="*" timestamp="*" classname="PropertyRecordingTest">
+    <testcase name="ThreeProperties" file="gtest_xml_output_unittest_.cc" line="127" status="run" result="completed" time="*" timestamp="*" classname="PropertyRecordingTest">
       <properties>
         <property name="key_1" value="1"/>
         <property name="key_2" value="2"/>
         <property name="key_3" value="3"/>
       </properties>
     </testcase>
-    <testcase name="TwoValuesForOneKeyUsesLastValue" status="run" result="completed" time="*" timestamp="*" classname="PropertyRecordingTest">
+    <testcase name="TwoValuesForOneKeyUsesLastValue" file="gtest_xml_output_unittest_.cc" line="133" status="run" result="completed" time="*" timestamp="*" classname="PropertyRecordingTest">
       <properties>
         <property name="key_1" value="2"/>
       </properties>
     </testcase>
   </testsuite>
   <testsuite name="NoFixtureTest" tests="3" failures="0" disabled="0" skipped="0" errors="0" time="*" timestamp="*">
-     <testcase name="RecordProperty" status="run" result="completed" time="*" timestamp="*" classname="NoFixtureTest">
+     <testcase name="RecordProperty" file="gtest_xml_output_unittest_.cc" line="138" status="run" result="completed" time="*" timestamp="*" classname="NoFixtureTest">
        <properties>
          <property name="key" value="1"/>
        </properties>
      </testcase>
-     <testcase name="ExternalUtilityThatCallsRecordIntValuedProperty" status="run" result="completed" time="*" timestamp="*" classname="NoFixtureTest">
+     <testcase name="ExternalUtilityThatCallsRecordIntValuedProperty" file="gtest_xml_output_unittest_.cc" line="151" status="run" result="completed" time="*" timestamp="*" classname="NoFixtureTest">
        <properties>
          <property name="key_for_utility_int" value="1"/>
        </properties>
      </testcase>
-     <testcase name="ExternalUtilityThatCallsRecordStringValuedProperty" status="run" result="completed" time="*" timestamp="*" classname="NoFixtureTest">
+     <testcase name="ExternalUtilityThatCallsRecordStringValuedProperty" file="gtest_xml_output_unittest_.cc" line="155" status="run" result="completed" time="*" timestamp="*" classname="NoFixtureTest">
        <properties>
          <property name="key_for_utility_string" value="1"/>
        </properties>
      </testcase>
   </testsuite>
   <testsuite name="Single/ValueParamTest" tests="4" failures="0" disabled="0" skipped="0" errors="0" time="*" timestamp="*">
-    <testcase name="HasValueParamAttribute/0" value_param="33" status="run" result="completed" time="*" timestamp="*" classname="Single/ValueParamTest" />
-    <testcase name="HasValueParamAttribute/1" value_param="42" status="run" result="completed" time="*" timestamp="*" classname="Single/ValueParamTest" />
-    <testcase name="AnotherTestThatHasValueParamAttribute/0" value_param="33" status="run" result="completed" time="*" timestamp="*" classname="Single/ValueParamTest" />
-    <testcase name="AnotherTestThatHasValueParamAttribute/1" value_param="42" status="run" result="completed" time="*" timestamp="*" classname="Single/ValueParamTest" />
+    <testcase name="HasValueParamAttribute/0" file="gtest_xml_output_unittest_.cc" line="162" value_param="33" status="run" result="completed" time="*" timestamp="*" classname="Single/ValueParamTest" />
+    <testcase name="HasValueParamAttribute/1" file="gtest_xml_output_unittest_.cc" line="162" value_param="42" status="run" result="completed" time="*" timestamp="*" classname="Single/ValueParamTest" />
+    <testcase name="AnotherTestThatHasValueParamAttribute/0" file="gtest_xml_output_unittest_.cc" line="163" value_param="33" status="run" result="completed" time="*" timestamp="*" classname="Single/ValueParamTest" />
+    <testcase name="AnotherTestThatHasValueParamAttribute/1" file="gtest_xml_output_unittest_.cc" line="163" value_param="42" status="run" result="completed" time="*" timestamp="*" classname="Single/ValueParamTest" />
   </testsuite>
   <testsuite name="TypedTest/0" tests="1" failures="0" disabled="0" skipped="0" errors="0" time="*" timestamp="*">
-    <testcase name="HasTypeParamAttribute" type_param="*" status="run" result="completed" time="*" timestamp="*" classname="TypedTest/0" />
+    <testcase name="HasTypeParamAttribute" file="gtest_xml_output_unittest_.cc" line="171" type_param="*" status="run" result="completed" time="*" timestamp="*" classname="TypedTest/0" />
   </testsuite>
   <testsuite name="TypedTest/1" tests="1" failures="0" disabled="0" skipped="0" errors="0" time="*" timestamp="*">
-    <testcase name="HasTypeParamAttribute" type_param="*" status="run" result="completed" time="*" timestamp="*" classname="TypedTest/1" />
+    <testcase name="HasTypeParamAttribute" file="gtest_xml_output_unittest_.cc" line="171" type_param="*" status="run" result="completed" time="*" timestamp="*" classname="TypedTest/1" />
   </testsuite>
   <testsuite name="Single/TypeParameterizedTestSuite/0" tests="1" failures="0" disabled="0" skipped="0" errors="0" time="*" timestamp="*">
-    <testcase name="HasTypeParamAttribute" type_param="*" status="run" result="completed" time="*" timestamp="*" classname="Single/TypeParameterizedTestSuite/0" />
+    <testcase name="HasTypeParamAttribute" file="gtest_xml_output_unittest_.cc" line="178" type_param="*" status="run" result="completed" time="*" timestamp="*" classname="Single/TypeParameterizedTestSuite/0" />
   </testsuite>
   <testsuite name="Single/TypeParameterizedTestSuite/1" tests="1" failures="0" disabled="0" skipped="0" errors="0" time="*" timestamp="*">
-    <testcase name="HasTypeParamAttribute" type_param="*" status="run" result="completed" time="*" timestamp="*" classname="Single/TypeParameterizedTestSuite/1" />
+    <testcase name="HasTypeParamAttribute" file="gtest_xml_output_unittest_.cc" line="178" type_param="*" status="run" result="completed" time="*" timestamp="*" classname="Single/TypeParameterizedTestSuite/1" />
   </testsuite>
 </testsuites>""" % {
     'stack': STACK_TRACE_TEMPLATE
@@ -195,24 +195,24 @@ EXPECTED_FILTERED_TEST_XML = """<?xml version="1.0" encoding="UTF-8"?>
             timestamp="*" name="AllTests" ad_hoc_property="42">
   <testsuite name="SuccessfulTest" tests="1" failures="0" disabled="0" skipped="0"
              errors="0" time="*" timestamp="*">
-    <testcase name="Succeeds" status="run" result="completed" time="*" timestamp="*" classname="SuccessfulTest"/>
+    <testcase name="Succeeds" file="gtest_xml_output_unittest_.cc" line="51" status="run" result="completed" time="*" timestamp="*" classname="SuccessfulTest"/>
   </testsuite>
 </testsuites>"""
 
 EXPECTED_SHARDED_TEST_XML = """<?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="3" failures="0" disabled="0" errors="0" time="*" timestamp="*" name="AllTests" ad_hoc_property="42">
   <testsuite name="SuccessfulTest" tests="1" failures="0" disabled="0" skipped="0" errors="0" time="*" timestamp="*">
-    <testcase name="Succeeds" status="run" result="completed" time="*" timestamp="*" classname="SuccessfulTest"/>
+    <testcase name="Succeeds" file="gtest_xml_output_unittest_.cc" line="51" status="run" result="completed" time="*" timestamp="*" classname="SuccessfulTest"/>
   </testsuite>
   <testsuite name="PropertyRecordingTest" tests="1" failures="0" disabled="0" skipped="0" errors="0" time="*" timestamp="*" SetUpTestSuite="yes" TearDownTestSuite="aye">
-    <testcase name="IntValuedProperty" status="run" result="completed" time="*" timestamp="*" classname="PropertyRecordingTest">
+    <testcase name="IntValuedProperty" file="gtest_xml_output_unittest_.cc" line="123" status="run" result="completed" time="*" timestamp="*" classname="PropertyRecordingTest">
       <properties>
         <property name="key_int" value="1"/>
       </properties>
     </testcase>
   </testsuite>
   <testsuite name="Single/ValueParamTest" tests="1" failures="0" disabled="0" skipped="0" errors="0" time="*" timestamp="*">
-    <testcase name="HasValueParamAttribute/0" value_param="33" status="run" result="completed" time="*" timestamp="*" classname="Single/ValueParamTest" />
+    <testcase name="HasValueParamAttribute/0" file="gtest_xml_output_unittest_.cc" line="162" value_param="33" status="run" result="completed" time="*" timestamp="*" classname="Single/ValueParamTest" />
   </testsuite>
 </testsuites>"""
 

--- a/googletest/test/gtest_xml_test_utils.py
+++ b/googletest/test/gtest_xml_test_utils.py
@@ -170,6 +170,10 @@ class GTestXMLTestCase(gtest_test_utils.TestCase):
     *  The stack traces are removed.
     """
 
+    if element.tagName == 'testcase':
+      source_file = element.getAttributeNode('file')
+      if source_file:
+        source_file.value = re.sub(r'^.*[/\\](.*)', '\\1', source_file.value)
     if element.tagName in ('testsuites', 'testsuite', 'testcase'):
       timestamp = element.getAttributeNode('timestamp')
       timestamp.value = re.sub(r'^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\d$',


### PR DESCRIPTION
Adds support to `file` and `line` attributes/keys in xml and json file output.
See #3772