### PR TITLE
modify some contents in sample2.cc

### DIFF
--- a/googletest/samples/sample2.cc
+++ b/googletest/samples/sample2.cc
@@ -47,8 +47,6 @@ const char* MyString::CloneCString(const char* a_c_string) {
 // Sets the 0-terminated C string this MyString object
 // represents.
 void MyString::Set(const char* a_c_string) {
-  // Makes sure this works when c_string == c_string_
   const char* const temp = MyString::CloneCString(a_c_string);
-  delete[] c_string_;
   c_string_ = temp;
 }


### PR DESCRIPTION
Hi,
1. Copy constructor is used for constructing a new object. So `c_string_ = nullptr`, I don't know the effect of `delete[] c_string_`.
2. I don't know why has `c_string == c_string_` comment, and don't have self-assignment situation?