### PR TITLE
Fix error in_death_test_child_process: undeclared identifier

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -5416,6 +5416,9 @@ int UnitTest::Run() {
   impl()->set_catch_exceptions(GTEST_FLAG_GET(catch_exceptions));
 
 #if GTEST_OS_WINDOWS
+#if !GTEST_HAS_DEATH_TEST
+  const bool in_death_test_child_process = false;
+#endif
   // Either the user wants Google Test to catch exceptions thrown by the
   // tests or this is executing in the context of death test child
   // process. In either case the user does not want to see pop-up dialogs


### PR DESCRIPTION
The error occurs if `!GTEST_HAS_DEATH_TEST` on Windows.

I could not make the change better. If I make
```c++
bool in_death_test_child_process = false;
#if GTEST_HAS_DEATH_TEST
  in_death_test_child_process =
      GTEST_FLAG_GET(internal_run_death_test).length() > 0;
```
then the error about an assigned but unused variable occurs on Linux.