### PR TITLE
cmake: make PDB output directory match that of a static library.

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -162,7 +162,8 @@ function(cxx_library_with_type name type cxx_flags)
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+    PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
   # make PDBs match library name
   get_target_property(pdb_debug_postfix ${name} DEBUG_POSTFIX)
   set_target_properties(${name}


### PR DESCRIPTION
PDB files should be created at the same location as their primary artifact, which is either static library or a DLL.

On Windows, an artifact location is controlled by:

* RUNTIME_OUTPUT_DIRECTORY is a directory of a DLL artifact.
* ARCHIVE_OUTPUT_DIRECTORY is a directory of a LIB artifact.

A PDB file location is controlled:

* PDB_OUTPUT_DIRECTORY should match a directory of a DLL artifact.
* COMPILE_PDB_OUTPUT_DIRECTORY should match a directory of a LIB artifact.