### PR TITLE
Add support for the NXP QN9090 MCU

### DIFF
--- a/googletest/include/gtest/internal/gtest-port-arch.h
+++ b/googletest/include/gtest/internal/gtest-port-arch.h
@@ -113,6 +113,8 @@
 #define GTEST_OS_XTENSA 1
 #elif defined(__hexagon__)
 #define GTEST_OS_QURT 1
+#elif defined(CPU_QN9090) || defined(CPU_QN9090HN)
+#define GTEST_OS_NXP_QN9090 1
 #endif  // __CYGWIN__
 
 #endif  // GOOGLETEST_INCLUDE_GTEST_INTERNAL_GTEST_PORT_ARCH_H_

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -505,7 +505,8 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 #if (!(defined(GTEST_OS_LINUX_ANDROID) || defined(GTEST_OS_CYGWIN) || \
        defined(GTEST_OS_SOLARIS) || defined(GTEST_OS_HAIKU) ||        \
        defined(GTEST_OS_ESP32) || defined(GTEST_OS_ESP8266) ||        \
-       defined(GTEST_OS_XTENSA) || defined(GTEST_OS_QURT)))
+       defined(GTEST_OS_XTENSA) || defined(GTEST_OS_QURT) ||          \
+       defined(GTEST_OS_NXP_QN9090)))
 #define GTEST_HAS_STD_WSTRING 1
 #else
 #define GTEST_HAS_STD_WSTRING 0

--- a/googletest/src/gtest-filepath.cc
+++ b/googletest/src/gtest-filepath.cc
@@ -102,7 +102,7 @@ FilePath FilePath::GetCurrentDir() {
 #if defined(GTEST_OS_WINDOWS_MOBILE) || defined(GTEST_OS_WINDOWS_PHONE) || \
     defined(GTEST_OS_WINDOWS_RT) || defined(GTEST_OS_ESP8266) ||           \
     defined(GTEST_OS_ESP32) || defined(GTEST_OS_XTENSA) ||                 \
-    defined(GTEST_OS_QURT)
+    defined(GTEST_OS_QURT) || defined(GTEST_OS_NXP_QN9090)
   // These platforms do not have a current directory, so we just return
   // something reasonable.
   return FilePath(kCurrentDirectoryString);
@@ -356,7 +356,7 @@ bool FilePath::CreateFolder() const {
 #elif defined(GTEST_OS_WINDOWS)
   int result = _mkdir(pathname_.c_str());
 #elif defined(GTEST_OS_ESP8266) || defined(GTEST_OS_XTENSA) || \
-    defined(GTEST_OS_QURT)
+    defined(GTEST_OS_QURT) || defined(GTEST_OS_NXP_QN9090)
   // do nothing
   int result = 0;
 #else


### PR DESCRIPTION
Added additional defines to correctly detect the NXP QN9090 MCU platform and allow for native googletest compability.