### PR TITLE
Cleanup of gtest.cc and a couple of unittests

### DIFF
--- a/googlemock/src/gmock-internal-utils.cc
+++ b/googlemock/src/gmock-internal-utils.cc
@@ -180,8 +180,7 @@ GTEST_API_ void Log(LogSeverity severity, const std::string& message,
       std::cout << "\n";
     }
     std::cout << "Stack trace:\n"
-              << ::testing::internal::GetCurrentOsStackTraceExceptTop(
-                     ::testing::UnitTest::GetInstance(), actual_to_skip);
+              << ::testing::internal::GetCurrentOsStackTraceExceptTop(actual_to_skip);
   }
   std::cout << ::std::flush;
 }

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -829,8 +829,7 @@ class TypeParameterizedTestSuite<Fixture, internal::None, Types> {
 // For example, if Foo() calls Bar(), which in turn calls
 // GetCurrentOsStackTraceExceptTop(..., 1), Foo() will be included in
 // the trace but Bar() and GetCurrentOsStackTraceExceptTop() won't.
-GTEST_API_ std::string GetCurrentOsStackTraceExceptTop(UnitTest* unit_test,
-                                                       int skip_count);
+GTEST_API_ std::string GetCurrentOsStackTraceExceptTop(int skip_count);
 
 // Helpers for suppressing warnings on unreachable code or constant
 // condition.

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -6245,7 +6245,7 @@ void UnitTestImpl::UnshuffleTests() {
 // GetCurrentOsStackTraceExceptTop(..., 1), Foo() will be included in
 // the trace but Bar() and GetCurrentOsStackTraceExceptTop() won't.
 GTEST_NO_INLINE_ GTEST_NO_TAIL_CALL_ std::string
-GetCurrentOsStackTraceExceptTop(UnitTest* /*unit_test*/, int skip_count) {
+GetCurrentOsStackTraceExceptTop(int skip_count) {
   // We pass skip_count + 1 to skip this wrapper function in addition
   // to what the user really wants to skip.
   return GetUnitTestImpl()->CurrentOsStackTraceExceptTop(skip_count + 1);

--- a/googletest/test/googletest-param-test-test.cc
+++ b/googletest/test/googletest-param-test-test.cc
@@ -821,7 +821,7 @@ TEST_F(PREFIX_WITH_MACRO(NamingTestNonParametrized),
 TEST(MacroNameing, LookupNames) {
   std::set<std::string> know_suite_names, know_test_names;
 
-  auto ins = testing::UnitTest::GetInstance();
+  const auto& ins = testing::UnitTest::GetInstance();
   int ts = 0;
   while (const testing::TestSuite* suite = ins->GetTestSuite(ts++)) {
     know_suite_names.insert(suite->name());
@@ -897,7 +897,7 @@ INSTANTIATE_TEST_SUITE_P(CustomParamNameLambda, CustomLambdaNamingTest,
                          });
 
 TEST(CustomNamingTest, CheckNameRegistry) {
-  ::testing::UnitTest* unit_test = ::testing::UnitTest::GetInstance();
+  const auto& unit_test = ::testing::UnitTest::GetInstance();
   std::set<std::string> test_names;
   for (int suite_num = 0; suite_num < unit_test->total_test_suite_count();
        ++suite_num) {

--- a/googletest/test/gtest-unittest-api_test.cc
+++ b/googletest/test/gtest-unittest-api_test.cc
@@ -106,7 +106,7 @@ const int kTypedTests = 1;
 // Since tests can be run in any order, the values the accessors that track
 // test execution (such as failed_test_count) can not be predicted.
 TEST(ApiTest, UnitTestImmutableAccessorsWork) {
-  UnitTest* unit_test = UnitTest::GetInstance();
+  const auto& unit_test = UnitTest::GetInstance();
 
   ASSERT_EQ(2 + kTypedTestSuites, unit_test->total_test_suite_count());
   EXPECT_EQ(1 + kTypedTestSuites, unit_test->test_suite_to_run_count());
@@ -224,7 +224,7 @@ TEST(DISABLED_Test, Dummy2) {}
 class FinalSuccessChecker : public Environment {
  protected:
   void TearDown() override {
-    UnitTest* unit_test = UnitTest::GetInstance();
+    const auto& unit_test = UnitTest::GetInstance();
 
     EXPECT_EQ(1 + kTypedTestSuites, unit_test->successful_test_suite_count());
     EXPECT_EQ(3 + kTypedTests, unit_test->successful_test_count());

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -7703,7 +7703,7 @@ auto* dynamic_test = testing::RegisterTest(
     __LINE__, []() -> DynamicUnitTestFixture* { return new DynamicTest; });
 
 TEST(RegisterTest, WasRegistered) {
-  auto* unittest = testing::UnitTest::GetInstance();
+  const auto& unittest = testing::UnitTest::GetInstance();
   for (int i = 0; i < unittest->total_test_suite_count(); ++i) {
     auto* tests = unittest->GetTestSuite(i);
     if (tests->name() != std::string("DynamicUnitTestFixture")) continue;


### PR DESCRIPTION
Changes:
1. Unused parameter was removed from `::testing::internal::GetCurrentOsStackTraceExceptTop`. This code was reworked more than a decade ago aaebfcdc4005afb22b68df61b58edd1ccc002913.
2. In a couple of tests return type was replaced with `const auto&`. It's a little bit more convenient because uncouples the implementation of the tests from the return type of `::GetInstance()`.

```
make test
Running tests...
...
100% tests passed, 0 tests failed out of 63

Total Test time (real) =   7.67 sec
```