### PR TITLE
Add missing absl dependency from build.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -132,6 +132,7 @@ cc_library(
     }),
     deps = select({
         ":has_absl": [
+            "@com_google_absl//absl/container:flat_hash_set",
             "@com_google_absl//absl/debugging:failure_signal_handler",
             "@com_google_absl//absl/debugging:stacktrace",
             "@com_google_absl//absl/debugging:symbolize",


### PR DESCRIPTION
https://github.com/google/googletest/commit/dea0484e4d3b6a2c50055c24c5617cd662a50c5f added an include on `absl::flat_hash_set` but didn't update the build. So it fails to build if we don't have the correct transient include.