### PR TITLE
Max: Change to MaxValue

### DIFF
--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -307,7 +307,7 @@ class FloatingPoint {
   static RawType Infinity() { return ReinterpretBits(kExponentBitMask); }
 
   // Returns the maximum representable finite floating-point number.
-  static RawType Max();
+  static RawType MaxValue();
 
   // Non-static methods
 
@@ -392,11 +392,11 @@ class FloatingPoint {
 // We cannot use std::numeric_limits<T>::max() as it clashes with the max()
 // macro defined by <windows.h>.
 template <>
-inline float FloatingPoint<float>::Max() {
+inline float FloatingPoint<float>::MaxValue() {
   return FLT_MAX;
 }
 template <>
-inline double FloatingPoint<double>::Max() {
+inline double FloatingPoint<double>::MaxValue() {
   return DBL_MAX;
 }
 


### PR DESCRIPTION
Some codebases still feature macroses
such as Max(), which clash with
gtrst-internal.h's Max() function.
This change proposes that we name
it as MaxValue().