### PR TITLE
FIX #3815 -- Use `"unknown file"` string in case `base_name` provided is empty

### DIFF
--- a/googletest/src/gtest-filepath.cc
+++ b/googletest/src/gtest-filepath.cc
@@ -184,10 +184,13 @@ FilePath FilePath::MakeFileName(const FilePath& directory,
                                 const char* extension) {
   std::string file;
   if (number == 0) {
-    file = base_name.string() + "." + extension;
+    file = (base_name.IsEmpty() ? "unknown file"
+                               : base_name.string()) + "." + extension;
   } else {
     file =
-        base_name.string() + "_" + StreamableToString(number) + "." + extension;
+        (base_name.IsEmpty() ? "unknown file"
+                            : base_name.string()) + "_" +
+                            StreamableToString(number) + "." + extension;
   }
   return ConcatPaths(directory, FilePath(file));
 }

--- a/googletest/test/googletest-filepath-test.cc
+++ b/googletest/test/googletest-filepath-test.cc
@@ -272,6 +272,18 @@ TEST(MakeFileNameTest, GenerateWhenNumberIsNotZeroAndDirIsEmpty) {
   EXPECT_EQ("bar_14.xml", actual.string());
 }
 
+TEST(MakeFileNameTest, GenerateWhenNumberIsZeroAndBaseNameIsEmpty) {
+  FilePath actual = FilePath::MakeFileName(FilePath("foo" GTEST_PATH_SEP_),
+                                           FilePath(""), 0, "xml");
+  EXPECT_EQ("foo" GTEST_PATH_SEP_ "unknown file.xml", actual.string());
+}
+
+TEST(MakeFileNameTest, GenerateWhenNumberIsNotZeroButBaseIsEmpty) {
+  FilePath actual = FilePath::MakeFileName(FilePath("foo" GTEST_PATH_SEP_),
+                                           FilePath(""), 22, "xml");
+  EXPECT_EQ("foo" GTEST_PATH_SEP_ "unknown file_22.xml", actual.string());
+}
+
 TEST(ConcatPathsTest, WorksWhenDirDoesNotEndWithPathSep) {
   FilePath actual = FilePath::ConcatPaths(FilePath("foo"), FilePath("bar.xml"));
   EXPECT_EQ("foo" GTEST_PATH_SEP_ "bar.xml", actual.string());


### PR DESCRIPTION
The previous version of function MakeFIleName() in FilePath API doesn't check if the base_name is empty or not. In case the number passed to the function is 0 then MakeFileName() function will create path for hidden files in *nix systems which is something that we don't want.

FIX #3815

Signed-off-by: Ayush Joshi <ayush854032@gmail.com>