### PR TITLE
Fix JSON output format

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -4829,6 +4829,9 @@ void JsonUnitTestResultPrinter::PrintJsonUnitTest(std::ostream* stream,
   // If there was a test failure outside of one of the test suites (like in a
   // test environment) include that in the output.
   if (unit_test.ad_hoc_test_result().Failed()) {
+    if (comma) {
+      *stream << ",\n";
+    }
     OutputJsonTestSuiteForTestResult(stream, unit_test.ad_hoc_test_result());
   }
 


### PR DESCRIPTION
#3884

`diff new-googletest-output-test_result old-googletest-output-test_result`
```
1886,1887c1886
<     },
<     {
---
>     }    {
```