### PR TITLE
Fix nvc++ compiler warnings

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -771,7 +771,7 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 // the marked function.
 #define GTEST_NO_TAIL_CALL_ __attribute__((disable_tail_calls))
 #endif
-#elif __GNUC__
+#elif __GNUC__ && (! __NVCOMPILER)
 #define GTEST_NO_TAIL_CALL_ \
   __attribute__((optimize("no-optimize-sibling-calls")))
 #else


### PR DESCRIPTION
When I build the current stable branch (760060059fb746018a9849234e02dc9bf003861b) of the reference mdspan implementation (https://github.com/kokkos/mdspan) with nvc++ (either 22.7 or a pre-release version), I get a couple build warnings like the following.
```
".../tests/googletest-src/googletest/src/gtest-internal-inl.h", line 636: warning: unknown attribute "optimize" [unrecognized_attribute]
        GTEST_NO_INLINE_ GTEST_NO_TAIL_CALL_;
                         ^
```
Issue https://github.com/google/googletest/issues/3849 explains: GTest is using `#elif __GNUC__` to protect use of `__attribute__((optimize("no-optimize-sibling-calls")))`.  Many compilers that are not GCC define `__GNUC__` to express some degree of compatibility with GCC extensions.  This includes nvc++.  nvc++ does not understand this attribute, so it emits a warning.  My fix just disables use of that attribute if `__NVCOMPILER` is defined.

I've tested this fix with a pre-release (post-22.7) version of nvc++.  It prevents the warning, and the reference mdspan implementation's tests build and run correctly.

Fixes #3849.