### PR TITLE
Avoid stack overflow in CreateDirectoriesRecursively

### DIFF
--- a/googletest/src/gtest-filepath.cc
+++ b/googletest/src/gtest-filepath.cc
@@ -335,7 +335,7 @@ bool FilePath::CreateDirectoriesRecursively() const {
     return false;
   }
 
-  if (pathname_.length() == 0 || this->DirectoryExists()) {
+  if (pathname_.length() == 0 || pathname_ == kCurrentDirectoryString || this->DirectoryExists()) {
     return true;
   }
 


### PR DESCRIPTION
Avoid stack overflow in CreateDirectoriesRecursively by checking for end condition of RemoveFileName()

Fixes #4262