### PR TITLE
Suppress a clang-tidy false positive

### DIFF
--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -985,7 +985,7 @@ class TypedExpectation<R(Args...)> : public ExpectationBase {
     return WillOnce(Action<F>(ActionAdaptor{
         std::make_shared<OnceAction<F>>(std::move(once_action)),
     }));
-  }
+  }  // NOLINT
 
   // Fallback overload: accept Action<F> objects and those actions that define
   // `operator Action<F>` but not `operator OnceAction<F>`.


### PR DESCRIPTION
In some tests we got the following error:

  /usr/local/include/gmock/gmock-spec-builders.h:988:3: note: Potential leak of memory pointed to by field '_M_pi'

This seems to be a false positive, so we simply suppress it.

See #2442.