### PR TITLE
ci: Fix Windows CI

### DIFF
--- a/.github/workflows/gtest-ci.yml
+++ b/.github/workflows/gtest-ci.yml
@@ -39,5 +39,9 @@ jobs:
       with:
         fetch-depth: 0
 
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: amd64
+
     - name: Tests
       run: bazel test --cxxopt=/std:c++14 --features=external_include_paths --test_output=errors ...


### PR DESCRIPTION
For context this is the action:
https://github.com/ilammy/msvc-dev-cmd

We use it for various Vulkan repos to setup CMake + Ninja on Windows.