### PR TITLE
bazel: move -std=c++14 to .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --cxxopt=-std=c++14

--- a/.github/workflows/gtest-ci.yml
+++ b/.github/workflows/gtest-ci.yml
@@ -4,9 +4,6 @@ on:
   push:
   pull_request:
 
-env:
-  BAZEL_CXXOPTS: -std=c++14
-
 jobs:
   Linux:
     runs-on: ubuntu-latest
@@ -17,7 +14,7 @@ jobs:
         fetch-depth: 0
 
     - name: Tests
-      run: bazel test --cxxopt=-std=c++14 --features=external_include_paths --test_output=errors ...
+      run: bazel test --features=external_include_paths --test_output=errors ...
 
   MacOs:
     runs-on: macos-latest
@@ -28,7 +25,7 @@ jobs:
         fetch-depth: 0
 
     - name: Tests
-      run:  bazel test --cxxopt=-std=c++14 --features=external_include_paths --test_output=errors ...
+      run:  bazel test --features=external_include_paths --test_output=errors ...
 
 
   Windows:
@@ -40,4 +37,4 @@ jobs:
         fetch-depth: 0
 
     - name: Tests
-      run: bazel test --cxxopt=-std=c++14 --features=external_include_paths --test_output=errors ...
+      run: bazel test --features=external_include_paths --test_output=errors ...

--- a/ci/linux-presubmit.sh
+++ b/ci/linux-presubmit.sh
@@ -72,7 +72,6 @@ time docker run \
   --workdir="/src" \
   --rm \
   --env="CC=/usr/local/bin/gcc" \
-  --env="BAZEL_CXXOPTS=-std=c++14" \
   ${LINUX_GCC_FLOOR_CONTAINER} \
     /usr/local/bin/bazel test ... \
       --copt="-Wall" \

--- a/ci/macos-presubmit.sh
+++ b/ci/macos-presubmit.sh
@@ -66,7 +66,6 @@ for absl in 0 1; do
   ${BAZEL_BIN} test ... \
     --copt="-Wall" \
     --copt="-Werror" \
-    --cxxopt="-std=c++14" \
     --define="absl=${absl}" \
     --features=external_include_paths \
     --keep_going \


### PR DESCRIPTION
Bazel defaults to -std=c++11 on macOS which gtest doesn't support.