### PR TITLE
Bazel quickstart: use a more recent commit of googletest

### DIFF
--- a/docs/quickstart-bazel.md
+++ b/docs/quickstart-bazel.md
@@ -51,16 +51,17 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
   name = "com_google_googletest",
-  urls = ["https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip"],
-  strip_prefix = "googletest-609281088cfefc76f9d0ce82e1ff6c30cc3591e5",
+  urls =
+  ["https://github.com/google/googletest/archive/5ab508a01f9eb089207ee87fd547d290da39d015.zip"],
+  strip_prefix = "googletest-5ab508a01f9eb089207ee87fd547d290da39d015",
 )
 ```
 
 The above configuration declares a dependency on GoogleTest which is downloaded
 as a ZIP archive from GitHub. In the above example,
-`609281088cfefc76f9d0ce82e1ff6c30cc3591e5` is the Git commit hash of the
+`5ab508a01f9eb089207ee87fd547d290da39d015` is the Git commit hash of the
 GoogleTest version to use; we recommend updating the hash often to point to the
-latest version.
+latest version.  Use a recent hash on the `main` branch.
 
 Now you're ready to build C++ code that uses GoogleTest.
 


### PR DESCRIPTION
Use a more recent commit of googletest that uses OS constraints from @platforms//os:* instead of from @build_tools//platforms:*

See https://github.com/bazelbuild/bazel/issues/8622

Necessary to fix #4096

Also need the fix for #4098