### PR TITLE
Fix compile error with MinGW-w64 GCC

### DIFF
--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -632,7 +632,7 @@ class GTEST_API_ TypedTestSuitePState {
                                         const char* registered_tests);
 
  private:
-  typedef ::std::map<std::string, CodeLocation, std::less<>> RegisteredTestsMap;
+  typedef ::std::map<std::string, CodeLocation> RegisteredTestsMap;
 
   bool registered_;
   RegisteredTestsMap registered_tests_;


### PR DESCRIPTION
Was getting this compile error:

```
$ ~/Downloads/bazel-5.2.0-windows-x86_64.exe  --batch build --compiler=mingw-gcc gtest gtest_main
INFO: Analyzed 2 targets (37 packages loaded, 242 targets configured).
INFO: Found 2 targets...
ERROR: C:/users/t_17_/source/repos/cryptopals/googletest/BUILD.bazel:80:11: Compiling googlemock/src/gmock-cardinalities.cc failed: (Exit 1): gcc failed: error executing command c:\msys64\mingw64\bin\gcc -std=gnu++0x -MD -MF bazel-out/x64_windows-fastbuild/bin/_objs/gtest/gmock-cardinalities.d -frandom-seed=bazel-out/x64_windows-fastbuild/bin/_objs/gtest/gmock-cardinalities.o ... (remaining 24 arguments skipped)
In file included from googletest/include/gtest/gtest-printers.h:114,
                 from googletest/include/gtest/gtest-matchers.h:48,
                 from googletest/include/gtest/internal/gtest-death-test-internal.h:46,
                 from googletest/include/gtest/gtest-death-test.h:43,
                 from googletest/include/gtest/gtest.h:60,
                 from googlemock/include/gmock/gmock-cardinalities.h:48,
                 from googlemock/src/gmock-cardinalities.cc:34:
googletest/include/gtest/internal/gtest-internal.h:635:58: error: type/value mismatch at argument 3 in template parameter list for 'template<class _Key, class _Tp, class _Compare, class _Alloc> class std::map'
  635 |   typedef ::std::map<std::string, CodeLocation, std::less> RegisteredTestsMap;
      |                                                          ^
googletest/include/gtest/internal/gtest-internal.h:635:58: note:   expected a type, got 'less'
googletest/include/gtest/internal/gtest-internal.h: In member function 'bool testing::internal::TypedTestSuitePState::AddTestName(const char*, int, const char*, const char*)':
googletest/include/gtest/internal/gtest-internal.h:612:23: error: request for member 'insert' in '((testing::internal::TypedTestSuitePState*)this)->testing::internal::TypedTestSuitePState::registered_tests_', which is of non-class type 'testing::internal::TypedTestSuitePState::RegisteredTestsMap' {aka 'int'}
  612 |     registered_tests_.insert(
      |                       ^~~~~~
googletest/include/gtest/internal/gtest-internal.h: In member function 'bool testing::internal::TypedTestSuitePState::TestExists(const std::string&) const':
googletest/include/gtest/internal/gtest-internal.h:618:30: error: request for member 'count' in '((const testing::internal::TypedTestSuitePState*)this)->testing::internal::TypedTestSuitePState::registered_tests_', which is of non-class type 'const testing::internal::TypedTestSuitePState::RegisteredTestsMap' {aka 'const int'}
  618 |     return registered_tests_.count(test_name) > 0;
      |                              ^~~~~
googletest/include/gtest/internal/gtest-internal.h: In member function 'const testing::internal::CodeLocation& testing::internal::TypedTestSuitePState::GetCodeLocation(const std::string&) const':
googletest/include/gtest/internal/gtest-internal.h:622:40: error: qualified-id in declaration before 'it'
  622 |     RegisteredTestsMap::const_iterator it = registered_tests_.find(test_name);
      |                                        ^~
In file included from googlemock/include/gmock/internal/gmock-port.h:57,
                 from googlemock/include/gmock/gmock-cardinalities.h:47:
googletest/include/gtest/internal/gtest-internal.h:623:5: error: 'it' was not declared in this scope; did you mean 'int'?
  623 |     GTEST_CHECK_(it != registered_tests_.end());
      |     ^~~~~~~~~~~~
googletest/include/gtest/internal/gtest-internal.h:623:5: error: request for member 'end' in '((const testing::internal::TypedTestSuitePState*)this)->testing::internal::TypedTestSuitePState::registered_tests_', which is of non-class type 'const testing::internal::TypedTestSuitePState::RegisteredTestsMap' {aka 'const int'}
  623 |     GTEST_CHECK_(it != registered_tests_.end());
      |     ^~~~~~~~~~~~
googletest/include/gtest/internal/gtest-internal.h:624:12: error: 'it' was not declared in this scope; did you mean 'int'?
  624 |     return it->second;
      |            ^~
      |            int
INFO: Elapsed time: 10.259s, Critical Path: 3.90s
INFO: 5 processes: 5 internal.
FAILED: Build did NOT complete successfully
```

The default value of the 3rd template parameter of `std::map` [is `std::less<Key>`](https://en.cppreference.com/w/cpp/container/map), so no need to specify it partially.

I'm using the latest GCC available in MSYS2:

```
$ /mingw64/bin/g++ --version
g++.exe (Rev3, Built by MSYS2 project) 12.1.0
Copyright (C) 2022 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```