### PR TITLE
Add support for QNX 7.1 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ googlemock/gtest
 /CMakeCache.txt
 /ALL_BUILD.vcxproj.filters
 /ALL_BUILD.vcxproj
+
+# Don't ignore QNX Makefile
+!build_qnx/**/Makefile

--- a/build_qnx/Makefile
+++ b/build_qnx/Makefile
@@ -1,0 +1,7 @@
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/common.mk
+++ b/build_qnx/common.mk
@@ -1,0 +1,84 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+NAME=googletest
+
+DIST_BASE=$(PRODUCT_ROOT)
+
+#$(INSTALL_ROOT_$(OS)) is pointing to $QNX_TARGET
+#by default, unless it was manually re-routed to
+#a staging area by setting both INSTALL_ROOT_nto
+#and USE_INSTALL_ROOT
+GOOGLETEST_INSTALL_ROOT ?= $(INSTALL_ROOT_$(OS))
+
+GOOGLETEST_VERSION = 1.13.0
+
+#choose Release or Debug
+CMAKE_BUILD_TYPE ?= Release
+
+#set the following to FALSE if generating .pinfo files is causing problems
+GENERATE_PINFO_FILES ?= TRUE
+
+#override 'all' target to bypass the default QNX build system
+ALL_DEPENDENCIES = googletest_all
+.PHONY: googletest_all install check clean
+
+CFLAGS += $(FLAGS)
+LDFLAGS += -Wl,--build-id=md5
+
+define PINFO
+endef
+PINFO_STATE=Experimental
+USEFILE=
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+CMAKE_ARGS = -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/qnx.nto.toolchain.cmake \
+             -DCMAKE_INSTALL_INCLUDEDIR=$(GOOGLETEST_INSTALL_ROOT)/usr/include \
+             -DCMAKE_INSTALL_LIBDIR=$(GOOGLETEST_INSTALL_ROOT)/$(CPUVARDIR)/usr/lib \
+             -DCMAKE_INSTALL_PREFIX=$(GOOGLETEST_INSTALL_ROOT)/$(CPUVARDIR)/usr \
+             -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+             -DEXTRA_CMAKE_C_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_CXX_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_ASM_FLAGS="$(FLAGS)" \
+             -DEXTRA_CMAKE_LINKER_FLAGS="$(LDFLAGS)" \
+             -DBUILD_SHARED_LIBS=1 \
+             -Dgtest_build_tests=OFF \
+             -Dgtest_build_samples=OFF
+
+MAKE_ARGS ?= -j $(firstword $(JLEVEL) 1)
+
+ifndef NO_TARGET_OVERRIDE
+googletest_all:
+	@mkdir -p build
+	@cd build && cmake $(CMAKE_ARGS) $(DIST_BASE)
+	@cd build && make VERBOSE=1 all $(MAKE_ARGS)
+
+install check: googletest_all
+	@echo Installing...
+	@cd build && make VERBOSE=1 install all $(MAKE_ARGS)
+	@echo Done.
+
+clean iclean spotless:
+	rm -fr build
+
+uninstall:
+endif
+
+#everything down below deals with the generation of the PINFO
+#information for shared objects that is used by the QNX build
+#infrastructure to embed metadata in the .so files, for example
+#data and time, version number, description, etc. Metadata can
+#be retrieved on the target by typing 'use -i <path to openblas .so file>'.
+#this is optional: setting GENERATE_PINFO_FILES to FALSE will disable
+#the insertion of metadata in .so files.
+ifeq ($(GENERATE_PINFO_FILES), TRUE)
+#the following rules are called by the cmake generated makefiles,
+#in order to generate the .pinfo files for the shared libraries
+%.so$(GOOGLETEST_VERSION):
+	$(ADD_PINFO)
+	$(ADD_USAGE)
+
+endif

--- a/build_qnx/nto/Makefile
+++ b/build_qnx/nto/Makefile
@@ -1,0 +1,8 @@
+LIST=CPU
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/nto/aarch64/Makefile
+++ b/build_qnx/nto/aarch64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/nto/aarch64/le/Makefile
+++ b/build_qnx/nto/aarch64/le/Makefile
@@ -1,0 +1,5 @@
+include ../../../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=aarch64
+FLAGS      += $(VFLAG_le) $(CCVFLAG_le)
+LDFLAGS    += $(VFLAG_le) $(LDVFLAG_le)

--- a/build_qnx/nto/x86_64/Makefile
+++ b/build_qnx/nto/x86_64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/nto/x86_64/so/Makefile
+++ b/build_qnx/nto/x86_64/so/Makefile
@@ -1,0 +1,5 @@
+include ../../../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=x86_64
+FLAGS      += $(VFLAG) $(CCVFLAG)
+LDFLAGS    += $(VFLAG) $(LDVFLAG)

