### PR TITLE
Avoid unreachable code warning

### DIFF
--- a/googlemock/include/gmock/gmock-actions.h
+++ b/googlemock/include/gmock/gmock-actions.h
@@ -175,9 +175,15 @@ struct BuiltInDefaultValueGetter<T, false> {
   static T Get() {
     Assert(false, __FILE__, __LINE__,
            "Default action undefined for the function return type.");
-    return internal::Invalid<T>();
+#if defined(__GNUC__) || defined(__clang__)
+    __builtin_unreachable();
+#elif defined(_MSC_VER)
+    __assume(0);
+#else
+    return Invalid<T>();
     // The above statement will never be reached, but is required in
     // order for this function to compile.
+#endif
   }
 };
 


### PR DESCRIPTION
When a mocked function returns a custom type without a default constructor, MSVC will trigger a C4702 warning.

This PR takes the same approach as is done in [`Invalid<T>()`](https://github.com/google/googletest/blob/main/googlemock/include/gmock/internal/gmock-internal-utils.h#L316) to avoid the warning.