### PR TITLE
Fix CMake build of gmock python tests

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -135,6 +135,8 @@ if (gmock_build_tests)
   # 'make test' or ctest.
   enable_testing()
 
+  set_python_interpreter(PYTHON_EXECUTABLE)
+
   if (MINGW OR CYGWIN)
     if (CMAKE_VERSION VERSION_LESS "2.8.12")
       add_compile_options("-Wa,-mbig-obj")

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -202,6 +202,8 @@ if (gtest_build_tests)
   # 'make test' or ctest.
   enable_testing()
 
+  set_python_interpreter(PYTHON_EXECUTABLE)
+
   ############################################################
   # C++ tests built with standard compiler flags.
 

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -256,14 +256,21 @@ if (POLICY CMP0094)
   cmake_policy(SET CMP0094 NEW)
 endif()
 
-# Sets PYTHONINTERP_FOUND and PYTHON_EXECUTABLE.
-if ("${CMAKE_VERSION}" VERSION_LESS "3.12.0")
-  find_package(PythonInterp)
-else()
-  find_package(Python COMPONENTS Interpreter)
-  set(PYTHONINTERP_FOUND ${Python_Interpreter_FOUND})
-  set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
-endif()
+# Sets PYTHONINTERP_FOUND and PYTHON_EXECUTABLE if they were not set before.
+macro(set_python_interpreter PYTHON_EXECUTABLE)
+  if(PYTHON_EXECUTABLE)
+    # We add this check for the case when user set python interpreter path explicitly
+    set(PYTHONINTERP_FOUND TRUE)
+  else()
+    if ("${CMAKE_VERSION}" VERSION_LESS "3.12.0")
+      find_package(PythonInterp)
+    else()
+      find_package(Python COMPONENTS Interpreter)
+      set(PYTHONINTERP_FOUND ${Python_Interpreter_FOUND})
+      set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
+    endif()
+  endif()
+endmacro()
 
 # cxx_test_with_flags(name cxx_flags libs srcs...)
 #


### PR DESCRIPTION
Old code set python variables in the scope which is not accessible for gmock build. Therefore py_test function in gmock was ignored. Now we set variables in the correct scope using corresponding macro.

This PR closes issue https://github.com/google/googletest/issues/4124