### PR TITLE
For sample1_unittest.cc etc, update comments to use new "test-suite, test-case" nomenclature.

### DIFF
--- a/googletest/samples/sample1_unittest.cc
+++ b/googletest/samples/sample1_unittest.cc
@@ -48,24 +48,25 @@ namespace {
 
 // Step 2. Use the TEST macro to define your tests.
 //
-// TEST has two parameters: the test case name and the test name.
+// TEST has two parameters: the test-suite name and the test-case name.
 // After using the macro, you should define your test logic between a
 // pair of braces.  You can use a bunch of macros to indicate the
-// success or failure of a test.  EXPECT_TRUE and EXPECT_EQ are
-// examples of such macros.  For a complete list, see gtest.h.
+// success or failure of a test(it means a test-assertion here).  
+// EXPECT_TRUE and EXPECT_EQ are examples of such macros.  
+// For a complete list, see gtest.h.
 //
 // <TechnicalDetails>
 //
-// In Google Test, tests are grouped into test cases.  This is how we
+// In Google Test, tests are grouped into test-suites.  This is how we
 // keep test code organized.  You should put logically related tests
-// into the same test case.
+// into the same test-suite.
 //
-// The test case name and the test name should both be valid C++
+// The test-suite name and the test-case name should both be valid C++
 // identifiers.  And you should not use underscore (_) in the names.
 //
-// Google Test guarantees that each test you define is run exactly
-// once, but it makes no guarantee on the order the tests are
-// executed.  Therefore, you should write your tests in such a way
+// Google Test guarantees that each test-case you define is run exactly
+// once, but it makes no guarantee on the order the test-cases are
+// executed.  Therefore, you should write your test-cases in such a way
 // that their results don't depend on their order.
 //
 // </TechnicalDetails>
@@ -74,8 +75,8 @@ namespace {
 
 // Tests factorial of negative numbers.
 TEST(FactorialTest, Negative) {
-  // This test is named "Negative", and belongs to the "FactorialTest"
-  // test case.
+  // This test-case is named "Negative", and belongs to the 
+  // "FactorialTest" test-suite.
   EXPECT_EQ(1, Factorial(-5));
   EXPECT_EQ(1, Factorial(-1));
   EXPECT_GT(Factorial(-10), 0);
@@ -97,7 +98,9 @@ TEST(FactorialTest, Negative) {
 }
 
 // Tests factorial of 0.
-TEST(FactorialTest, Zero) { EXPECT_EQ(1, Factorial(0)); }
+TEST(FactorialTest, Zero) {
+  EXPECT_EQ(1, Factorial(0)); 
+}
 
 // Tests factorial of positive numbers.
 TEST(FactorialTest, Positive) {
@@ -111,7 +114,7 @@ TEST(FactorialTest, Positive) {
 
 // Tests negative input.
 TEST(IsPrimeTest, Negative) {
-  // This test belongs to the IsPrimeTest test case.
+  // This test-case belongs to the IsPrimeTest test-suite.
 
   EXPECT_FALSE(IsPrime(-1));
   EXPECT_FALSE(IsPrime(-2));

--- a/googletest/samples/sample2_unittest.cc
+++ b/googletest/samples/sample2_unittest.cc
@@ -32,9 +32,9 @@
 // This sample shows how to write a more complex unit test for a class
 // that has multiple member functions.
 //
-// Usually, it's a good idea to have one test for each method in your
+// Usually, it's a good idea to have one test-case for each method in your
 // class.  You don't have to do that exactly, but it helps to keep
-// your tests organized.  You may also throw in additional tests as
+// your tests organized.  You may also throw in additional test-cases as
 // needed.
 
 #include "sample2.h"
@@ -43,30 +43,11 @@
 namespace {
 // In this example, we test the MyString class (a simple string).
 
-// Tests the default c'tor.
+// Tests the default-ctor.
 TEST(MyString, DefaultConstructor) {
   const MyString s;
 
-  // Asserts that s.c_string() returns NULL.
-  //
-  // <TechnicalDetails>
-  //
-  // If we write NULL instead of
-  //
-  //   static_cast<const char *>(NULL)
-  //
-  // in this assertion, it will generate a warning on gcc 3.4.  The
-  // reason is that EXPECT_EQ needs to know the types of its
-  // arguments in order to print them when it fails.  Since NULL is
-  // #defined as 0, the compiler will use the formatter function for
-  // int to print it.  However, gcc thinks that NULL should be used as
-  // a pointer, not an int, and therefore complains.
-  //
-  // The root of the problem is C++'s lack of distinction between the
-  // integer number 0 and the null pointer constant.  Unfortunately,
-  // we have to live with this fact.
-  //
-  // </TechnicalDetails>
+  // Asserts that s.c_string() returns nullptr.
   EXPECT_STREQ(nullptr, s.c_string());
 
   EXPECT_EQ(0u, s.Length());
@@ -74,18 +55,22 @@ TEST(MyString, DefaultConstructor) {
 
 const char kHelloString[] = "Hello, world!";
 
-// Tests the c'tor that accepts a C string.
+// Tests the ctor that accepts a C string.
 TEST(MyString, ConstructorFromCString) {
   const MyString s(kHelloString);
   EXPECT_EQ(0, strcmp(s.c_string(), kHelloString));
   EXPECT_EQ(sizeof(kHelloString) / sizeof(kHelloString[0]) - 1, s.Length());
 }
 
-// Tests the copy c'tor.
+// Tests the copy-ctor.
 TEST(MyString, CopyConstructor) {
   const MyString s1(kHelloString);
   const MyString s2 = s1;
   EXPECT_EQ(0, strcmp(s2.c_string(), kHelloString));
+  
+  // Instead of strcmp(), using EXPECT_STREQ is more concise.
+  // Relative new GoogleTest versions supports EXPECT_STREQ .
+  EXPECT_STREQ(s2.c_string(), kHelloString);
 }
 
 // Tests the Set method.
@@ -93,12 +78,12 @@ TEST(MyString, Set) {
   MyString s;
 
   s.Set(kHelloString);
-  EXPECT_EQ(0, strcmp(s.c_string(), kHelloString));
+  EXPECT_STREQ(s.c_string(), kHelloString);
 
   // Set should work when the input pointer is the same as the one
   // already in the MyString object.
   s.Set(s.c_string());
-  EXPECT_EQ(0, strcmp(s.c_string(), kHelloString));
+  EXPECT_STREQ(s.c_string(), kHelloString);
 
   // Can we set the MyString to NULL?
   s.Set(nullptr);

--- a/googletest/samples/sample3_unittest.cc
+++ b/googletest/samples/sample3_unittest.cc
@@ -33,24 +33,24 @@
 // test fixture.
 //
 // A test fixture is a place to hold objects and functions shared by
-// all tests in a test case.  Using a test fixture avoids duplicating
+// all test-cases in a test-suite.  Using a test fixture avoids duplicating
 // the test code necessary to initialize and cleanup those common
-// objects for each test.  It is also useful for defining sub-routines
+// objects for each test-case.  It is also useful for defining sub-routines
 // that your tests need to invoke a lot.
 //
 // <TechnicalDetails>
 //
-// The tests share the test fixture in the sense of code sharing, not
-// data sharing.  Each test is given its own fresh copy of the
-// fixture.  You cannot expect the data modified by one test to be
-// passed on to another test, which is a bad idea.
+// The test-cases share the test fixture in the sense of code sharing, 
+// not data sharing.  Each test-case is given its own fresh copy of the
+// fixture.  You cannot expect the data modified by one test-case to be
+// passed on to another test-case, which is a bad idea.
 //
-// The reason for this design is that tests should be independent and
-// repeatable.  In particular, a test should not fail as the result of
-// another test's failure.  If one test depends on info produced by
-// another test, then the two tests should really be one big test.
+// The reason for this design is that test-cases should be independent and
+// repeatable.  In particular, a test-case should not fail as the result of
+// another test-case's failure.  If one test-case depends on info produced by
+// another test-case, then the two test-cases should really be one big test-case.
 //
-// The macros for indicating the success/failure of a test
+// The macros for indicating the success/failure of a test-assertion
 // (EXPECT_TRUE, FAIL, etc) need to know what the current test is
 // (when Google Test prints the test result, it tells you which test
 // each failure belongs to).  Technically, these macros invoke a
@@ -67,7 +67,7 @@ namespace {
 class QueueTestSmpl3 : public testing::Test {
  protected:  // You should make the members protected s.t. they can be
              // accessed from sub-classes.
-  // virtual void SetUp() will be called before each test is run.  You
+  // virtual void SetUp() will be called *before* each test-case is run.  You
   // should define it if you need to initialize the variables.
   // Otherwise, this can be skipped.
   void SetUp() override {
@@ -76,7 +76,7 @@ class QueueTestSmpl3 : public testing::Test {
     q2_.Enqueue(3);
   }
 
-  // virtual void TearDown() will be called after each test is run.
+  // virtual void TearDown() will be called *after* each test-case is run.
   // You should define it if there is cleanup work to do.  Otherwise,
   // you don't have to provide it.
   //
@@ -110,7 +110,7 @@ class QueueTestSmpl3 : public testing::Test {
   Queue<int> q2_;
 };
 
-// When you have a test fixture, you define a test using TEST_F
+// When you have a test fixture, you define a test-case using TEST_F
 // instead of TEST.
 
 // Tests the default c'tor.

--- a/googletest/samples/sample5_unittest.cc
+++ b/googletest/samples/sample5_unittest.cc
@@ -27,19 +27,19 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// This sample teaches how to reuse a test fixture in multiple test
-// cases by deriving sub-fixtures from it.
+// This sample teaches how to reuse a test fixture in multiple test-suites
+// by deriving sub-fixtures from it.
 //
-// When you define a test fixture, you specify the name of the test
-// case that will use this fixture.  Therefore, a test fixture can
-// be used by only one test case.
+// When you define a test fixture, you implicitly create a name of a 
+// test-suite that will use this fixture. In this simplest case, 
+// a test fixture can be used by only one test-suite.
 //
-// Sometimes, more than one test cases may want to use the same or
+// Sometimes, more than one test-suites may want to use the same or
 // slightly different test fixtures.  For example, you may want to
-// make sure that all tests for a GUI library don't leak important
+// make sure that all test-suites for a GUI library don't leak important
 // system resources like fonts and brushes.  In Google Test, you do
 // this by putting the shared logic in a super (as in "super class")
-// test fixture, and then have each test case use a fixture derived
+// test fixture, and then have each test-suite use a fixture derived
 // from this super fixture.
 
 #include <limits.h>
@@ -49,13 +49,13 @@
 #include "sample3-inl.h"
 #include "gtest/gtest.h"
 namespace {
-// In this sample, we want to ensure that every test finishes within
-// ~5 seconds.  If a test takes longer to run, we consider it a
+// In this sample, we want to ensure that every test-case finishes within
+// ~5 seconds.  If a test-case takes longer to run, we consider it a
 // failure.
 //
-// We put the code for timing a test in a test fixture called
+// We put the code for timing a test-case in a test fixture called
 // "QuickTest".  QuickTest is intended to be the super fixture that
-// other fixtures derive from, therefore there is no test case with
+// other fixtures derive from, therefore there is no test-suite with
 // the name "QuickTest".  This is OK.
 //
 // Later, we will derive multiple test fixtures from QuickTest.
@@ -89,7 +89,7 @@ class IntegerFunctionTest : public QuickTest {
   // Therefore the body is empty.
 };
 
-// Now we can write tests in the IntegerFunctionTest test case.
+// Now we can write tests in the IntegerFunctionTest test-suite.
 
 // Tests Factorial()
 TEST_F(IntegerFunctionTest, Factorial) {
@@ -128,7 +128,7 @@ TEST_F(IntegerFunctionTest, IsPrime) {
   EXPECT_TRUE(IsPrime(23));
 }
 
-// The next test case (named "QueueTest") also needs to be quick, so
+// The next test-suite (named "QueueTest") also needs to be quick, so
 // we derive another fixture from QuickTest.
 //
 // The QueueTest test fixture has some logic and shared objects in

--- a/googletest/samples/sample6_unittest.cc
+++ b/googletest/samples/sample6_unittest.cc
@@ -65,7 +65,7 @@ class PrimeTableTest : public testing::Test {
   // instead of the actual implementation class.  This is important
   // for keeping the tests close to the real world scenario, where the
   // implementation is invoked via the base interface.  It avoids
-  // got-yas where the implementation class has a method that shadows
+  // gotchas where the implementation class has a method that shadows
   // a method with the same name (but slightly different argument
   // types) in the base interface, for example.
   PrimeTable* const table_;
@@ -73,24 +73,24 @@ class PrimeTableTest : public testing::Test {
 
 using testing::Types;
 
-// Google Test offers two ways for reusing tests for different types.
+// Google Test offers two ways for reusing test-cases for different types.
 // The first is called "typed tests".  You should use it if you
 // already know *all* the types you are gonna exercise when you write
 // the tests.
 
 // To write a typed test case, first use
 //
-//   TYPED_TEST_SUITE(TestCaseName, TypeList);
+//   TYPED_TEST_SUITE(TestSuiteName, TypeList);
 //
 // to declare it and specify the type parameters.  As with TEST_F,
-// TestCaseName must match the test fixture name.
+// TestSuiteName must match the test fixture name.
 
 // The list of types we want to test.
 typedef Types<OnTheFlyPrimeTable, PreCalculatedPrimeTable> Implementations;
 
 TYPED_TEST_SUITE(PrimeTableTest, Implementations);
 
-// Then use TYPED_TEST(TestCaseName, TestName) to define a typed test,
+// Then use TYPED_TEST(TestSuiteName, TestCaseName) to define a typed test,
 // similar to TEST_F.
 TYPED_TEST(PrimeTableTest, ReturnsFalseForNonPrimes) {
   // Inside the test body, you can refer to the type parameter by
@@ -130,6 +130,8 @@ TYPED_TEST(PrimeTableTest, CanGetNextPrime) {
 // in the type list specified in TYPED_TEST_SUITE.  Sit back and be
 // happy that you don't have to define them multiple times.
 
+
+
 using testing::Types;
 
 // Sometimes, however, you don't yet know all the types that you want
@@ -151,12 +153,12 @@ using testing::Types;
 template <class T>
 class PrimeTableTest2 : public PrimeTableTest<T> {};
 
-// Then, declare the test case.  The argument is the name of the test
-// fixture, and also the name of the test case (as usual).  The _P
+// Then, declare the test-suite.  The argument is the name of the test
+// fixture, and also the name of the test-suite (as usual).  The _P
 // suffix is for "parameterized" or "pattern".
 TYPED_TEST_SUITE_P(PrimeTableTest2);
 
-// Next, use TYPED_TEST_P(TestCaseName, TestName) to define a test,
+// Next, use TYPED_TEST_P(TestSuiteName, TestCaseName) to define a test,
 // similar to what you do with TEST_F.
 TYPED_TEST_P(PrimeTableTest2, ReturnsFalseForNonPrimes) {
   EXPECT_FALSE(this->table_->IsPrime(-5));
@@ -186,10 +188,10 @@ TYPED_TEST_P(PrimeTableTest2, CanGetNextPrime) {
 }
 
 // Type-parameterized tests involve one extra step: you have to
-// enumerate the tests you defined:
+// enumerate the test-cases you defined:
 REGISTER_TYPED_TEST_SUITE_P(
-    PrimeTableTest2,  // The first argument is the test case name.
-    // The rest of the arguments are the test names.
+    PrimeTableTest2,  // The first argument is the test-suite name.
+    // The rest of the arguments are the test-case names.
     ReturnsFalseForNonPrimes, ReturnsTrueForPrimes, CanGetNextPrime);
 
 // At this point the test pattern is done.  However, you don't have
@@ -201,14 +203,14 @@ REGISTER_TYPED_TEST_SUITE_P(
 // in a .h file, and anyone can #include and instantiate it.  You can
 // even instantiate it more than once in the same program.  To tell
 // different instances apart, you give each of them a name, which will
-// become part of the test case name and can be used in test filters.
+// become part of the test-suite name and can be used in test filters.
 
 // The list of types we want to test.  Note that it doesn't have to be
 // defined at the time we write the TYPED_TEST_P()s.
 typedef Types<OnTheFlyPrimeTable, PreCalculatedPrimeTable>
     PrimeTableImplementations;
 INSTANTIATE_TYPED_TEST_SUITE_P(OnTheFlyAndPreCalculated,    // Instance name
-                               PrimeTableTest2,             // Test case name
+                               PrimeTableTest2,             // Test-suite name
                                PrimeTableImplementations);  // Type list
 
 }  // namespace

--- a/googletest/samples/sample7_unittest.cc
+++ b/googletest/samples/sample7_unittest.cc
@@ -29,7 +29,7 @@
 
 // This sample shows how to test common properties of multiple
 // implementations of an interface (aka interface tests) using
-// value-parameterized tests. Each test in the test case has
+// value-parameterized tests. Each test-case in the test-suite has
 // a parameter that is an interface pointer to an implementation
 // tested.
 
@@ -41,10 +41,10 @@ namespace {
 using ::testing::TestWithParam;
 using ::testing::Values;
 
-// As a general rule, to prevent a test from affecting the tests that come
-// after it, you should create and destroy the tested objects for each test
+// As a general rule, to prevent a test-case from affecting those that come
+// after it, you should create and destroy the tested objects for each test-case
 // instead of reusing them.  In this sample we will define a simple factory
-// function for PrimeTable objects.  We will instantiate objects in test's
+// function for PrimeTable objects.  We will instantiate objects in test-suite's
 // SetUp() method and delete them in TearDown() method.
 typedef PrimeTable* CreatePrimeTableFunc();
 
@@ -55,7 +55,7 @@ PrimeTable* CreatePreCalculatedPrimeTable() {
   return new PreCalculatedPrimeTable(max_precalculated);
 }
 
-// Inside the test body, fixture constructor, SetUp(), and TearDown() you
+// Inside the test-case body, fixture constructor, SetUp(), and TearDown() you
 // can refer to the test parameter by GetParam().  In this case, the test
 // parameter is a factory function which we call in fixture's SetUp() to
 // create and store an instance of PrimeTable.
@@ -104,8 +104,8 @@ TEST_P(PrimeTableTestSmpl7, CanGetNextPrime) {
 // You can instantiate them in a different translation module, or even
 // instantiate them several times.
 //
-// Here, we instantiate our tests with a list of two PrimeTable object
-// factory functions:
+// Here, we instantiate our test-suite with a list of two PrimeTable object
+// factory functions. The instantiation name is called OnTheFlyAndPreCalculated.
 INSTANTIATE_TEST_SUITE_P(OnTheFlyAndPreCalculated, PrimeTableTestSmpl7,
                          Values(&CreateOnTheFlyPrimeTable,
                                 &CreatePreCalculatedPrimeTable<1000>));

--- a/googletest/samples/sample8_unittest.cc
+++ b/googletest/samples/sample8_unittest.cc
@@ -29,7 +29,7 @@
 
 // This sample shows how to test code relying on some global flag variables.
 // Combine() helps with generating all possible combinations of such flags,
-// and each test is given one combination as a parameter.
+// and each test-case is given one combination as a parameter.
 
 // Use class definitions to test from this header.
 #include <tuple>
@@ -105,7 +105,7 @@ class PrimeTableTest : public TestWithParam< ::std::tuple<bool, int> > {
 };
 
 TEST_P(PrimeTableTest, ReturnsFalseForNonPrimes) {
-  // Inside the test body, you can refer to the test parameter by GetParam().
+  // Inside the test-case body, you can refer to the test parameter by GetParam().
   // In this case, the test parameter is a PrimeTable interface pointer which
   // we can use directly.
   // Please note that you can also save it in the fixture's SetUp() method
@@ -142,12 +142,15 @@ TEST_P(PrimeTableTest, CanGetNextPrime) {
 // You can instantiate them in a different translation module, or even
 // instantiate them several times.
 //
-// Here, we instantiate our tests with a list of parameters. We must combine
+// Here, we instantiate our test-suite with a list of parameters. We must combine
 // all variations of the boolean flag suppressing PrecalcPrimeTable and some
 // meaningful values for tests. We choose a small value (1), and a value that
 // will put some of the tested numbers beyond the capability of the
 // PrecalcPrimeTable instance and some inside it (10). Combine will produce all
 // possible combinations.
+//   ::testing::Bool() equals ::testing::Values(false, true), this is 2 values.
+//   ::testing::Values(1, 10) is another 2 values.
+// So the combination results in 2*2=4 ways to initialize a PrimeTableTest instance.
 INSTANTIATE_TEST_SUITE_P(MeaningfulTestParameters, PrimeTableTest,
                          Combine(Bool(), Values(1, 10)));
 

--- a/googletest/samples/sample8_unittest.cc
+++ b/googletest/samples/sample8_unittest.cc
@@ -105,12 +105,6 @@ class PrimeTableTest : public TestWithParam< ::std::tuple<bool, int> > {
 };
 
 TEST_P(PrimeTableTest, ReturnsFalseForNonPrimes) {
-  // Inside the test-case body, you can refer to the test parameter by GetParam().
-  // In this case, the test parameter is a PrimeTable interface pointer which
-  // we can use directly.
-  // Please note that you can also save it in the fixture's SetUp() method
-  // or constructor and use saved copy in the tests.
-
   EXPECT_FALSE(table_->IsPrime(-5));
   EXPECT_FALSE(table_->IsPrime(0));
   EXPECT_FALSE(table_->IsPrime(1));


### PR DESCRIPTION
According to 2019 updates of [GoogleTest Primer](http://google.github.io/googletest/primer.html), we have two naming change:

* a **test-case** now becomes **test-suite** .
* a **TEST_F()** now becomes a **test-case** .

I totally agree with this change, because the new naming is clearer and more natural. 

Although 3 years has passed, most code comments in `sample1_unittest.cc` ... `sample8_unittest.cc` has not been updated to reflect the new naming, so I offer to do the updates.

BTW, how do you call a `EXPECT_EQ` or a `EXPECT_TRUE` inside a test-case? This naming is not very clear yet. I offer to call it a test-assertion. 