### PR TITLE
Fix "unused variable" warning

### DIFF
--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -90,6 +90,7 @@
 namespace testing {
 namespace internal {
 
+#if GTEST_HAS_STREAM_REDIRECTION
 #if defined(_MSC_VER) || defined(__BORLANDC__)
 // MSVC and C++Builder do not provide a definition of STDERR_FILENO.
 const int kStdOutFileno = 1;
@@ -98,6 +99,7 @@ const int kStdErrFileno = 2;
 const int kStdOutFileno = STDOUT_FILENO;
 const int kStdErrFileno = STDERR_FILENO;
 #endif  // _MSC_VER
+#endif // GTEST_HAS_STREAM_REDIRECTION
 
 #if GTEST_OS_LINUX || GTEST_OS_GNU_HURD
 


### PR DESCRIPTION
Fix "unused variable" warning when GTEST_HAS_STREAM_REDIRECTION is set to false in gtest-port.cc

The three guarded constants are used only when `GTEST_HAS_STREAM_REDIRECTION` is enabled and currently trigger the following warnings when `GTEST_HAS_STREAM_REDIRECTION` is disabled:

```
1\googletest\googletest\src\gtest-port.cc(99,11): warning : unused variable 'kStdOutFileno' [-Wunused-const-variable]
1>const int kStdOutFileno = STDOUT_FILENO;
1>          ^
1>\googletest\googletest\src\gtest-port.cc(100,11): warning : unused variable 'kStdErrFileno' [-Wunused-const-variable]
1>const int kStdErrFileno = STDERR_FILENO;
```
