### PR TITLE
Address compilation problems on Windows with IntelLLVM compiler using CMake

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -82,7 +82,9 @@ macro(config_compiler_and_linker)
     # http://stackoverflow.com/questions/3232669 explains the issue.
     set(cxx_base_flags "${cxx_base_flags} -wd4702")
     # Ensure MSVC treats source files as UTF-8 encoded.
-    set(cxx_base_flags "${cxx_base_flags} -utf-8")
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+      set(cxx_base_flags "${cxx_base_flags} -utf-8")
+    endif()
   elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(cxx_base_flags "-Wall -Wshadow -Wconversion")
     set(cxx_exception_flags "-fexceptions")


### PR DESCRIPTION
This adds the /utf-8 flag only for the real MSVC compiler.
The Intel icx.exe compiler does not recognize it, but it otherwise accepts most cl.exe compiler flags.