### PR TITLE
fix: warning for unused parameter

### DIFF
--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -1709,8 +1709,7 @@ class FunctionMocker<R(Args...)> final : public UntypedFunctionMockerBase {
                 internal::negation<can_print_result<T>>::value, int>::type = 0>
   R PerformActionAndPrintResult(const void* const untyped_action,
                                 ArgumentTuple&& args,
-                                const std::string& call_description,
-                                std::ostream& os) {
+                                const std::string& call_description) {
     return PerformAction(untyped_action, std::move(args), call_description);
   }
 

--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -1709,7 +1709,8 @@ class FunctionMocker<R(Args...)> final : public UntypedFunctionMockerBase {
                 internal::negation<can_print_result<T>>::value, int>::type = 0>
   R PerformActionAndPrintResult(const void* const untyped_action,
                                 ArgumentTuple&& args,
-                                const std::string& call_description) {
+                                const std::string& call_description,
+                                std::ostream& /* os */) {
     return PerformAction(untyped_action, std::move(args), call_description);
   }
 


### PR DESCRIPTION
We are encountering on https://github.com/azerothcore/mod-emblem-transfer/pull/27 this warning
 `gmock-spec-builders.h:1713:47: error: unused parameter 'os' [-Werror,-Wunused-parameter]`

full warning:
```
In file included from /home/runner/work/mod-emblem-transfer/mod-emblem-transfer/var/build/obj/googletest/googletest-src/googlemock/src/gmock-all.cc:39:
In file included from /home/runner/work/mod-emblem-transfer/mod-emblem-transfer/var/build/obj/googletest/googletest-src/googlemock/include/gmock/gmock.h:58:
In file included from /home/runner/work/mod-emblem-transfer/mod-emblem-transfer/var/build/obj/googletest/googletest-src/googlemock/include/gmock/gmock-function-mocker.h:43:
/home/runner/work/mod-emblem-transfer/mod-emblem-transfer/var/build/obj/googletest/googletest-src/googlemock/include/gmock/gmock-spec-builders.h:1713:47: error: unused parameter 'os' [-Werror,-Wunused-parameter]
                                std::ostream& os) {
                                              ^
1 error generated.
make[2]: *** [googletest/googletest-build/googlemock/CMakeFiles/gmock.dir/build.make:76: googletest/googletest-build/googlemock/CMakeFiles/gmock.dir/src/gmock-all.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1534: googletest/googletest-build/googlemock/CMakeFiles/gmock.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 11%] Building CXX object deps/g3dlite/CMakeFiles/g3dlib.dir/source/Vector4.cpp.o
[ 11%] Linking CXX static library libg3dlib.a
[ 11%] Built target g3dlib
make: *** [Makefile:146: all] Error 2
```

I restarted the build btw