### PR TITLE
gmock-actions: suppress warning about unreachable code

### DIFF
--- a/googlemock/include/gmock/gmock-actions.h
+++ b/googlemock/include/gmock/gmock-actions.h
@@ -148,7 +148,7 @@
 
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable : 4100)
+#pragma warning(disable : 4100 4702)
 #endif
 
 namespace testing {


### PR DESCRIPTION
MSVC warns about unreachable code in `BuiltInDefaultValueGetter::Get`.
The `C4702` warning has been disabled globally in the GoogleTest project itself
but might pop up in downstream code.