### PR TITLE
Move the LocalTime implementation to gtest-port.h so it can be customized for each port;

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -2405,4 +2405,32 @@ using Variant = ::std::variant<T...>;
 #endif  // __has_include
 #endif  // GTEST_HAS_ABSL
 
+#ifndef GTEST_INTERNAL_LOCALTIME_
+#include <time.h>  // NOLINT
+namespace testing {
+namespace internal {
+inline bool LocalTime(time_t seconds, struct tm* out) {
+#if defined(_MSC_VER)
+  return localtime_s(out, &seconds) == 0;
+#elif defined(__MINGW32__) || defined(__MINGW64__)
+  // MINGW <time.h> provides neither localtime_r nor localtime_s, but uses
+  // Windows' localtime(), which has a thread-local tm buffer.
+  struct tm* tm_ptr = localtime(&seconds);  // NOLINT
+  if (tm_ptr == nullptr) return false;
+  *out = *tm_ptr;
+  return true;
+#elif defined(__STDC_LIB_EXT1__)
+  // Uses localtime_s when available as localtime_r is only available from
+  // C23 standard.
+  return localtime_s(&seconds, out) != nullptr;
+#else
+  return localtime_r(&seconds, out) != nullptr;
+#endif
+}
+}  // namespace internal
+}  // namespace testing
+#endif // GTEST_INTERNAL_LOCALTIME_
+
+
+
 #endif  // GOOGLETEST_INCLUDE_GTEST_INTERNAL_GTEST_PORT_H_

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -4103,22 +4103,7 @@ std::string FormatTimeInMillisAsSeconds(TimeInMillis ms) {
 }
 
 static bool PortableLocaltime(time_t seconds, struct tm* out) {
-#if defined(_MSC_VER)
-  return localtime_s(out, &seconds) == 0;
-#elif defined(__MINGW32__) || defined(__MINGW64__)
-  // MINGW <time.h> provides neither localtime_r nor localtime_s, but uses
-  // Windows' localtime(), which has a thread-local tm buffer.
-  struct tm* tm_ptr = localtime(&seconds);  // NOLINT
-  if (tm_ptr == nullptr) return false;
-  *out = *tm_ptr;
-  return true;
-#elif defined(__STDC_LIB_EXT1__)
-  // Uses localtime_s when available as localtime_r is only available from
-  // C23 standard.
-  return localtime_s(&seconds, out) != nullptr;
-#else
-  return localtime_r(&seconds, out) != nullptr;
-#endif
+  return internal::LocalTime(seconds, out);
 }
 
 // Converts the given epoch time in milliseconds to a date string in the ISO


### PR DESCRIPTION
The logic to convert `time_t` to `tm` is unfortunately quite platform dependant; This PR moves the selection of the right `localtime` function (`localtime`, `localtime_r` or `localtime_s`) to `gtest-port.h` so it is easier to customize on new ports.