### PR TITLE
googletest: ansi color

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -3228,7 +3228,8 @@ static const char* GetAnsiColorCode(GTestColor color) {
     case GTestColor::kYellow:
       return "3";
     default:
-      return nullptr;
+      assert(false);
+      return "9" ;
   }
 }
 


### PR DESCRIPTION
Adds support for kDefault option and also prevents from returning nullptr by choosing default color.

Issue: #4321