### PR TITLE
[document] Add vcpkg instruction step

### DIFF
--- a/googletest/README.md
+++ b/googletest/README.md
@@ -131,6 +131,29 @@ is not feasible, for example in a C project using GoogleTest for validation,
 then it can be specified by adding it to the options for cmake via the
 `DCMAKE_CXX_FLAGS` option.
 
+### Build with vcpkg
+
+vcpkg is a package manager that supports all platforms, you can use vcpkg to
+build and use googletest.
+
+#### Build googletest
+
+You can use the following steps to build googletest:
+```bash
+git clone https://github.com/microsoft/vcpkg.git
+./bootstrap-vcpkg.bat # for powershell
+./bootstrap-vcpkg.sh # for bash
+./vcpkg install gtest
+```
+
+#### Incorporating Into An Existing CMake Project
+
+You can easily use the following commands to use googletest in your custom
+project and follow the output prompts:
+```
+./vcpkg integrate install
+```
+
 ### Tweaking GoogleTest
 
 GoogleTest can be used in diverse environments. The default configuration may


### PR DESCRIPTION
`googletest` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `googletest` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `googletest`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/gtest/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)