### PR TITLE
Enable c++14 by default in bazel build issue: #4254

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -101,7 +101,7 @@ cc_library(
     copts = select({
         ":qnx": [],
         ":windows": [],
-        "//conditions:default": ["-pthread"],
+        "//conditions:default": ["-pthread", "-std=c++14"],
     }),
     defines = select({
         ":has_absl": ["GTEST_HAS_ABSL=1"],


### PR DESCRIPTION
This change is related to issue   #4254