### PR TITLE
List all the tests with their test suite names for easy parsing of the output by a program

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1786,6 +1786,15 @@ TestSuite2.
   TestName
 ```
 
+And if flag `--gtest_list_tests_verbosely` is used in conjunction with the above
+flag then the output format is the following:
+
+```none
+TestSuite1.TestName1
+TestSuite1.TestName2
+TestSuite2.TestName
+```
+
 None of the tests listed are actually run if the flag is provided. There is no
 corresponding environment variable for this flag.
 

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -105,6 +105,8 @@ GTEST_DECLARE_bool_(install_failure_signal_handler);
 // are actually run if the flag is provided.
 GTEST_DECLARE_bool_(list_tests);
 
+GTEST_DECLARE_bool_(list_tests_verbosely);
+
 // This flag controls whether Google Test emits a detailed XML report to a file
 // in addition to its normal textual output.
 GTEST_DECLARE_string_(output);

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -277,6 +277,10 @@ GTEST_DEFINE_bool_(
 
 GTEST_DEFINE_bool_(list_tests, false, "List all tests without running them.");
 
+GTEST_DEFINE_bool_(list_tests_verbosely, false, "List all tests verbosely "
+    "without running them.  Outputs the full name of the test.  Can be used "
+    "only in conjunction with --gtest_list_tests.");
+
 // The net priority order after flag processing is thus:
 //   --gtest_output command line flag
 //   GTEST_OUTPUT environment variable
@@ -6130,14 +6134,16 @@ void UnitTestImpl::ListTestsMatchingFilter() {
 
     for (size_t j = 0; j < test_suite->test_info_list().size(); j++) {
       const TestInfo* const test_info = test_suite->test_info_list()[j];
-      if (test_info->matches_filter_) {
+      if (!test_info->matches_filter_)
+        continue;
+      if (!GTEST_FLAG_GET(list_tests_verbosely)) {
         if (!printed_test_suite_name) {
           printed_test_suite_name = true;
           printf("%s.", test_suite->name());
           if (test_suite->type_param() != nullptr) {
             printf("  # %s = ", kTypeParamLabel);
-            // We print the type parameter on a single line to make
-            // the output easy to parse by a program.
+            // We print the type parameter on a single line to make the
+            // output easy to parse by a program.
             PrintOnOneLine(test_suite->type_param(), kMaxParamLength);
           }
           printf("\n");
@@ -6149,6 +6155,9 @@ void UnitTestImpl::ListTestsMatchingFilter() {
           // output easy to parse by a program.
           PrintOnOneLine(test_info->value_param(), kMaxParamLength);
         }
+        printf("\n");
+      } else {
+        printf("%s.%s", test_suite->name(), test_info->name());
         printf("\n");
       }
     }
@@ -6545,6 +6554,7 @@ static bool ParseGoogleTestFlag(const char* const arg) {
   GTEST_INTERNAL_PARSE_FLAG(filter);
   GTEST_INTERNAL_PARSE_FLAG(internal_run_death_test);
   GTEST_INTERNAL_PARSE_FLAG(list_tests);
+  GTEST_INTERNAL_PARSE_FLAG(list_tests_verbosely);
   GTEST_INTERNAL_PARSE_FLAG(output);
   GTEST_INTERNAL_PARSE_FLAG(brief);
   GTEST_INTERNAL_PARSE_FLAG(print_time);

--- a/googletest/test/googletest-list-tests-unittest.py
+++ b/googletest/test/googletest-list-tests-unittest.py
@@ -108,6 +108,38 @@ FooTest\.
   Test3
 """)
 
+# The expected output when running googletest-list-tests-unittest_ with
+# --gtest_list_tests and --gtest_list_tests_verbosely.
+EXPECTED_OUTPUT_VERBOSE_RE = re.compile(r"""FooDeathTest.Test1
+Foo\.Bar1
+Foo\.Bar2
+Foo\.DISABLED_Bar3
+Abc\.Xyz
+Abc\.Def
+FooBar\.Baz
+FooTest\.Test1
+FooTest\.DISABLED_Test2
+FooTest\.Test3
+TypedTest/0\.TestA
+TypedTest/0\.TestB
+TypedTest/1\.TestA
+TypedTest/1\.TestB
+TypedTest/2\.TestA
+TypedTest/2\.TestB
+My/TypeParamTest/0\.TestA
+My/TypeParamTest/0\.TestB
+My/TypeParamTest/1\.TestA
+My/TypeParamTest/1\.TestB
+My/TypeParamTest/2\.TestA
+My/TypeParamTest/2\.TestB
+MyInstantiation/ValueParamTest\.TestA/0
+MyInstantiation/ValueParamTest\.TestA/1
+MyInstantiation/ValueParamTest\.TestA/2
+MyInstantiation/ValueParamTest\.TestB/0
+MyInstantiation/ValueParamTest\.TestB/1
+MyInstantiation/ValueParamTest\.TestB/2
+""")
+
 # Utilities.
 
 
@@ -199,6 +231,14 @@ class GTestListTestsUnitTest(gtest_test_utils.TestCase):
     self.RunAndVerify(flag_value='1',
                       expected_output_re=EXPECTED_OUTPUT_FILTER_FOO_RE,
                       other_flag='--gtest_filter=Foo*')
+
+  def testWithVerboseFlag(self):
+    """Tests that --gtest_list_tests takes into account the
+    --gtest_list_tests_verbosely flag."""
+
+    self.RunAndVerify(flag_value='1',
+                      expected_output_re=EXPECTED_OUTPUT_VERBOSE_RE,
+                      other_flag='--gtest_list_tests_verbosely')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Use flag `--gtest_list_tests_verbosely` in conjunction with `--gtest_list_tests` to make `gtest` list the tests with their suite names.

FIX #3822

Signed-off-by: Ayush Joshi <ayush854032@gmail.com>