### PR TITLE
FIX #3813 -- Trim out leading and trailing whitespaces from the file path when `IsEmpty()` function is called.

### DIFF
--- a/googletest/include/gtest/internal/gtest-filepath.h
+++ b/googletest/include/gtest/internal/gtest-filepath.h
@@ -109,8 +109,12 @@ class GTEST_API_ FilePath {
                                          const FilePath& base_name,
                                          const char* extension);
 
-  // Returns true if and only if the path is "".
-  bool IsEmpty() const { return pathname_.empty(); }
+  // Returns true if the path is empty.
+  bool IsEmpty() const {
+    std::string s = pathname_;
+    String::TrimString(&s);
+    return s.empty();
+  }
 
   // If input name has a trailing separator character, removes it and returns
   // the name, otherwise return the name string unmodified.

--- a/googletest/include/gtest/internal/gtest-string.h
+++ b/googletest/include/gtest/internal/gtest-string.h
@@ -163,7 +163,16 @@ class GTEST_API_ String {
   // Formats a byte as "%02X".
   static std::string FormatByte(unsigned char value);
 
+  // Trims out leading and trailing whitespaces in the given string.
+  static void TrimString(std::string *str);
+
  private:
+  // Trims out leading whitespaces in the given string.
+  static void LTrimString(std::string *str);
+
+  // Trims out trailing whitespaces in the given string.
+  static void RTrimString(std::string *str);
+
   String();  // Not meant to be instantiated.
 };           // class String
 

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -53,6 +53,7 @@
 #include <sstream>
 #include <unordered_set>
 #include <vector>
+#include <cctype>
 
 #include "gtest/gtest-assertion-result.h"
 #include "gtest/gtest-spi.h"
@@ -2166,6 +2167,27 @@ std::string String::FormatByte(unsigned char value) {
   ss << std::setfill('0') << std::setw(2) << std::hex << std::uppercase
      << static_cast<unsigned int>(value);
   return ss.str();
+}
+
+// Trims out leading whitespaces in the given string.
+void String::LTrimString(std::string *str) {
+  str->erase(str->begin(), std::find_if(str->begin(), str->end(),
+  [](unsigned char c) {
+    return !std::isspace(c);
+  }));
+}
+
+// Trims out trailing whitespaces in the given string.
+void String::RTrimString(std::string *str) {
+  str->erase(std::find_if(str->rbegin(), str->rend(), [](unsigned char c) {
+    return !std::isspace(c);
+  }).base(), str->end());
+}
+
+// Trims out leading and trailing whitespaces in the given string.
+void String::TrimString(std::string *str) {
+  String::LTrimString(str);
+  String::RTrimString(str);
 }
 
 // Converts the buffer in a stringstream to an std::string, converting NUL

--- a/googletest/test/googletest-filepath-test.cc
+++ b/googletest/test/googletest-filepath-test.cc
@@ -96,6 +96,7 @@ TEST(GetCurrentDirTest, ReturnsCurrentDir) {
 
 TEST(IsEmptyTest, ReturnsTrueForEmptyPath) {
   EXPECT_TRUE(FilePath("").IsEmpty());
+  EXPECT_TRUE(FilePath(" ").IsEmpty());
 }
 
 TEST(IsEmptyTest, ReturnsFalseForNonEmptyPath) {

--- a/googletest/test/googletest-filepath-test.cc
+++ b/googletest/test/googletest-filepath-test.cc
@@ -99,6 +99,10 @@ TEST(IsEmptyTest, ReturnsTrueForEmptyPath) {
   EXPECT_TRUE(FilePath(" ").IsEmpty());
 }
 
+TEST(IsEmptyTest, ReturnsTrueForNullBytes) {
+  EXPECT_TRUE(FilePath("\0").IsEmpty());
+}
+
 TEST(IsEmptyTest, ReturnsFalseForNonEmptyPath) {
   EXPECT_FALSE(FilePath("a").IsEmpty());
   EXPECT_FALSE(FilePath(".").IsEmpty());


### PR DESCRIPTION
`IsEmpty()` must return `true` for strings that are filled with just white-spaces.

FIX #3814

Signed-off-by: Ayush Joshi <ayush854032@gmail.com>