### PR TITLE
gmock: Detect absl libary exist by #if not #ifdef

### DIFF
--- a/googlemock/include/gmock/internal/gmock-port.h
+++ b/googlemock/include/gmock/internal/gmock-port.h
@@ -56,7 +56,7 @@
 #include "gmock/internal/custom/gmock-port.h"
 #include "gtest/internal/gtest-port.h"
 
-#ifdef GTEST_HAS_ABSL
+#if GTEST_HAS_ABSL
 #include "absl/flags/declare.h"
 #include "absl/flags/flag.h"
 #endif
@@ -73,7 +73,7 @@
 #define GMOCK_FLAG(name) FLAGS_gmock_##name
 
 // Pick a command line flags implementation.
-#ifdef GTEST_HAS_ABSL
+#if GTEST_HAS_ABSL
 
 // Macros for defining flags.
 #define GMOCK_DEFINE_bool_(name, default_val, doc) \


### PR DESCRIPTION
align with the detection done by googletest
