### PR TITLE
Use `-lm` on linux as well.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -120,15 +120,10 @@ cc_library(
     linkopts = select({
         ":qnx": ["-lregex"],
         ":windows": [],
-        ":freebsd": [
+        "//conditions:default": [
             "-lm",
             "-pthread",
         ],
-        ":openbsd": [
-            "-lm",
-            "-pthread",
-        ],
-        "//conditions:default": ["-pthread"],
     }),
     deps = select({
         ":has_absl": [


### PR DESCRIPTION
Not all compilers on linux add it implicitly.
It won't do any harm on those which do.

Closes #3878