### PR TITLE
Environment variables are accessible in UWP/WinRT apps

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -2169,8 +2169,8 @@ inline const char* StrError(int errnum) { return strerror(errnum); }
 
 inline const char* GetEnv(const char* name) {
 #if defined(GTEST_OS_WINDOWS_MOBILE) || defined(GTEST_OS_WINDOWS_PHONE) || \
-    defined(GTEST_OS_WINDOWS_RT) || defined(GTEST_OS_ESP8266) ||           \
-    defined(GTEST_OS_XTENSA) || defined(GTEST_OS_QURT)
+    defined(GTEST_OS_ESP8266) || defined(GTEST_OS_XTENSA) ||               \
+    defined(GTEST_OS_QURT)
   // We are on an embedded platform, which has no environment variables.
   static_cast<void>(name);  // To prevent 'unused argument' warning.
   return nullptr;


### PR DESCRIPTION
Environment variables, for example `GTEST_FILTER`, `GTEST_OUTPUT` can be set before getting WinRT app run. GoogleTest can read environment variables and use them. It's easier than setting and passing command line parameters to WinRT app.