### PR TITLE
fix: correct threadsafe preprocessor check

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -1190,7 +1190,7 @@ void ClearInjectableArgvs();
 #endif  // GTEST_HAS_DEATH_TEST
 
 // Defines synchronization primitives.
-#ifdef GTEST_IS_THREADSAFE
+#if defined(GTEST_IS_THREADSAFE) && (GTEST_IS_THREADSAFE==1)
 
 #ifdef GTEST_OS_WINDOWS
 // Provides leak-safe Windows kernel handle ownership.


### PR DESCRIPTION
Corrected logic in checking the define for GTEST_IS_THREADSAFE.  The block was being entered when GTEST_IS_THREADSAFE was defined at all vs. being defined and set to a value of 1.