### PR TITLE
Check code formatting with GitHub Action

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -1,0 +1,20 @@
+name: cpp-linter
+
+on: pull_request
+
+jobs:
+  cpp-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cpp-linter/cpp-linter-action@v2.2.0
+        id: linter
+        with:
+          style: file # load .clang-format config file.
+          tidy-checks: '-*' # disable clang-tidy check.
+
+      - name: Fail fast?!
+        if: steps.linter.outputs.checks-failed > 0
+        run: echo "Some files failed the linting checks!"
+        # for actual deployment
+        # run: exit 1

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cpp-linter/cpp-linter-action@v2.2.0
+      - uses: cpp-linter/cpp-linter-action@v2.2.2
         id: linter
         with:
           style: file # load .clang-format config file.


### PR DESCRIPTION
I see that there is a .clang-format configuration file under the code repository, and the[ contribution documentation](https://github.com/google/googletest/blob/main/CONTRIBUTING.md#style) reminds developers that they need to use clang-format to check to format. 

So it would help googletest to have a CI to check the code formatting of the pull request every time.
