### PR TITLE
Add return for GTEST_FAIL_AT #4038

### DIFF
--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1735,8 +1735,8 @@ class TestWithParam : public Test, public WithParamInterface<T> {};
 
 // Like GTEST_FAIL(), but at the given source file location.
 #define GTEST_FAIL_AT(file, line)         \
-  GTEST_MESSAGE_AT_(file, line, "Failed", \
-                    ::testing::TestPartResult::kFatalFailure)
+  return GTEST_MESSAGE_AT_(file, line, "Failed", \
+                           ::testing::TestPartResult::kFatalFailure)
 
 // Define this macro to 1 to omit the definition of FAIL(), which is a
 // generic name and clashes with some other libraries.


### PR DESCRIPTION
Now the test case works fine.
```cpp 
TEST(Foo, Bar) {
    GTEST_FAIL_AT("foo.c", 5) << "fail";
    abort();
}
```