### PR TITLE
Fixed missing definition of GTEST_NO_TAIL_CALL_ with old clang

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -770,6 +770,8 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 // Ask the compiler not to perform tail call optimization inside
 // the marked function.
 #define GTEST_NO_TAIL_CALL_ __attribute__((disable_tail_calls))
+#else
+#define GTEST_NO_TAIL_CALL_
 #endif
 #elif __GNUC__
 #define GTEST_NO_TAIL_CALL_ \


### PR DESCRIPTION
There was a missing else branch for:

#if __has_attribute(disable_tail_calls)

and so old versions of clang ended up with GTEST_NO_TAIL_CALL_ totally undefined, and various syntax errors ensued.

Closes #4024.
