### PR TITLE
Remove public includes of `<iomanip>`

### DIFF
--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -51,7 +51,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <iomanip>
 #include <limits>
 #include <memory>
 #include <ostream>
@@ -1574,12 +1573,12 @@ AssertionResult CmpHelperFloatingPointEQ(const char* lhs_expression,
   }
 
   ::std::stringstream lhs_ss;
-  lhs_ss << std::setprecision(std::numeric_limits<RawType>::digits10 + 2)
-         << lhs_value;
+  lhs_ss.precision(std::numeric_limits<RawType>::digits10 + 2);
+  lhs_ss << lhs_value;
 
   ::std::stringstream rhs_ss;
-  rhs_ss << std::setprecision(std::numeric_limits<RawType>::digits10 + 2)
-         << rhs_value;
+  rhs_ss.precision(std::numeric_limits<RawType>::digits10 + 2);
+  rhs_ss << rhs_value;
 
   return EqFailure(lhs_expression, rhs_expression,
                    StringStreamToString(&lhs_ss), StringStreamToString(&rhs_ss),

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -58,7 +58,6 @@
 
 #include <cstdint>
 #include <functional>
-#include <iomanip>
 #include <limits>
 #include <map>
 #include <set>


### PR DESCRIPTION
This commit removes `<iomanip>` from public GoogleTest header files.

As `<iomanip>` is not a common included file, its content is unlikely to be included in translation units other than through GoogleTest includes.

By reducing the number of include directives public headers in GoogleTest, this may reduce the time taken to compile tests as it would reduce the amount of work that the preprocessor and compiler front-end need to do.