### PR TITLE
Print stacktraces using std::stacktrace if available

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -216,6 +216,7 @@
 //                                specializations. Always defined to 0 or 1.
 //   GTEST_USE_OWN_FLAGFILE_FLAG_ - Always defined to 0 or 1.
 //   GTEST_HAS_CXXABI_H_ - Always defined to 0 or 1.
+//   GTEST_HAS_STD_STACKTRACE_ - Always defined to 0 or 1.
 //   GTEST_CAN_STREAM_RESULTS_ - Always defined to 0 or 1.
 //   GTEST_HAS_ALT_PATH_SEP_ - Always defined to 0 or 1.
 //   GTEST_WIDE_STRING_USES_UTF16_ - Always defined to 0 or 1.
@@ -870,6 +871,14 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 #define GTEST_HAS_CXXABI_H_ 1
 #else
 #define GTEST_HAS_CXXABI_H_ 0
+#endif
+#endif
+
+#if !defined(GTEST_HAS_STD_STACKTRACE_)
+#if defined(__cpp_lib_stacktrace) && __cpp_lib_stacktrace >= 202011L
+#define GTEST_HAS_STD_STACKTRACE_ 1
+#else
+#define GTEST_HAS_STD_STACKTRACE_ 0
 #endif
 #endif
 


### PR DESCRIPTION
Reviewers: See issue #4336 for some design considerations. This PR chooses approach B. The first commit changes the design, and the second commit adds the std::stacktrace feature. If this should be split into two separate pull requests (one commit per PR), let me know.

If std::stacktrace is available (currently only GCC (opt-in feature) and MSVC), use it for printing stack traces.

If both Abseil and std::stacktrace are available, prefer std::stacktrace.

Advantages of std::stacktrace over Abseil:

* Includes file and line information
* Includes DLL information
* Better stack trace quality on Windows

Disadvantages of std::stacktrace compared to Abseil:

* Runs more slowly on Windows
* Includes information which might not be relevant such as byte offsets
* Printed lines are longer thus harder to skim

Before (Windows using Abseil):

    [ RUN      ] FooTest.Xyz
    [snip]\googletest-filter-unittest_.cc(49): error: Failed
    Expected failure.
    Stack trace:
      00007FF69EF90E8D: testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test,void>
      00007FF69EF90AC3: testing::internal::HandleExceptionsInMethodIfSupported<testing::Test,void>
      00007FF69EF5C01B: testing::Test::Run
      00007FF69EF5CCC5: testing::TestInfo::Run
      00007FF69EF5D6EC: testing::TestSuite::Run
    ... Google Test internal frames ...

    [  FAILED  ] FooTest.Xyz (21 ms)

After (Windows using MSVC STL's std::stacktrace):

    [ RUN      ] FooTest.Xyz
    [snip]\googletest-filter-unittest_.cc(49): error: Failed
    Expected failure.
    Stack trace:
      00007FF6770283A9: googletest_filter_unittest_!`anonymous namespace'::FooTest_Xyz_Test::TestBody+0x89 [snip]\googletest-filter-unittest_.cc:49
      00007FF677080E8D: googletest_filter_unittest_!testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test,void>+0x1D [snip]\gtest.cc:2609
      00007FF677080AC3: googletest_filter_unittest_!testing::internal::HandleExceptionsInMethodIfSupported<testing::Test,void>+0x73 [snip]\gtest.cc:2652
      00007FF67704C01B: googletest_filter_unittest_!testing::Test::Run+0xAB [snip]\gtest.cc:2698
    ... Google Test internal frames ...

    [  FAILED  ] FooTest.Xyz (127 ms)


