### PR TITLE
Allow using re2 without absl dependency

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -393,8 +393,11 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 #if GTEST_HAS_ABSL
 // When using Abseil, RE2 is required.
 #include "absl/strings/string_view.h"
-#include "re2/re2.h"
 #define GTEST_USES_RE2 1
+#endif
+
+#if GTEST_USES_RE2
+#include "re2/re2.h"
 #elif GTEST_HAS_POSIX_RE
 #include <regex.h>  // NOLINT
 #define GTEST_USES_POSIX_RE 1
@@ -834,6 +837,34 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 #define GTEST_ATTRIBUTE_NO_SANITIZE_THREAD_
 #endif  // __clang__
 
+#if GTEST_HAS_ABSL
+// Always use absl::string_view for Matcher<> specializations if googletest
+// is built with absl support.
+#define GTEST_INTERNAL_HAS_STRING_VIEW 1
+#include "absl/strings/string_view.h"
+namespace testing {
+namespace internal {
+using StringView = ::absl::string_view;
+}  // namespace internal
+}  // namespace testing
+#else
+#ifdef __has_include
+#if __has_include(<string_view>) && __cplusplus >= 201703L
+// Otherwise for C++17 and higher use std::string_view for Matcher<>
+// specializations.
+#define GTEST_INTERNAL_HAS_STRING_VIEW 1
+#include <string_view>
+namespace testing {
+namespace internal {
+using StringView = ::std::string_view;
+}  // namespace internal
+}  // namespace testing
+// The case where absl is configured NOT to alias std::string_view is not
+// supported.
+#endif  // __has_include(<string_view>) && __cplusplus >= 201703L
+#endif  // __has_include
+#endif  // GTEST_HAS_ABSL
+
 namespace testing {
 
 class Message;
@@ -866,17 +897,17 @@ GTEST_API_ bool IsTrue(bool condition);
 // char*` constructors.
 class GTEST_API_ RE {
  public:
-  RE(absl::string_view regex) : regex_(regex) {}                  // NOLINT
-  RE(const char* regex) : RE(absl::string_view(regex)) {}         // NOLINT
-  RE(const std::string& regex) : RE(absl::string_view(regex)) {}  // NOLINT
+  RE(std::string_view regex) : regex_(regex) {}                  // NOLINT
+  RE(const char* regex) : RE(internal::StringView(regex)) {}         // NOLINT
+  RE(const std::string& regex) : RE(internal::StringView(regex)) {}  // NOLINT
   RE(const RE& other) : RE(other.pattern()) {}
 
   const std::string& pattern() const { return regex_.pattern(); }
 
-  static bool FullMatch(absl::string_view str, const RE& re) {
+  static bool FullMatch(internal::StringView str, const RE& re) {
     return RE2::FullMatch(str, re.regex_);
   }
-  static bool PartialMatch(absl::string_view str, const RE& re) {
+  static bool PartialMatch(internal::StringView str, const RE& re) {
     return RE2::PartialMatch(str, re.regex_);
   }
 
@@ -2350,34 +2381,6 @@ inline ::std::nullopt_t Nullopt() { return ::std::nullopt; }
 // The case where absl is configured NOT to alias std::optional is not
 // supported.
 #endif  // __has_include(<optional>) && __cplusplus >= 201703L
-#endif  // __has_include
-#endif  // GTEST_HAS_ABSL
-
-#if GTEST_HAS_ABSL
-// Always use absl::string_view for Matcher<> specializations if googletest
-// is built with absl support.
-#define GTEST_INTERNAL_HAS_STRING_VIEW 1
-#include "absl/strings/string_view.h"
-namespace testing {
-namespace internal {
-using StringView = ::absl::string_view;
-}  // namespace internal
-}  // namespace testing
-#else
-#ifdef __has_include
-#if __has_include(<string_view>) && __cplusplus >= 201703L
-// Otherwise for C++17 and higher use std::string_view for Matcher<>
-// specializations.
-#define GTEST_INTERNAL_HAS_STRING_VIEW 1
-#include <string_view>
-namespace testing {
-namespace internal {
-using StringView = ::std::string_view;
-}  // namespace internal
-}  // namespace testing
-// The case where absl is configured NOT to alias std::string_view is not
-// supported.
-#endif  // __has_include(<string_view>) && __cplusplus >= 201703L
 #endif  // __has_include
 #endif  // GTEST_HAS_ABSL
 


### PR DESCRIPTION
googletest 1.12 does not allow using re2 without abseil dependency out of the box.

In our case re2 is the only option to enable regexp support and absl dependency is not favourable.
This PR uses testing::internal::StringView typedef instead of the unconditional dependency on absl::string_view.