### PR TITLE
Fix Clang compiler settings when used with option GTEST_FORCE_SHARED_CRT=ON

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -21,8 +21,8 @@ endif (POLICY CMP0054)
 # This must be a macro(), as inside a function string() can only
 # update variables in the function scope.
 macro(fix_default_compiler_settings_)
-  if (MSVC)
-    # For MSVC, CMake sets certain flags to defaults we want to override.
+  if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC|Clang")
+    # For MSVC and Clang, CMake sets certain flags to defaults we want to override.
     # This replacement code is taken from sample in the CMake Wiki at
     # https://gitlab.kitware.com/cmake/community/wikis/FAQ#dynamic-replace.
     foreach (flag_var
@@ -39,6 +39,7 @@ macro(fix_default_compiler_settings_)
         # on CRT DLLs being available. CMake always defaults to using shared
         # CRT libraries, so we override that default here.
         string(REPLACE "/MD" "-MT" ${flag_var} "${${flag_var}}")
+        string(REPLACE "-D_DLL" "" ${flag_var} "${${flag_var}}")
       endif()
 
       # We prefer more strict warning checking for building Google Test.


### PR DESCRIPTION
…CRT=ON

Clang (on Windows) selects MSVC RuntimeLibrary with the following defines:
* _MT for MultiThreaded (static runtime lib),
* _MT and _DLL for MultiThreadedDLL (dynamic runtime lib) See: https://learn.microsoft.com/en-us/visualstudio/msbuild/clangcompile-task?view=vs-2022.

The fix allows Clang to behave on Windows similar to MSVC compiler:
* by default it compiles for MultiThreaded (defines _MT only),
* but it compiles for MultiThreadedDLL (defines both _MT and _DLL) when BUILD_SHARED_LIBS or GTEST_FORCE_SHARED_CRT option is used.

Without the fix Clang always compiles for MultiThreadedDLL (with both _MT and _DLL defined).