### PR TITLE
Http to https, issue number #4341

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,9 @@ PR is acceptable as an alternative.
 ## The Google Test and Google Mock Communities
 
 The Google Test community exists primarily through the
-[discussion group](http://groups.google.com/group/googletestframework) and the
+[discussion group](https://groups.google.com/group/googletestframework) and the
 GitHub repository. Likewise, the Google Mock community exists primarily through
-their own [discussion group](http://groups.google.com/group/googlemock). You are
+their own [discussion group](https://groups.google.com/group/googlemock). You are
 definitely encouraged to contribute to the discussion and you can also help us
 to keep the effectiveness of the group high by following and promoting the
 guidelines listed here.

--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ tools.
 In addition to many internal projects at Google, GoogleTest is also used by the
 following notable projects:
 
-*   The [Chromium projects](http://www.chromium.org/) (behind the Chrome browser
+*   The [Chromium projects](https://www.chromium.org/) (behind the Chrome browser
     and Chrome OS).
-*   The [LLVM](http://llvm.org/) compiler.
+*   The [LLVM](https://llvm.org/) compiler.
 *   [Protocol Buffers](https://github.com/google/protobuf), Google's data
     interchange format.
-*   The [OpenCV](http://opencv.org/) computer vision library.
+*   The [OpenCV](https://opencv.org/) computer vision library.
 
 ## Related Open Source Projects
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -508,9 +508,9 @@ TEST_F(FooDeathTest, DoesThat) {
 When built with Bazel and using Abseil, GoogleTest uses the
 [RE2](https://github.com/google/re2/wiki/Syntax) syntax. Otherwise, for POSIX
 systems (Linux, Cygwin, Mac), GoogleTest uses the
-[POSIX extended regular expression](http://www.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap09.html#tag_09_04)
+[POSIX extended regular expression](https://www.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap09.html#tag_09_04)
 syntax. To learn about POSIX syntax, you may want to read this
-[Wikipedia entry](http://en.wikipedia.org/wiki/Regular_expression#POSIX_extended).
+[Wikipedia entry](https://en.wikipedia.org/wiki/Regular_expression#POSIX_extended).
 
 On Windows, GoogleTest uses its own simple regular expression implementation. It
 lacks many features. For example, we don't support union (`"x|y"`), grouping

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -2171,7 +2171,7 @@ The report format conforms to the following JSON Schema:
 
 ```json
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "https://json-schema.org/schema#",
   "type": "object",
   "definitions": {
     "TestCase": {

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -607,7 +607,7 @@ defined such that we can print a value of `FooType`.
 
 In addition, if `FooType` is declared in a name space, the `<<` operator also
 needs to be defined in the *same* name space. See
-[Tip of the Week #49](http://abseil.io/tips/49) for details.
+[Tip of the Week #49](https://abseil.io/tips/49) for details.
 
 ## How do I suppress the memory leak messages on Windows?
 
@@ -628,10 +628,10 @@ mistake in production. Such cleverness also leads to
 advise against the practice, and GoogleTest doesn't provide a way to do it.
 
 In general, the recommended way to cause the code to behave differently under
-test is [Dependency Injection](http://en.wikipedia.org/wiki/Dependency_injection). You can inject
+test is [Dependency Injection](https://en.wikipedia.org/wiki/Dependency_injection). You can inject
 different functionality from the test and from the production code. Since your
 production code doesn't link in the for-test logic at all (the
-[`testonly`](http://docs.bazel.build/versions/master/be/common-definitions.html#common.testonly) attribute for BUILD targets helps to ensure
+[`testonly`](https://docs.bazel.build/versions/master/be/common-definitions.html#common.testonly) attribute for BUILD targets helps to ensure
 that), there is no danger in accidentally running it.
 
 However, if you *really*, *really*, *really* have no choice, and if you follow


### PR DESCRIPTION
Changed unencrypted public links to use HTTPS.
The new URLs work well.

I've signed the Contributor License Agreement