### PR TITLE
Suppress clang-tidy warnings about goto statements

### DIFF
--- a/googletest/include/gtest/internal/gtest-death-test-internal.h
+++ b/googletest/include/gtest/internal/gtest-death-test-internal.h
@@ -227,6 +227,7 @@ inline Matcher<const ::std::string&> MakeDeathTestMatcher(
             #statement,                                                        \
             ::testing::internal::MakeDeathTestMatcher(regex_or_matcher),       \
             __FILE__, __LINE__, &gtest_dt)) {                                  \
+      /* NOLINTNEXTLINE(cppcoreguidelines-avoid-goto, hicpp-avoid-goto) */     \
       goto GTEST_CONCAT_TOKEN_(gtest_label_, __LINE__);                        \
     }                                                                          \
     if (gtest_dt != nullptr) {                                                 \
@@ -234,6 +235,7 @@ inline Matcher<const ::std::string&> MakeDeathTestMatcher(
       switch (gtest_dt->AssumeRole()) {                                        \
         case ::testing::internal::DeathTest::OVERSEE_TEST:                     \
           if (!gtest_dt->Passed(predicate(gtest_dt->Wait()))) {                \
+            /* NOLINTNEXTLINE(cppcoreguidelines-avoid-goto, hicpp-avoid-goto) */ \
             goto GTEST_CONCAT_TOKEN_(gtest_label_, __LINE__);                  \
           }                                                                    \
           break;                                                               \

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1395,6 +1395,7 @@ class NeverThrown {
     gtest_msg.value += " with description \"";                                 \
     gtest_msg.value += e.what();                                               \
     gtest_msg.value += "\".";                                                  \
+    /* NOLINTNEXTLINE(cppcoreguidelines-avoid-goto, hicpp-avoid-goto) */       \
     goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__);                \
   }
 
@@ -1418,12 +1419,14 @@ class NeverThrown {
       gtest_msg.value = "Expected: " #statement                             \
                         " throws an exception of type " #expected_exception \
                         ".\n  Actual: it throws a different type.";         \
+      /* NOLINTNEXTLINE(cppcoreguidelines-avoid-goto, hicpp-avoid-goto) */  \
       goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__);           \
     }                                                                       \
     if (!gtest_caught_expected) {                                           \
       gtest_msg.value = "Expected: " #statement                             \
                         " throws an exception of type " #expected_exception \
                         ".\n  Actual: it throws nothing.";                  \
+      /* NOLINTNEXTLINE(cppcoreguidelines-avoid-goto, hicpp-avoid-goto) */  \
       goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__);           \
     }                                                                       \
   } else /*NOLINT*/                                                         \
@@ -1439,6 +1442,7 @@ class NeverThrown {
     gtest_msg.value += " with description \"";                    \
     gtest_msg.value += e.what();                                  \
     gtest_msg.value += "\".";                                     \
+    /* NOLINTNEXTLINE(cppcoreguidelines-avoid-goto, hicpp-avoid-goto) */ \
     goto GTEST_CONCAT_TOKEN_(gtest_label_testnothrow_, __LINE__); \
   }
 
@@ -1457,6 +1461,7 @@ class NeverThrown {
     GTEST_TEST_NO_THROW_CATCH_STD_EXCEPTION_()                           \
     catch (...) {                                                        \
       gtest_msg.value = "it throws.";                                    \
+      /* NOLINTNEXTLINE(cppcoreguidelines-avoid-goto, hicpp-avoid-goto) */ \
       goto GTEST_CONCAT_TOKEN_(gtest_label_testnothrow_, __LINE__);      \
     }                                                                    \
   } else                                                                 \
@@ -1476,6 +1481,7 @@ class NeverThrown {
       gtest_caught_any = true;                                       \
     }                                                                \
     if (!gtest_caught_any) {                                         \
+      /* NOLINTNEXTLINE(cppcoreguidelines-avoid-goto, hicpp-avoid-goto) */ \
       goto GTEST_CONCAT_TOKEN_(gtest_label_testanythrow_, __LINE__); \
     }                                                                \
   } else                                                             \
@@ -1504,6 +1510,7 @@ class NeverThrown {
         gtest_fatal_failure_checker;                                \
     GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement);      \
     if (gtest_fatal_failure_checker.has_new_fatal_failure()) {      \
+      /* NOLINTNEXTLINE(cppcoreguidelines-avoid-goto, hicpp-avoid-goto) */ \
       goto GTEST_CONCAT_TOKEN_(gtest_label_testnofatal_, __LINE__); \
     }                                                               \
   } else /* NOLINT */                                               \


### PR DESCRIPTION
Partially fixes #2442