### PR TITLE
Fix quickstart-cmake documentation

### DIFF
--- a/docs/quickstart-cmake.md
+++ b/docs/quickstart-cmake.md
@@ -58,7 +58,8 @@ set(CMAKE_CXX_STANDARD 11)
 include(FetchContent)
 FetchContent_Declare(
   googletest
-  URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG release-1.11.0
 )
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
@@ -108,7 +109,7 @@ add_executable(
 )
 target_link_libraries(
   hello_test
-  gtest_main
+  GTest::gtest_main
 )
 
 include(GoogleTest)


### PR DESCRIPTION
CMake_FetchContent provides a popular way to make it easy to compile a package, by allowing CMake to fetch and compile the package's dependencies during the build process.

However, the instructions provided for using GoogleTest with CMake_FetchContent have issues that make it incompatible with usage of GoogleTest with find_package.

This issue occurs in the way users are instructed to link against GoogleTest:
```cmake
target_link_libraries(
  hello_test
  gtest_main
)
```
When GoogleTest is used with CMake_FetchContent, this will link against `GTest::gtest_main`, which is a CMake library target that causes `hello_test` to be linked against *both* `libgtest_main.so` as well as `libgtest.so`.

However, if a user instead uses GoogleTest via `find_package`, linking against `gtest_main` is now **incorrect** because CMake will attempt to link directly against `libgtest_main.so`, and *won't* link against the CMake library target. This results in confusing linker errors, due to the missing `libgtest.so` library.

The **correct** way to link against GoogleTest should be via `GTest::gtest_main`, which ensures that CMake will always use the GoogleTest library target, and the executable will always be linked against both `libgtest_main.so` and also `libgtest.so`. 

**Unfortunately**, the CMake contained in the zip file provided to FetchContent_Declare does not provide `GTest::gtest_main` as a library target, and so I've also amended the FetchContent declaration to use the git repository and the tag for version v1.11.0. This allows users to link against `GTest::gtest_main` both when consuming GoogleTest via the `find_package` interface and the `FetchContent` interface:
```cmake
include(FetchContent)
FetchContent_Declare(
  googletest
  GIT_REPOSITORY https://github.com/google/googletest.git
  GIT_TAG release-1.11.0
)
# For Windows: Prevent overriding the parent project's compiler/linker settings
set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
FetchContent_MakeAvailable(googletest)

enable_testing()

add_executable(
  hello_test
  hello_test.cc
)
target_link_libraries(
  hello_test
  GTest::gtest_main
)

include(GoogleTest)
gtest_discover_tests(hello_test)
```