### PR TITLE
Use constructor instead of aggregate initialization for ActionAdaptor

### DIFF
--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -1096,11 +1096,16 @@ class TypedExpectation<R(Args...)> : public ExpectationBase {
 
   // An adaptor that turns a OneAction<F> into something compatible with
   // Action<F>. Must be called at most once.
-  struct ActionAdaptor {
-    std::shared_ptr<OnceAction<R(Args...)>> once_action;
+  class ActionAdaptor {
+   private:
+    std::shared_ptr<OnceAction<R(Args...)>> once_action_;
+
+   public:
+    ActionAdaptor(std::shared_ptr<OnceAction<R(Args...)>>&& once_action) :
+      once_action_(once_action) {}
 
     R operator()(Args&&... args) const {
-      return std::move(*once_action).Call(std::forward<Args>(args)...);
+      return std::move(*once_action_).Call(std::forward<Args>(args)...);
     }
   };
 


### PR DESCRIPTION
This PR fixes https://github.com/google/googletest/issues/3553