### PR TITLE
Add version check for QNX systems before linking regex

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -147,7 +147,7 @@ target_include_directories(gtest SYSTEM INTERFACE
 target_include_directories(gtest_main SYSTEM INTERFACE
   "$<BUILD_INTERFACE:${dirs}>"
   "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
-if(CMAKE_SYSTEM_NAME MATCHES "QNX")
+if(CMAKE_SYSTEM_NAME MATCHES "QNX" AND NOT (CMAKE_SYSTEM_VERSION VERSION_LESS 7.1.0))
   target_link_libraries(gtest PUBLIC regex)
 endif()
 target_link_libraries(gtest_main PUBLIC gtest)


### PR DESCRIPTION
This is a follow up for #3713. For QNX RTOS, regex functionality was broken out into a separate library libregex as of version 7.1. However, in earlier versions, the same functionality is present in the core libc, and libregex doesn't exist. This causes problems when trying to configure GoogleTest using a toolchain for QNX < 7.1.0.

You can see the difference by comparing point 2 in the reference page for two different versions:

Version 7.0: http://www.qnx.com/developers/docs/7.0.0/#com.qnx.doc.ide.userguide/topic/writing_test_programs.html

Version 7.1: https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.ide.userguide/topic/writing_test_programs.html

This PR allows GoogleTest to build successfully on QNX toolchains < 7.1.0.

cc @PhilipMourdjis the author of the previous PR that added this line.