### PR TITLE
Don't set GTEST_HAS_CXXABI_H_ to 1 if __NuttX__ is defined

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -780,7 +780,7 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 
 // _LIBCPP_VERSION is defined by the libc++ library from the LLVM project.
 #if !defined(GTEST_HAS_CXXABI_H_)
-#if defined(__GLIBCXX__) || (defined(_LIBCPP_VERSION) && !defined(_MSC_VER))
+#if !defined(__NuttX__) && (defined(__GLIBCXX__) || (defined(_LIBCPP_VERSION) && !defined(_MSC_VER)))
 #define GTEST_HAS_CXXABI_H_ 1
 #else
 #define GTEST_HAS_CXXABI_H_ 0


### PR DESCRIPTION
since NuttX(https://github.com/apache/incubator-nuttx) doesn't support cxxabi
