### PR TITLE
Enforce printability of all types (optionally)

### DIFF
--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -250,6 +250,16 @@ struct ConvertibleToIntegerPrinter {
   }
 };
 
+struct ScopedEnumPrinter {
+  // Print scoped enums. These are not implicitly convertible to int, so they
+  // are not covered by ConvertibleToIntegerPrinter above.
+  template <typename T,
+            typename = typename std::enable_if<std::is_enum<T>::value>::type>
+  static void PrintValue(T value, ::std::ostream* os) {
+    *os << static_cast<internal::BiggestInt>(value);
+  }
+};
+
 struct ConvertibleToStringViewPrinter {
 #if GTEST_INTERNAL_HAS_STRING_VIEW
   static void PrintValue(internal::StringView value, ::std::ostream* os) {
@@ -306,7 +316,7 @@ void PrintWithFallback(const T& value, ::std::ostream* os) {
   using Printer = typename FindFirstPrinter<
       T, void, ContainerPrinter, FunctionPointerPrinter, PointerPrinter,
       internal_stream_operator_without_lexical_name_lookup::StreamPrinter,
-      ProtobufPrinter, ConvertibleToIntegerPrinter,
+      ProtobufPrinter, ConvertibleToIntegerPrinter, ScopedEnumPrinter,
       ConvertibleToStringViewPrinter, RawBytesPrinter, FallbackPrinter>::type;
   Printer::PrintValue(value, os);
 }

--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -284,7 +284,7 @@ struct RawBytesPrinter {
   }
 };
 
-struct FallbackPrinter {
+struct IncompleteTypePrinter {
   template <typename T>
   static void PrintValue(const T&, ::std::ostream* os) {
     *os << "(incomplete type)";
@@ -317,7 +317,7 @@ void PrintWithFallback(const T& value, ::std::ostream* os) {
       T, void, ContainerPrinter, FunctionPointerPrinter, PointerPrinter,
       internal_stream_operator_without_lexical_name_lookup::StreamPrinter,
       ProtobufPrinter, ConvertibleToIntegerPrinter, ScopedEnumPrinter,
-      ConvertibleToStringViewPrinter, RawBytesPrinter, FallbackPrinter>::type;
+      ConvertibleToStringViewPrinter, RawBytesPrinter, IncompleteTypePrinter>::type;
   Printer::PrintValue(value, os);
 }
 

--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -291,6 +291,14 @@ struct IncompleteTypePrinter {
   }
 };
 
+struct CustomFallbackPrinter {
+  // Used as a last fallback if the user defined GTEST_FALLBACK_PRINTER.
+  template <typename T>
+  static void PrintValue(const T& t, ::std::ostream* os) {
+    GTEST_FALLBACK_PRINTER(t, os);
+  }
+};
+
 // Try every printer in order and return the first one that works.
 template <typename T, typename E, typename Printer, typename... Printers>
 struct FindFirstPrinter : FindFirstPrinter<T, E, Printers...> {};
@@ -317,7 +325,13 @@ void PrintWithFallback(const T& value, ::std::ostream* os) {
       T, void, ContainerPrinter, FunctionPointerPrinter, PointerPrinter,
       internal_stream_operator_without_lexical_name_lookup::StreamPrinter,
       ProtobufPrinter, ConvertibleToIntegerPrinter, ScopedEnumPrinter,
-      ConvertibleToStringViewPrinter, RawBytesPrinter, IncompleteTypePrinter>::type;
+      ConvertibleToStringViewPrinter,
+#ifdef GTEST_FALLBACK_PRINTER
+      CustomFallbackPrinter
+#else
+      RawBytesPrinter, IncompleteTypePrinter
+#endif
+      >::type;
   Printer::PrintValue(value, os);
 }
 

--- a/googletest/test/googletest-printers-test.cc
+++ b/googletest/test/googletest-printers-test.cc
@@ -74,6 +74,23 @@ void PrintTo(EnumWithPrintTo e, std::ostream* os) {
   *os << (e == kEWPT1 ? "kEWPT1" : "invalid");
 }
 
+// A scoped enum type.
+enum class ScopedEnum { kSE1 = -1, kSE2 = 1 };
+
+// A scoped enum with a << operator.
+enum class ScopedEnumWithStreaming { kSEWS1 = 10 };
+
+std::ostream& operator<<(std::ostream& os, ScopedEnumWithStreaming e) {
+  return os << (e == ScopedEnumWithStreaming::kSEWS1 ? "kSEWS1" : "invalid");
+}
+
+// A scoped enum with a PrintTo() function.
+enum class ScopedEnumWithPrintTo { kSEWPT1 = 1 };
+
+void PrintTo(ScopedEnumWithPrintTo e, std::ostream* os) {
+  *os << (e == ScopedEnumWithPrintTo::kSEWPT1 ? "kSEWPT1" : "invalid");
+}
+
 // A class implicitly convertible to BiggestInt.
 class BiggestIntConvertible {
  public:
@@ -308,6 +325,21 @@ TEST(PrintEnumTest, EnumWithStreaming) {
 TEST(PrintEnumTest, EnumWithPrintTo) {
   EXPECT_EQ("kEWPT1", Print(kEWPT1));
   EXPECT_EQ("invalid", Print(static_cast<EnumWithPrintTo>(0)));
+}
+
+TEST(PrintEnumTest, ScopedEnum) {
+  EXPECT_EQ("-1", Print(ScopedEnum::kSE1));
+  EXPECT_EQ("1", Print(ScopedEnum::kSE2));
+}
+
+TEST(PrintEnumTest, ScopedEnumWithStreaming) {
+  EXPECT_EQ("kSEWS1", Print(ScopedEnumWithStreaming::kSEWS1));
+  EXPECT_EQ("invalid", Print(static_cast<ScopedEnumWithStreaming>(0)));
+}
+
+TEST(PrintEnumTest, ScopedEnumWithPrintTo) {
+  EXPECT_EQ("kSEWPT1", Print(ScopedEnumWithPrintTo::kSEWPT1));
+  EXPECT_EQ("invalid", Print(static_cast<ScopedEnumWithPrintTo>(0)));
 }
 
 // Tests printing a class implicitly convertible to BiggestInt.


### PR DESCRIPTION
Introduce a new customization point GTEST_FALLBACK_PRINTER which can be defined to a function that is used as a fallback for types that are not printable, instead of the default raw bytes printer. One especially useful way to use this is to define it to a symbol that doesn't exist (e.g. "#define GTEST_FALLBACK_PRINTER MISSING_PRINTER") to enforce printability of all types that are used in gtest checks at compile time. See #4027 for why this can be useful.

The first commit of the branch, "Add ScopedEnumPrinter", is somewhat independent and could be broken out into a PR of its own. Let me know if you'd like me to do that. I'm including it here because it becomes more important when you enforce printabilty at compile time, because in that case it fixes compilation errors for scoped enums, rather than just printing them as raw bytes, which is not quite as severe.

Fixes #4027.