### PR TITLE
Add testing framework to the PlatformIO Registry

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,47 @@
+{
+  "name": "googletest",
+  "keywords": "unit-testing, testing, tdd, testing-framework, gtest, gmock",
+  "description": "Google Testing and Mocking Framework",
+  "license": "BSD-3-Clause",
+  "homepage": "https://google.github.io/googletest/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/google/googletest.git"
+  },
+  "version": "1.11.0",
+  "frameworks": "*",
+  "platforms": [
+    "espressif32",
+    "espressif8266",
+    "native"
+  ],
+  "export": {
+    "include": [
+      "googlemock/include",
+      "googlemock/src",
+      "googletest/include",
+      "googletest/src"
+    ]
+  },
+  "headers": [
+    "gtest/gtest.h",
+    "gmock/gmock.h"
+  ],
+  "build": {
+    "flags": [
+      "-Igooglemock",
+      "-Igooglemock/include",
+      "-Igoogletest",
+      "-Igoogletest/include"
+    ],
+    "srcFilter": [
+      "-<*>",
+      "+<googletest/src/*.cc>",
+      "-<googletest/src/gtest-all.cc>",
+      "-<googletest/src/gtest_main.cc>",
+      "+<googlemock/src/*.cc>",
+      "-<googlemock/src/gmock-all.cc>",
+      "-<googlemock/src/gmock_main.cc>"
+    ]
+  }
+}


### PR DESCRIPTION
Hi,

This PR allows embedded developers to use GoogleTest with ESP32/ESP8266 and native platforms supported by [PlatformIO](https://platformio.org/).

The library is already manually added to the registry https://registry.platformio.org/libraries/google/googletest
Having `library.json` manifest in the repository root will allow developers to GoogleTest directly from the Github (dev-version).

There is also rich documentation on how to use GoogleTest with PlatformIO => https://docs.platformio.org/en/latest/advanced/unit-testing/frameworks/googletest.html

Regards,
The PlatformIO Team.