### PR TITLE
Add "ansi" to supported gtest_color values

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -2047,10 +2047,11 @@ important information:
 </pre>
 
 You can set the `GTEST_COLOR` environment variable or the `--gtest_color`
-command line flag to `yes`, `no`, or `auto` (the default) to enable colors,
-disable colors, or let GoogleTest decide. When the value is `auto`, GoogleTest
-will use colors if and only if the output goes to a terminal and (on non-Windows
-platforms) the `TERM` environment variable is set to `xterm` or `xterm-color`.
+command line flag to `yes`, `no`, `ansi`, or `auto` (the default) to enable
+colors, disable colors, force using ANSI color escape sequences or let
+GoogleTest decide. When the value is `auto`, GoogleTest will use colors if and
+only if the output goes to a terminal and (on non-Windows platforms) the `TERM`
+environment variable is set to `xterm` or `xterm-color`.
 
 #### Suppressing test passes
 

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -75,6 +75,8 @@ GTEST_DECLARE_bool_(death_test_use_fork);
 namespace testing {
 namespace internal {
 
+enum class GTestColorMode { kNo, kYes, kAnsi };
+
 // The value of GetTestTypeId() as seen from within the Google Test
 // library.  This is solely for testing GetTestTypeId().
 GTEST_API_ extern const TypeId kTestTypeIdInGoogleTest;
@@ -89,8 +91,9 @@ GTEST_API_ extern bool g_help_flag;
 // Returns the current time in milliseconds.
 GTEST_API_ TimeInMillis GetTimeInMillis();
 
-// Returns true if and only if Google Test should use colors in the output.
-GTEST_API_ bool ShouldUseColor(bool stdout_is_tty);
+// Returns the color mode kNo if and only if Google Test should not use colors
+// in the output.
+GTEST_API_ GTestColorMode ShouldUseColor(bool stdout_is_tty);
 
 // Formats the given time in milliseconds as seconds. If the input is an exact N
 // seconds, the output has a trailing decimal point (e.g., "N." instead of "N").

--- a/googletest/test/googletest-color-test.py
+++ b/googletest/test/googletest-color-test.py
@@ -92,6 +92,7 @@ class GTestColorTest(gtest_test_utils.TestCase):
     self.assertTrue(UsesColor('xterm', None, 'auto'))
     self.assertTrue(UsesColor('dumb', None, 'yes'))
     self.assertTrue(UsesColor('xterm', None, 'yes'))
+    self.assertTrue(UsesColor('xterm', None, 'ansi'))
 
   def testEnvVarOnly(self):
     """Tests the case when there's GTEST_COLOR but not --gtest_color."""
@@ -103,6 +104,7 @@ class GTestColorTest(gtest_test_utils.TestCase):
     self.assertTrue(UsesColor('xterm-color', 'auto', None))
     self.assertTrue(UsesColor('dumb', 'yes', None))
     self.assertTrue(UsesColor('xterm-color', 'yes', None))
+    self.assertTrue(UsesColor('xterm-color', 'ansi', None))
 
   def testEnvVarAndFlag(self):
     """Tests the case when there are both GTEST_COLOR and --gtest_color."""
@@ -110,6 +112,7 @@ class GTestColorTest(gtest_test_utils.TestCase):
     self.assertTrue(not UsesColor('xterm-color', 'no', 'no'))
     self.assertTrue(UsesColor('dumb', 'no', 'yes'))
     self.assertTrue(UsesColor('xterm-color', 'no', 'auto'))
+    self.assertTrue(UsesColor('xterm-color', 'no', 'ansi'))
 
   def testAliasesOfYesAndNo(self):
     """Tests using aliases in specifying --gtest_color."""

--- a/googletest/test/googletest-color-test_.cc
+++ b/googletest/test/googletest-color-test_.cc
@@ -36,6 +36,7 @@
 #include "gtest/gtest.h"
 #include "src/gtest-internal-inl.h"
 
+using testing::internal::GTestColorMode;
 using testing::internal::ShouldUseColor;
 
 // The purpose of this is to ensure that the UnitTest singleton is
@@ -47,7 +48,7 @@ TEST(GTestColorTest, Dummy) {}
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
 
-  if (ShouldUseColor(true)) {
+  if (ShouldUseColor(true) == GTestColorMode::kYes) {
     // Google Test decides to use colors in the output (assuming it
     // goes to a TTY).
     printf("YES\n");

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -250,6 +250,7 @@ using testing::internal::GetTestTypeId;
 using testing::internal::GetTimeInMillis;
 using testing::internal::GetTypeId;
 using testing::internal::GetUnitTestImpl;
+using testing::internal::GTestColorMode;
 using testing::internal::GTestFlagSaver;
 using testing::internal::HasDebugStringAndShortDebugString;
 using testing::internal::Int32FromEnvOrDie;
@@ -6573,59 +6574,67 @@ TEST(StreamingAssertionsTest, AnyThrow) {
 TEST(ColoredOutputTest, UsesColorsWhenGTestColorFlagIsYes) {
   GTEST_FLAG_SET(color, "yes");
 
-  SetEnv("TERM", "xterm");             // TERM supports colors.
-  EXPECT_TRUE(ShouldUseColor(true));   // Stdout is a TTY.
-  EXPECT_TRUE(ShouldUseColor(false));  // Stdout is not a TTY.
+  SetEnv("TERM", "xterm");  // TERM supports colors.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kYes);  // Stdout is a TTY.
+  EXPECT_EQ(ShouldUseColor(false),
+            GTestColorMode::kYes);  // Stdout is not a TTY.
 
-  SetEnv("TERM", "dumb");              // TERM doesn't support colors.
-  EXPECT_TRUE(ShouldUseColor(true));   // Stdout is a TTY.
-  EXPECT_TRUE(ShouldUseColor(false));  // Stdout is not a TTY.
+  SetEnv("TERM", "dumb");  // TERM doesn't support colors.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kYes);  // Stdout is a TTY.
+  EXPECT_EQ(ShouldUseColor(false),
+            GTestColorMode::kYes);  // Stdout is not a TTY.
 }
 
 TEST(ColoredOutputTest, UsesColorsWhenGTestColorFlagIsAliasOfYes) {
   SetEnv("TERM", "dumb");  // TERM doesn't support colors.
 
   GTEST_FLAG_SET(color, "True");
-  EXPECT_TRUE(ShouldUseColor(false));  // Stdout is not a TTY.
+  EXPECT_EQ(ShouldUseColor(false),
+            GTestColorMode::kYes);  // Stdout is not a TTY.
 
   GTEST_FLAG_SET(color, "t");
-  EXPECT_TRUE(ShouldUseColor(false));  // Stdout is not a TTY.
+  EXPECT_EQ(ShouldUseColor(false),
+            GTestColorMode::kYes);  // Stdout is not a TTY.
 
   GTEST_FLAG_SET(color, "1");
-  EXPECT_TRUE(ShouldUseColor(false));  // Stdout is not a TTY.
+  EXPECT_EQ(ShouldUseColor(false),
+            GTestColorMode::kYes);  // Stdout is not a TTY.
 }
 
 TEST(ColoredOutputTest, UsesNoColorWhenGTestColorFlagIsNo) {
   GTEST_FLAG_SET(color, "no");
 
-  SetEnv("TERM", "xterm");              // TERM supports colors.
-  EXPECT_FALSE(ShouldUseColor(true));   // Stdout is a TTY.
-  EXPECT_FALSE(ShouldUseColor(false));  // Stdout is not a TTY.
+  SetEnv("TERM", "xterm");  // TERM supports colors.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kNo);  // Stdout is a TTY.
+  EXPECT_EQ(ShouldUseColor(false),
+            GTestColorMode::kNo);  // Stdout is not a TTY.
 
-  SetEnv("TERM", "dumb");               // TERM doesn't support colors.
-  EXPECT_FALSE(ShouldUseColor(true));   // Stdout is a TTY.
-  EXPECT_FALSE(ShouldUseColor(false));  // Stdout is not a TTY.
+  SetEnv("TERM", "dumb");  // TERM doesn't support colors.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kNo);  // Stdout is a TTY.
+  EXPECT_EQ(ShouldUseColor(false),
+            GTestColorMode::kNo);  // Stdout is not a TTY.
 }
 
 TEST(ColoredOutputTest, UsesNoColorWhenGTestColorFlagIsInvalid) {
   SetEnv("TERM", "xterm");  // TERM supports colors.
 
   GTEST_FLAG_SET(color, "F");
-  EXPECT_FALSE(ShouldUseColor(true));  // Stdout is a TTY.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kNo);  // Stdout is a TTY.
 
   GTEST_FLAG_SET(color, "0");
-  EXPECT_FALSE(ShouldUseColor(true));  // Stdout is a TTY.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kNo);  // Stdout is a TTY.
 
   GTEST_FLAG_SET(color, "unknown");
-  EXPECT_FALSE(ShouldUseColor(true));  // Stdout is a TTY.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kNo);  // Stdout is a TTY.
 }
 
 TEST(ColoredOutputTest, UsesColorsWhenStdoutIsTty) {
   GTEST_FLAG_SET(color, "auto");
 
-  SetEnv("TERM", "xterm");              // TERM supports colors.
-  EXPECT_FALSE(ShouldUseColor(false));  // Stdout is not a TTY.
-  EXPECT_TRUE(ShouldUseColor(true));    // Stdout is a TTY.
+  SetEnv("TERM", "xterm");  // TERM supports colors.
+  EXPECT_EQ(ShouldUseColor(false),
+            GTestColorMode::kNo);  // Stdout is not a TTY.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kYes);  // Stdout is a TTY.
 }
 
 TEST(ColoredOutputTest, UsesColorsWhenTermSupportsColors) {
@@ -6635,64 +6644,68 @@ TEST(ColoredOutputTest, UsesColorsWhenTermSupportsColors) {
   // On Windows, we ignore the TERM variable as it's usually not set.
 
   SetEnv("TERM", "dumb");
-  EXPECT_TRUE(ShouldUseColor(true));  // Stdout is a TTY.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kYes);  // Stdout is a TTY.
 
   SetEnv("TERM", "");
-  EXPECT_TRUE(ShouldUseColor(true));  // Stdout is a TTY.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kYes);  // Stdout is a TTY.
 
   SetEnv("TERM", "xterm");
-  EXPECT_TRUE(ShouldUseColor(true));  // Stdout is a TTY.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kYes);  // Stdout is a TTY.
 #else
   // On non-Windows platforms, we rely on TERM to determine if the
   // terminal supports colors.
 
-  SetEnv("TERM", "dumb");              // TERM doesn't support colors.
-  EXPECT_FALSE(ShouldUseColor(true));  // Stdout is a TTY.
+  SetEnv("TERM", "dumb");  // TERM doesn't support colors.
+  EXPECT_EQ(ShouldUseColor(true),
+            GTestColorMode::kNo);  // Stdout is a TTY.
 
-  SetEnv("TERM", "emacs");             // TERM doesn't support colors.
-  EXPECT_FALSE(ShouldUseColor(true));  // Stdout is a TTY.
+  SetEnv("TERM", "emacs");  // TERM doesn't support colors.
+  EXPECT_EQ(ShouldUseColor(true),
+            GTestColorMode::kNo);  // Stdout is a TTY.
 
-  SetEnv("TERM", "vt100");             // TERM doesn't support colors.
-  EXPECT_FALSE(ShouldUseColor(true));  // Stdout is a TTY.
+  SetEnv("TERM", "vt100");  // TERM doesn't support colors.
+  EXPECT_EQ(ShouldUseColor(true),
+            GTestColorMode::kNo);  // Stdout is a TTY.
 
-  SetEnv("TERM", "xterm-mono");        // TERM doesn't support colors.
-  EXPECT_FALSE(ShouldUseColor(true));  // Stdout is a TTY.
+  SetEnv("TERM", "xterm-mono");  // TERM doesn't support colors.
+  EXPECT_EQ(ShouldUseColor(true),
+            GTestColorMode::kNo);  // Stdout is a TTY.
 
-  SetEnv("TERM", "xterm");            // TERM supports colors.
-  EXPECT_TRUE(ShouldUseColor(true));  // Stdout is a TTY.
+  SetEnv("TERM", "xterm");  // TERM supports colors.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kYes);  // Stdout is a TTY.
 
-  SetEnv("TERM", "xterm-color");      // TERM supports colors.
-  EXPECT_TRUE(ShouldUseColor(true));  // Stdout is a TTY.
+  SetEnv("TERM", "xterm-color");  // TERM supports colors.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kYes);  // Stdout is a TTY.
 
-  SetEnv("TERM", "xterm-kitty");      // TERM supports colors.
-  EXPECT_TRUE(ShouldUseColor(true));  // Stdout is a TTY.
+  SetEnv("TERM", "xterm-kitty");  // TERM supports colors.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kYes);  // Stdout is a TTY.
 
-  SetEnv("TERM", "xterm-256color");   // TERM supports colors.
-  EXPECT_TRUE(ShouldUseColor(true));  // Stdout is a TTY.
+  SetEnv("TERM", "xterm-256color");  // TERM supports colors.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kYes);  // Stdout is a TTY.
 
-  SetEnv("TERM", "screen");           // TERM supports colors.
-  EXPECT_TRUE(ShouldUseColor(true));  // Stdout is a TTY.
+  SetEnv("TERM", "screen");  // TERM supports colors.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kYes);  // Stdout is a TTY.
 
   SetEnv("TERM", "screen-256color");  // TERM supports colors.
-  EXPECT_TRUE(ShouldUseColor(true));  // Stdout is a TTY.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kYes);  // Stdout is a TTY.
 
-  SetEnv("TERM", "tmux");             // TERM supports colors.
-  EXPECT_TRUE(ShouldUseColor(true));  // Stdout is a TTY.
+  SetEnv("TERM", "tmux");  // TERM supports colors.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kYes);  // Stdout is a TTY.
 
-  SetEnv("TERM", "tmux-256color");    // TERM supports colors.
-  EXPECT_TRUE(ShouldUseColor(true));  // Stdout is a TTY.
+  SetEnv("TERM", "tmux-256color");  // TERM supports colors.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kYes);  // Stdout is a TTY.
 
-  SetEnv("TERM", "rxvt-unicode");     // TERM supports colors.
-  EXPECT_TRUE(ShouldUseColor(true));  // Stdout is a TTY.
+  SetEnv("TERM", "rxvt-unicode");  // TERM supports colors.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kYes);  // Stdout is a TTY.
 
   SetEnv("TERM", "rxvt-unicode-256color");  // TERM supports colors.
-  EXPECT_TRUE(ShouldUseColor(true));        // Stdout is a TTY.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kYes);  // Stdout is a TTY.
 
-  SetEnv("TERM", "linux");            // TERM supports colors.
-  EXPECT_TRUE(ShouldUseColor(true));  // Stdout is a TTY.
+  SetEnv("TERM", "linux");  // TERM supports colors.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kYes);  // Stdout is a TTY.
 
   SetEnv("TERM", "cygwin");  // TERM supports colors.
-  EXPECT_TRUE(ShouldUseColor(true));  // Stdout is a TTY.
+  EXPECT_EQ(ShouldUseColor(true), GTestColorMode::kYes);  // Stdout is a TTY.
 #endif  // GTEST_OS_WINDOWS
 }
 


### PR DESCRIPTION
Fixes uncolored output on Windows PowerShell with CTest (#2930)

Fixes uncolored output on GitHub and other Windows terminals.

CTest writes googlest standard output and error streams to standard output and a file. Windows `_isatty()` returns 0 in this case and `ShouldUseColor()` returns `false`. Windows PowerShell supports ANSI escape sequences.

Reviewed-by: Nathan Moinvaziri <nathan@nathanm.com>
Reviewed-by: steve-tucker <steve-tucker@users.noreply.github.com>