### PR TITLE
Fix RETest/1.ImplicitConstructorWorks on non-ABSL platforms

### DIFF
--- a/googletest/test/googletest-port-test.cc
+++ b/googletest/test/googletest-port-test.cc
@@ -418,8 +418,8 @@ TYPED_TEST(RETest, ImplicitConstructorWorks) {
   const RE simple(TypeParam("hello"));
   EXPECT_STREQ("hello", simple.pattern());
 
-  const RE normal(TypeParam(".*(\\w+)"));
-  EXPECT_STREQ(".*(\\w+)", normal.pattern());
+  const RE normal(TypeParam(".*([[:alnum:]_]+)"));
+  EXPECT_STREQ(".*([[:alnum:]_]+)", normal.pattern());
 }
 
 // Tests that RE's constructors reject invalid regular expressions.


### PR DESCRIPTION
The last regular expression specified in the test is not technically POSIX compatible. Use `[[:alnum:]_]` instead of `\w+`; the latter is a Perl-compatible regular expression.