### PR TITLE
Ignore the .cache directory created by VSCode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ Win32-Release/
 x64-Debug/
 x64-Release/
 
+# VSCode files
+.cache/
+cmake-variants.yaml
+
 # Ignore autoconf / automake files
 Makefile.in
 aclocal.m4


### PR DESCRIPTION
This is populated by the clangd language service provider.

Also ignore the cmake-variants.yaml file.
This can be created locally to select various build/test configurations.

Fixes #4266