### PR TITLE
__cpp_char8_t does not cover std::u8string implementation

### DIFF
--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -1003,7 +1003,7 @@ template <>
 class UniversalTersePrinter<char*> : public UniversalTersePrinter<const char*> {
 };
 
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
 template <>
 class UniversalTersePrinter<const char8_t*> {
  public:

--- a/googletest/src/gtest-printers.cc
+++ b/googletest/src/gtest-printers.cc
@@ -528,7 +528,7 @@ void PrintStringTo(const ::std::string& s, ostream* os) {
   }
 }
 
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
 void PrintU8StringTo(const ::std::u8string& s, ostream* os) {
   PrintCharsAsStringTo(s.data(), s.size(), os);
 }

--- a/googletest/test/googletest-printers-test.cc
+++ b/googletest/test/googletest-printers-test.cc
@@ -532,7 +532,9 @@ TEST(PrintU8StringTest, NonConst) {
   EXPECT_EQ(PrintPointer(p) + " pointing to u8\"\\xE4\\xB8\\x96\"",
             Print(static_cast<char8_t*>(p)));
 }
+#endif
 
+#ifdef __cpp_lib_char8_t
 // NULL u8 string.
 TEST(PrintU8StringTest, Null) {
   const char8_t* p = nullptr;
@@ -936,7 +938,7 @@ TEST(PrintWideStringTest, StringAmbiguousHex) {
 }
 #endif  // GTEST_HAS_STD_WSTRING
 
-#ifdef __cpp_char8_t
+#ifdef __cpp_lib_char8_t
 TEST(PrintStringTest, U8String) {
   std::u8string str = u8"Hello, 世界";
   EXPECT_EQ(str, str);  // Verify EXPECT_EQ compiles with this type.


### PR DESCRIPTION
In MSVS `std::u8string` is enabled only when `__cpp_lib_char8_t` is defined. `__cpp_char8_t` enables only `char8_t`. This PR complements aa2e91fd6918519dafa3bee4aa706d04857e7d06 and 996328bb8eeea7e3b824a7cf4c156640600d9778.

More details:
https://developercommunity.visualstudio.com/t/support-for-cpp-char8-t-feature-test-macro-and-if/586040
https://en.cppreference.com/w/cpp/feature_test

In MSVS, when compiled with pre-c++20 compiler, char8_t is enabled with `/Zc:char8_t` flag. But this flag does not enable library support, which in MSVS comes only with c++20. It's quite easy to reproduce
```
PS C:\w\thirdparty\googletest\mybuild> git diff
diff --git a/googletest/cmake/internal_utils.cmake b/googletest/cmake/internal_utils.cmake
index 0438bef8..502f09f4 100644
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -86,6 +86,7 @@ macro(config_compiler_and_linker)
     # Suppress "unreachable code" warning
     # http://stackoverflow.com/questions/3232669 explains the issue.
     set(cxx_base_flags "${cxx_base_flags} -wd4702")
+    set(cxx_base_flags "${cxx_base_flags} /Zc:char8_t")
     # Ensure MSVC treats source files as UTF-8 encoded.
     if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
       set(cxx_base_flags "${cxx_base_flags} -utf-8")
```
All tests passed:
```
[----------] Global test environment tear-down
[==========] 152 tests from 34 test suites ran. (2415 ms total)
[  PASSED  ] 152 tests.
```

Fixes: https://github.com/google/googletest/issues/4183