### PR TITLE
Provide implicit cast of MockFunction to std::function

### DIFF
--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -1851,6 +1851,10 @@ class MockFunction<R(Args...)> {
     };
   }
 
+  operator std::function<R(Args...)>() {
+    return AsStdFunction();
+  }
+
   // Implementation detail: the expansion of the MOCK_METHOD macro.
   R Call(Args... args) {
     mock_.SetOwnerAndName(this, "Call");

--- a/googlemock/test/gmock-function-mocker_test.cc
+++ b/googlemock/test/gmock-function-mocker_test.cc
@@ -852,6 +852,25 @@ TEST(MockMethodMockFunctionTest, AsStdFunctionWithReferenceParameter) {
   EXPECT_EQ(-1, call(foo.AsStdFunction(), i));
 }
 
+TEST(MockMethodMockFunctionTest, ImplicitConversionToStdFunction) {
+  MockFunction<int(int)> foo;
+  auto call = [](const std::function<int(int)>& f, int i) { return f(i); };
+  EXPECT_CALL(foo, Call(1)).WillOnce(Return(-1));
+  EXPECT_CALL(foo, Call(2)).WillOnce(Return(-2));
+  EXPECT_EQ(-1, call(foo, 1));
+  EXPECT_EQ(-2, call(foo, 2));
+}
+
+TEST(MockMethodMockFunctionTest, ExplicitConversionToStdFunction) {
+  MockFunction<int(int)> foo;
+  auto call = [](const std::function<int(int)>& f, int i) { return f(i); };
+  EXPECT_CALL(foo, Call(1)).WillOnce(Return(-1));
+  EXPECT_CALL(foo, Call(2)).WillOnce(Return(-2));
+  const auto stdFuncFoo = static_cast<std::function<int(int)>>(foo);
+  EXPECT_EQ(-1, call(stdFuncFoo, 1));
+  EXPECT_EQ(-2, call(stdFuncFoo, 2));
+}
+
 namespace {
 
 template <typename Expected, typename F>


### PR DESCRIPTION
Add a type cast operator overload to allow implicit conversion of `MockFunction` to `std::function`. This reduces test code verbosity such as from
`Foo(mock_function.AsStdFunction());`
to
`Foo(mock_function);`