### PR TITLE
Fix #3800: make static analysis work better on assertions

### DIFF
--- a/googletest/include/gtest/gtest-assertion-result.h
+++ b/googletest/include/gtest/gtest-assertion-result.h
@@ -208,13 +208,13 @@ class GTEST_API_ AssertionResult {
   // Swap the contents of this AssertionResult with other.
   void swap(AssertionResult& other);
 
-  // Stores result of the assertion predicate.
-  bool success_;
   // Stores the message describing the condition in case the expectation
   // construct is not satisfied with the predicate's outcome.
   // Referenced via a pointer to avoid taking too much stack frame space
   // with test assertions.
   std::unique_ptr< ::std::string> message_;
+  // Stores result of the assertion predicate.
+  bool success_;
 };
 
 // Makes a successful assertion result.

--- a/googletest/include/gtest/gtest-assertion-result.h
+++ b/googletest/include/gtest/gtest-assertion-result.h
@@ -218,10 +218,10 @@ class GTEST_API_ AssertionResult {
 };
 
 // Makes a successful assertion result.
-GTEST_API_ AssertionResult AssertionSuccess();
+inline AssertionResult AssertionSuccess() { return AssertionResult(true); }
 
 // Makes a failed assertion result.
-GTEST_API_ AssertionResult AssertionFailure();
+inline AssertionResult AssertionFailure() { return AssertionResult(false); }
 
 // Makes a failed assertion result with the given failure message.
 // Deprecated; use AssertionFailure() << msg.

--- a/googletest/src/gtest-assertion-result.cc
+++ b/googletest/src/gtest-assertion-result.cc
@@ -43,16 +43,16 @@ namespace testing {
 // AssertionResult constructors.
 // Used in EXPECT_TRUE/FALSE(assertion_result).
 AssertionResult::AssertionResult(const AssertionResult& other)
-    : success_(other.success_),
-      message_(other.message_.get() != nullptr
+    : message_(other.message_.get() != nullptr
                    ? new ::std::string(*other.message_)
-                   : static_cast< ::std::string*>(nullptr)) {}
+                   : static_cast< ::std::string*>(nullptr)),
+      success_(other.success_) {}
 
 // Swaps two AssertionResults.
 void AssertionResult::swap(AssertionResult& other) {
   using std::swap;
-  swap(success_, other.success_);
   swap(message_, other.message_);
+  swap(success_, other.success_);
 }
 
 // Returns the assertion's negation. Used with EXPECT/ASSERT_FALSE.

--- a/googletest/src/gtest-assertion-result.cc
+++ b/googletest/src/gtest-assertion-result.cc
@@ -62,12 +62,6 @@ AssertionResult AssertionResult::operator!() const {
   return negation;
 }
 
-// Makes a successful assertion result.
-AssertionResult AssertionSuccess() { return AssertionResult(true); }
-
-// Makes a failed assertion result.
-AssertionResult AssertionFailure() { return AssertionResult(false); }
-
 // Makes a failed assertion result with the given failure message.
 // Deprecated; use AssertionFailure() << message.
 AssertionResult AssertionFailure(const Message& message) {


### PR DESCRIPTION
For example, `clang++ --analyze` will no longer flag a potential memory leak in this program:

```c++
#include <new>
#include <gtest/gtest.h>

TEST(Foo, Bar) {
  int *ptr = new (std::nothrow) int;
  ASSERT_NE(ptr, nullptr);
  delete ptr;
}
```
Previously, it would, because it couldn't figure out that the only time `ASSERT_NE` will return
early is if allocation failed.