### PR TITLE
Use absolute path for ::testing namespace rather than a relative one

### DIFF
--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -1274,7 +1274,7 @@ class TypedExpectation<R(Args...)> : public ExpectationBase {
 // ::testing::internal and import it into ::testing.
 
 // Logs a message including file and line number information.
-GTEST_API_ void LogWithLocation(testing::internal::LogSeverity severity,
+GTEST_API_ void LogWithLocation(::testing::internal::LogSeverity severity,
                                 const char* file, int line,
                                 const std::string& message);
 


### PR DESCRIPTION
With only a relative path, this will cause compiler errors (or worse, silently wrong behavior) when this header is included in a translation unit which defines a different `testing` namespace nested in another namespace.