### PR TITLE
Port GoogleTest to QuRT (Hexagon RTOS)

### DIFF
--- a/googlemock/src/gmock-spec-builders.cc
+++ b/googlemock/src/gmock-spec-builders.cc
@@ -51,6 +51,9 @@
 #if GTEST_OS_CYGWIN || GTEST_OS_LINUX || GTEST_OS_MAC
 #include <unistd.h>  // NOLINT
 #endif
+#if GTEST_OS_QURT
+#include <qurt_event.h>
+#endif
 
 // Silence C4800 (C4800: 'int *const ': forcing value
 // to bool 'true' or 'false') for MSVC 15
@@ -519,8 +522,12 @@ class MockObjectRegistry {
       // RUN_ALL_TESTS() has already returned when this destructor is
       // called.  Therefore we cannot use the normal Google Test
       // failure reporting mechanism.
+#if GTEST_OS_QURT
+      qurt_exception_raise_fatal();
+#else
       _exit(1);  // We cannot call exit() as it is not reentrant and
                  // may already have been called.
+#endif
     }
   }
 

--- a/googletest/include/gtest/internal/gtest-port-arch.h
+++ b/googletest/include/gtest/internal/gtest-port-arch.h
@@ -111,6 +111,8 @@
 #define GTEST_OS_ESP32 1
 #elif defined(__XTENSA__)
 #define GTEST_OS_XTENSA 1
+#elif defined(__hexagon__)
+#define GTEST_OS_QURT 1
 #endif  // __CYGWIN__
 
 #endif  // GOOGLETEST_INCLUDE_GTEST_INTERNAL_GTEST_PORT_ARCH_H_

--- a/googletest/src/gtest-filepath.cc
+++ b/googletest/src/gtest-filepath.cc
@@ -96,7 +96,7 @@ static bool IsPathSeparator(char c) {
 FilePath FilePath::GetCurrentDir() {
 #if GTEST_OS_WINDOWS_MOBILE || GTEST_OS_WINDOWS_PHONE ||         \
     GTEST_OS_WINDOWS_RT || GTEST_OS_ESP8266 || GTEST_OS_ESP32 || \
-    GTEST_OS_XTENSA
+    GTEST_OS_XTENSA || GTEST_OS_QURT
   // These platforms do not have a current directory, so we just return
   // something reasonable.
   return FilePath(kCurrentDirectoryString);
@@ -323,7 +323,7 @@ bool FilePath::CreateFolder() const {
   delete[] unicode;
 #elif GTEST_OS_WINDOWS
   int result = _mkdir(pathname_.c_str());
-#elif GTEST_OS_ESP8266 || GTEST_OS_XTENSA
+#elif GTEST_OS_ESP8266 || GTEST_OS_XTENSA || GTEST_OS_QURT
   // do nothing
   int result = 0;
 #else

--- a/googletest/src/gtest_main.cc
+++ b/googletest/src/gtest_main.cc
@@ -32,9 +32,12 @@
 #include "gtest/gtest.h"
 
 #if GTEST_OS_ESP8266 || GTEST_OS_ESP32
+// Aduino-like platforms: program entry points are setup/loop instead of main.
+
 #if GTEST_OS_ESP8266
 extern "C" {
 #endif
+
 void setup() { testing::InitGoogleTest(); }
 
 void loop() { RUN_ALL_TESTS(); }
@@ -43,7 +46,16 @@ void loop() { RUN_ALL_TESTS(); }
 }
 #endif
 
+#elif GTEST_OS_QURT
+// QuRT: program entry point is main, but argc/argv are unusable.
+
+GTEST_API_ int main() {
+  printf("Running main() from %s\n", __FILE__);
+  testing::InitGoogleTest();
+  return RUN_ALL_TESTS();
+}
 #else
+// Normal platforms: program entry point is main, argc/argv are initialized.
 
 GTEST_API_ int main(int argc, char **argv) {
   printf("Running main() from %s\n", __FILE__);


### PR DESCRIPTION
This change makes possible to build and use Google Test framework on Hexagon DSPs