### PR TITLE
Fix for undefined symbol: testing::internal::Random::kMaxRange

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -372,6 +372,8 @@ GTEST_DEFINE_string_(
 namespace testing {
 namespace internal {
 
+const uint32_t Random::kMaxRange;
+
 // Generates a random number from [0, range), using a Linear
 // Congruential Generator (LCG).  Crashes if 'range' is 0 or greater
 // than kMaxRange.


### PR DESCRIPTION
Most compilers won't require static const to have a definition in an object file, but unfortunately some do... This PR fixes the following error in clang:

```
error : undefined symbol: testing::internal::Random::kMaxRange
```
