### PR TITLE
Set CMP0069 policy to avoid warnings

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -16,6 +16,10 @@ if (POLICY CMP0054)
   cmake_policy(SET CMP0054 NEW)
 endif (POLICY CMP0054)
 
+if (POLICY CMP0069)
+  cmake_policy(SET CMP0069 NEW)
+endif (POLICY CMP0069)
+
 # Tweaks CMake's default compiler/linker settings to suit Google Test's needs.
 #
 # This must be a macro(), as inside a function string() can only


### PR DESCRIPTION
When googletest and googlemock are included as a git submodule and referenced as part of an existing CMake project, multiple warnings are printed out due to not setting a value for the CMP0069 policy.