### PR TITLE
cmake: find python in order specified by PATH environment variable.

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -244,6 +244,12 @@ function(cxx_executable name dir libs)
     ${name} "${cxx_default}" "${libs}" "${dir}/${name}.cc" ${ARGN})
 endfunction()
 
+# CMP0094 policy enables finding a Python executable in the LOCATION order, as
+# specified by the PATH environment variable.
+if (POLICY CMP0094)
+  cmake_policy(SET CMP0094 NEW)
+endif()
+
 # Sets PYTHONINTERP_FOUND and PYTHON_EXECUTABLE.
 if ("${CMAKE_VERSION}" VERSION_LESS "3.12.0")
   find_package(PythonInterp)


### PR DESCRIPTION
CMake policy CMP0094 controls a lookup strategy used to find a Python executable:

* CMP0094=OLD selects a Python executable with a higher version.
* CMP0094=NEW selects a Python executable found earlier in PATH.

NEW behavior is critical in presence of a Python virtual environment established and activated, i.e. added to the PATH variable.

In case GoogleTest is embedded into a larger project, the result of `find_package(Python)` affects the whole build, not only GoogleTest component itself.