### PR TITLE
Update TEST_P to adhere to C++ guidelines

### DIFF
--- a/googletest/include/gtest/gtest-param-test.h
+++ b/googletest/include/gtest/gtest-param-test.h
@@ -412,11 +412,17 @@ internal::CartesianProductHolder<Generator...> Combine(const Generator&... g) {
       : public test_suite_name {                                               \
    public:                                                                     \
     GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)() {}                    \
+    ~GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)() override = default;  \
     GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)                         \
     (const GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) &) = delete;     \
     GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) & operator=(            \
         const GTEST_TEST_CLASS_NAME_(test_suite_name,                          \
                                      test_name) &) = delete; /* NOLINT */      \
+    GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)                         \
+    (GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) &&) noexcept = delete; \
+    GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) & operator=(            \
+        GTEST_TEST_CLASS_NAME_(test_suite_name,                                \
+                               test_name) &&) noexcept = delete; /* NOLINT */  \
     void TestBody() override;                                                  \
                                                                                \
    private:                                                                    \

--- a/googletest/include/gtest/gtest-param-test.h
+++ b/googletest/include/gtest/gtest-param-test.h
@@ -412,6 +412,11 @@ internal::CartesianProductHolder<Generator...> Combine(const Generator&... g) {
       : public test_suite_name {                                               \
    public:                                                                     \
     GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)() {}                    \
+    GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)                         \
+    (const GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) &) = delete;     \
+    GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) & operator=(            \
+        const GTEST_TEST_CLASS_NAME_(test_suite_name,                          \
+                                     test_name) &) = delete; /* NOLINT */      \
     void TestBody() override;                                                  \
                                                                                \
    private:                                                                    \
@@ -429,11 +434,6 @@ internal::CartesianProductHolder<Generator...> Combine(const Generator&... g) {
       return 0;                                                                \
     }                                                                          \
     static int gtest_registering_dummy_ GTEST_ATTRIBUTE_UNUSED_;               \
-    GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)                         \
-    (const GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) &) = delete;     \
-    GTEST_TEST_CLASS_NAME_(test_suite_name, test_name) & operator=(            \
-        const GTEST_TEST_CLASS_NAME_(test_suite_name,                          \
-                                     test_name) &) = delete; /* NOLINT */      \
   };                                                                           \
   int GTEST_TEST_CLASS_NAME_(test_suite_name,                                  \
                              test_name)::gtest_registering_dummy_ =            \


### PR DESCRIPTION
Update the `TEST_P` macro so that test classes adhere to the `Google C++ Style Guide` and the `C++ Core Guidelines`.

* Make the copy constructor and the assignment operator public according to [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html#Copyable_Movable_Types).
* Follow "The rule of five" according to [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c21-if-you-define-or-delete-any-copy-move-or-destructor-function-define-or-delete-them-all):
  - Define default destructor
  - Define deleted move constructor and move assignment operator

Previous implementation only disabled the copy constructor and the assignment operator, which did not adhere to the [rule of five](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c21-if-you-define-or-delete-any-copy-move-or-destructor-function-define-or-delete-them-all). This was indicated by static code analysis tools like clang-tidy, using the rule `cppcoreguidelines-special-member-functions`.

This change is similar to the outcome of #2639, which covered the `TEST()` and `TEST_F()` macros.
The macros are now consistent.

- [X] Run clang-format
- [X] Testing Google Test and Google Mock Themselves