### PR TITLE
Add CXX_STANDARD_REQUIRED to CMake quickstart

### DIFF
--- a/docs/quickstart-cmake.md
+++ b/docs/quickstart-cmake.md
@@ -54,6 +54,7 @@ project(my_project)
 
 # GoogleTest requires at least C++14
 set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(FetchContent)
 FetchContent_Declare(

--- a/googletest/README.md
+++ b/googletest/README.md
@@ -126,10 +126,10 @@ match the project in which it is included.
 
 An environment that supports C++11 is required in order to successfully build
 GoogleTest. One way to ensure this is to specify the standard in the top-level
-project, for example by using the `set(CMAKE_CXX_STANDARD 11)` command. If this
-is not feasible, for example in a C project using GoogleTest for validation,
-then it can be specified by adding it to the options for cmake via the
-`DCMAKE_CXX_FLAGS` option.
+project, for example by using the `set(CMAKE_CXX_STANDARD 11)` command along
+with `set(CMAKE_CXX_STANDARD_REQUIRED ON). If this is not feasible, for example
+in a C project using GoogleTest for validation, then it can be specified by
+adding it to the options for cmake via the `-DCMAKE_CXX_FLAGS` option.
 
 ### Tweaking GoogleTest
 


### PR DESCRIPTION
The `CXX_STANDARD` property specifies the language standard that the project wants to use if it is available. `CXX_STANDARD_REQUIRED` makes it a hard requirement. Note that `CXX_STANDARD_REQUIRED` is turned off by default.