### PR TITLE
Fix GTestHelpTest.TestHelpFlag on FreeBSD

### DIFF
--- a/googletest/test/gtest_help_test.py
+++ b/googletest/test/gtest_help_test.py
@@ -43,11 +43,21 @@ import sys
 from googletest.test import gtest_test_utils
 
 
+FREEBSD = ('FreeBSD', 'GNU/kFreeBSD')
+NETBSD = ('NetBSD', )
+OPENBSD = ('OpenBSD', )
+
+def is_bsd_based_os() -> bool:
+  """Determine whether or not the OS is BSD-based."""
+  if os.name != 'posix':
+      return False
+
+  return os.uname()[0] in (FREEBSD + NETBSD + OPENBSD)
+
+
 IS_DARWIN = os.name == 'posix' and os.uname()[0] == 'Darwin'
 IS_LINUX = os.name == 'posix' and os.uname()[0] == 'Linux'
 IS_GNUHURD = os.name == 'posix' and os.uname()[0] == 'GNU'
-IS_GNUKFREEBSD = os.name == 'posix' and os.uname()[0] == 'GNU/kFreeBSD'
-IS_OPENBSD = os.name == 'posix' and os.uname()[0] == 'OpenBSD'
 IS_WINDOWS = os.name == 'nt'
 
 PROGRAM_PATH = gtest_test_utils.GetTestExecutablePath('gtest_help_test_')
@@ -136,7 +146,7 @@ class GTestHelpTest(gtest_test_utils.TestCase):
 
     self.assertTrue(HELP_REGEX.search(output), output)
 
-    if IS_DARWIN or IS_LINUX or IS_GNUHURD or IS_GNUKFREEBSD or IS_OPENBSD:
+    if IS_DARWIN or IS_LINUX or IS_GNUHURD or is_bsd_based_os():
       self.assertIn(STREAM_RESULT_TO_FLAG, output)
     else:
       self.assertNotIn(STREAM_RESULT_TO_FLAG, output)


### PR DESCRIPTION
The test supported a variety of BSDs, including kFreeBSD, but not FreeBSD.

Move the BSD checks to a separate function and support checking for FreeBSD, in addition to kFreeBSD.