### PR TITLE
Add a manual anchor

### DIFF
--- a/docs/gmock_cook_book.md
+++ b/docs/gmock_cook_book.md
@@ -1485,7 +1485,7 @@ mock object and gMock.
 
 ## Setting Expectations
 
-### Knowing When to Expect {#UseOnCall}
+### <a id="knowing-when-to-expect"></a>Knowing When to Expect {#UseOnCall}
 
 **`ON_CALL`** is likely the *single most under-utilized construct* in gMock.
 


### PR DESCRIPTION
gMock outputs text like:
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/docs/gmock_cook_book.md#knowing-when-to-expect for details.

This pull request adds the manual anchor to make that link work.