### PR TITLE
Prefer $TMPDIR to /data/local/tmp on Android

### DIFF
--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -1067,10 +1067,7 @@ class CapturedStream {
     //
     // However, prefer using the TMPDIR environment variable if set, as newer
     // devices may have /data/local/tmp read-only.
-    if (auto tmpdir = ::getenv("TMPDIR"))
-      name_template.assign(tmpdir) += '/';
-    else
-      name_template = "/data/local/tmp/";
+    name_template = TempDir();
 #elif defined(GTEST_OS_IOS)
     char user_temp_dir[PATH_MAX + 1];
 

--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -1064,7 +1064,13 @@ class CapturedStream {
     // The location /data/local/tmp is directly accessible from native code.
     // '/sdcard' and other variants cannot be relied on, as they are not
     // guaranteed to be mounted, or may have a delay in mounting.
-    name_template = "/data/local/tmp/";
+    //
+    // However, prefer using the TMPDIR environment variable if set, as newer
+    // devices may have /data/local/tmp read-only.
+    if (auto tmpdir = ::getenv("TMPDIR"))
+      name_template.assign(tmpdir) += '/';
+    else
+      name_template = "/data/local/tmp/";
 #elif defined(GTEST_OS_IOS)
     char user_temp_dir[PATH_MAX + 1];
 


### PR DESCRIPTION
Newer devices can have the latter location read-only. (I observed this with Termux on a non-rooted Pixel 6.)

Fixes: #4167