--- a/build_qnx/qnx.nto.toolchain.cmake
+++ b/build_qnx/qnx.nto.toolchain.cmake
@@ -1,0 +1,34 @@
+if("$ENV{QNX_HOST}" STREQUAL "")
+    message(FATAL_ERROR "QNX_HOST environment variable not found. Please set the variable to your host's build tools")
+endif()
+if("$ENV{QNX_TARGET}" STREQUAL "")
+    message(FATAL_ERROR "QNX_TARGET environment variable not found. Please set the variable to the qnx target location")
+endif()
+
+if(CMAKE_HOST_WIN32)
+    set(HOST_EXECUTABLE_SUFFIX ".exe")
+    #convert windows paths to cmake paths
+    file(TO_CMAKE_PATH "$ENV{QNX_HOST}" QNX_HOST)
+    file(TO_CMAKE_PATH "$ENV{QNX_TARGET}" QNX_TARGET)
+else()
+    set(QNX_HOST "$ENV{QNX_HOST}")
+    set(QNX_TARGET "$ENV{QNX_TARGET}")
+endif()
+
+message(STATUS "using QNX_HOST ${QNX_HOST}")
+message(STATUS "using QNX_TARGET ${QNX_TARGET}")
+
+set(QNX TRUE)
+set(CMAKE_SYSTEM_NAME QNX)
+set(CMAKE_C_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_CXX_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_ASM_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_AR "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ar${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "archiver")
+set(CMAKE_RANLIB "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ranlib${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "ranlib")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_C_FLAGS}" CACHE STRING "c_flags")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} -std=gnu++11 ${EXTRA_CMAKE_CXX_FLAGS}" CACHE STRING "cxx_flags")
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_ASM_FLAGS}" CACHE STRING "asm_flags")
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "exe_linker_flags")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "so_linker_flags")

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -254,14 +254,24 @@ if (gtest_build_tests)
     "${cxx_exception} -DGTEST_ENABLE_CATCH_EXCEPTIONS_=1"
     gtest test/googletest-death-test_ex_test.cc)
 
-  cxx_test_with_flags(gtest_no_rtti_unittest "${cxx_no_rtti}"
-    gtest_main_no_rtti test/gtest_unittest.cc)
+  if(QNX)
+    cxx_test_with_flags(gtest_no_rtti_unittest "${cxx_no_rtti}"
+      "gtest_main_no_rtti;regex" test/gtest_unittest.cc)
+  else()
+    cxx_test_with_flags(gtest_no_rtti_unittest "${cxx_no_rtti}"
+      gtest_main_no_rtti test/gtest_unittest.cc)
+  endif()
 
   cxx_shared_library(gtest_dll "${cxx_default}"
     src/gtest-all.cc src/gtest_main.cc)
 
-  cxx_executable_with_flags(gtest_dll_test_ "${cxx_default}"
-    gtest_dll test/gtest_all_test.cc)
+  if(QNX)
+    cxx_executable_with_flags(gtest_dll_test_ "${cxx_default}"
+      "gtest_dll;regex" test/gtest_all_test.cc)
+  else()
+    cxx_executable_with_flags(gtest_dll_test_ "${cxx_default}"
+      gtest_dll test/gtest_all_test.cc)
+  endif()
   set_target_properties(gtest_dll_test_
                         PROPERTIES
                         COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
@@ -277,11 +287,19 @@ if (gtest_build_tests)
 
   # Visual Studio .NET 2003 does not support STL with exceptions disabled.
   if (NOT MSVC OR MSVC_VERSION GREATER 1310)  # 1310 is Visual Studio .NET 2003
-    cxx_executable_with_flags(
-      googletest-catch-exceptions-no-ex-test_
-      "${cxx_no_exception}"
-      gtest_main_no_exception
-      test/googletest-catch-exceptions-test_.cc)
+    if(QNX)
+      cxx_executable_with_flags(
+        googletest-catch-exceptions-no-ex-test_
+        "${cxx_no_exception}"
+        "gtest_main_no_exception;regex"
+        test/googletest-catch-exceptions-test_.cc)
+    else()
+      cxx_executable_with_flags(
+        googletest-catch-exceptions-no-ex-test_
+        "${cxx_no_exception}"
+        gtest_main_no_exception
+        test/googletest-catch-exceptions-test_.cc)
+    endif()
   endif()
 
   cxx_executable_with_flags(
@@ -314,7 +332,11 @@ if (gtest_build_tests)
 
   # MSVC 7.1 does not support STL with exceptions disabled.
   if (NOT MSVC OR MSVC_VERSION GREATER 1310)
-    cxx_executable(googletest-throw-on-failure-test_ test gtest_no_exception)
+    if(QNX)
+      cxx_executable(googletest-throw-on-failure-test_ test "gtest_no_exception;regex")
+    else()
+      cxx_executable(googletest-throw-on-failure-test_ test gtest_no_exception)
+    endif()
     set_target_properties(googletest-throw-on-failure-test_
       PROPERTIES
       COMPILE_FLAGS "${cxx_no_exception}")
@@ -335,4 +357,13 @@ if (gtest_build_tests)
   cxx_executable(gtest_xml_output_unittest_ test gtest)
   py_test(gtest_xml_output_unittest --no_stacktrace_support)
   py_test(googletest-json-output-unittest --no_stacktrace_support)
+
+  if(QNX AND INSTALL_GTEST)
+    install(DIRECTORY ${PROJECT_BINARY_DIR}/
+      DESTINATION bin/googletest_tests
+      PATTERN "Makefile" EXCLUDE
+      PATTERN "CMakeFiles" EXCLUDE
+      PATTERN "*.cmake" EXCLUDE
+      PATTERN "generated" EXCLUDE)
+  endif()
 endif()


### PR DESCRIPTION
Add support for QNX 7.1 build.

Build instruction:
```bash
source <path-to-qnxsdp-env.sh>/qnxsdp-env.sh
git clone https://github.com/chachoi/googletest.git && cd googletest/build_qnx
make -j 4 install
```
To build googletest tests and samples, set gtest_build_tests and gtest_build_samples to ON in build_qnx/common.mk.

[Test wiki](https://gitlab.com/qnx/libs/googletest/-/wikis/Test-GoogleTest)