### PR TITLE
Add MODULE.bazel to support bzlmod

### DIFF
--- a/.github/workflows/gtest-ci.yml
+++ b/.github/workflows/gtest-ci.yml
@@ -4,40 +4,45 @@ on:
   push:
   pull_request:
 
-env:
-  BAZEL_CXXOPTS: -std=c++14
-
 jobs:
   Linux:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Tests
       run: bazel test --cxxopt=-std=c++14 --features=external_include_paths --test_output=errors ...
 
+    - name: Tests with bzlmod
+      run: bazel test --cxxopt=-std=c++14 --features=external_include_paths --test_output=errors --enable_bzlmod ...
+      
   macOS:
     runs-on: macos-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Tests
-      run:  bazel test --cxxopt=-std=c++14 --features=external_include_paths --test_output=errors ...
+      run: bazel test --cxxopt=-std=c++14 --features=external_include_paths --test_output=errors ...
 
+    - name: Tests with bzlmod
+      run: bazel test --cxxopt=-std=c++14 --features=external_include_paths --test_output=errors --enable_bzlmod ...
 
   Windows:
     runs-on: windows-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Tests
       run: bazel test --cxxopt=/std:c++14 --features=external_include_paths --test_output=errors ...
+
+    - name: Tests with bzlmod
+      run: bazel test --cxxopt=/std:c++14 --features=external_include_paths --test_output=errors --enable_bzlmod ...

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,42 @@
+module(
+    name = "googletest",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "abseil-cpp", version = "20230802.0", repo_name = "com_google_absl")
+bazel_dep(name = "bazel_skylib", version = "1.4.2")
+bazel_dep(name = "platforms", version = "0.0.7")
+bazel_dep(name = "re2", version = "2021-09-01", repo_name = "com_googlesource_code_re2")
+bazel_dep(name = "rules_cc", version = "0.0.8")
+bazel_dep(name = "rules_python", version = "0.25.0")
+
+archive_override(
+    module_name = "rules_python",  # 2023-07-31T20:39:27Z
+    strip_prefix = "rules_python-e355becc30275939d87116a4ec83dad4bb50d9e1",
+    urls = ["https://github.com/bazelbuild/rules_python/archive/e355becc30275939d87116a4ec83dad4bb50d9e1.zip"],
+)
+
+archive_override(
+    module_name = "bazel_skylib",  # 2023-05-31T19:24:07Z
+    strip_prefix = "bazel-skylib-288731ef9f7f688932bd50e704a91a45ec185f9b",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/288731ef9f7f688932bd50e704a91a45ec185f9b.zip"],
+)
+
+archive_override(
+    module_name = "platforms",  # 2023-07-28T19:44:27Z
+    strip_prefix = "platforms-4ad40ef271da8176d4fc0194d2089b8a76e19d7b",
+    urls = ["https://github.com/bazelbuild/platforms/archive/4ad40ef271da8176d4fc0194d2089b8a76e19d7b.zip"],
+)
+
+archive_override(
+    module_name = "com_googlesource_code_re2",  # 2023-03-17T11:36:51Z
+    strip_prefix = "re2-578843a516fd1da7084ae46209a75f3613b6065e",
+    urls = ["https://github.com/google/re2/archive/578843a516fd1da7084ae46209a75f3613b6065e.zip"],
+)
+
+archive_override(
+    module_name = "abseil-cpp",  # 2023-08-01T14:59:13Z
+    patches = ["//:module_dot_bazel.patch"],
+    strip_prefix = "abseil-cpp-22091f4c0d6626b3ef40446ce3d4ccab19425ca3",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/22091f4c0d6626b3ef40446ce3d4ccab19425ca3.zip"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,27 +1,28 @@
 workspace(name = "com_google_googletest")
 
 load("//:googletest_deps.bzl", "googletest_deps")
+
 googletest_deps()
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-  name = "rules_python",  # 2023-07-31T20:39:27Z
-  sha256 = "1250b59a33c591a1c4ba68c62e95fc88a84c334ec35a2e23f46cbc1b9a5a8b55",
-  strip_prefix = "rules_python-e355becc30275939d87116a4ec83dad4bb50d9e1",
-  urls = ["https://github.com/bazelbuild/rules_python/archive/e355becc30275939d87116a4ec83dad4bb50d9e1.zip"],
+    name = "rules_python",  # 2023-07-31T20:39:27Z
+    sha256 = "1250b59a33c591a1c4ba68c62e95fc88a84c334ec35a2e23f46cbc1b9a5a8b55",
+    strip_prefix = "rules_python-e355becc30275939d87116a4ec83dad4bb50d9e1",
+    urls = ["https://github.com/bazelbuild/rules_python/archive/e355becc30275939d87116a4ec83dad4bb50d9e1.zip"],
 )
 
 http_archive(
-  name = "bazel_skylib",  # 2023-05-31T19:24:07Z
-  sha256 = "08c0386f45821ce246bbbf77503c973246ed6ee5c3463e41efc197fa9bc3a7f4",
-  strip_prefix = "bazel-skylib-288731ef9f7f688932bd50e704a91a45ec185f9b",
-  urls = ["https://github.com/bazelbuild/bazel-skylib/archive/288731ef9f7f688932bd50e704a91a45ec185f9b.zip"],
+    name = "bazel_skylib",  # 2023-05-31T19:24:07Z
+    sha256 = "08c0386f45821ce246bbbf77503c973246ed6ee5c3463e41efc197fa9bc3a7f4",
+    strip_prefix = "bazel-skylib-288731ef9f7f688932bd50e704a91a45ec185f9b",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/288731ef9f7f688932bd50e704a91a45ec185f9b.zip"],
 )
 
 http_archive(
-  name = "platforms",  # 2023-07-28T19:44:27Z
-  sha256 = "40eb313613ff00a5c03eed20aba58890046f4d38dec7344f00bb9a8867853526",
-  strip_prefix = "platforms-4ad40ef271da8176d4fc0194d2089b8a76e19d7b",
-  urls = ["https://github.com/bazelbuild/platforms/archive/4ad40ef271da8176d4fc0194d2089b8a76e19d7b.zip"],
+    name = "platforms",  # 2023-07-28T19:44:27Z
+    sha256 = "40eb313613ff00a5c03eed20aba58890046f4d38dec7344f00bb9a8867853526",
+    strip_prefix = "platforms-4ad40ef271da8176d4fc0194d2089b8a76e19d7b",
+    urls = ["https://github.com/bazelbuild/platforms/archive/4ad40ef271da8176d4fc0194d2089b8a76e19d7b.zip"],
 )

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,0 +1,3 @@
+# When using Bzlmod WORKSPACE.bzlmod will take precedence before the WORKSPACE file.
+# Via this "empty" WORKSPACE.bzlmod file we can assure that Bzlmod works without the legacy WORKSPACE file
+# and everything is prepared for a "pure" Bzlmod approach

--- a/module_dot_bazel.patch
+++ b/module_dot_bazel.patch
@@ -1,0 +1,14 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,11 @@
++"""Module definition for Abseil LTS 20230802.0."""
++module(
++    name = "abseil-cpp",
++    version = "20230802.0",
++    compatibility_level = 1,
++)
++bazel_dep(name = "rules_cc", version = "0.0.8")
++bazel_dep(name = "platforms", version = "0.0.7")
++bazel_dep(name = "bazel_skylib", version = "1.4.2")
++bazel_dep(name = "googletest", version = "1.14.0", repo_name = "com_google_googletest")
++bazel_dep(name = "google_benchmark", version = "1.8.2", repo_name = "com_github_google_benchmark")


### PR DESCRIPTION
Life with [Bzlmod](https://bazel.build/external/overview#bzlmod) is easier if every dependency provides a `MODULE.bazel` file. Therefore, the main purpose of this PR is to introduce a `MODULE.bazel` file in googletest. The `MODULE.bazel` can coexist with the `WORKSPACE` file. Users have to enable bzlmod via `--enable_bzlmod` flag (more details to the Bzlmod migration plan can be found [here](https://blog.bazel.build/2023/07/24/whats-new-with-bzlmod.html#high-level-roadmap-for-the-future)).

This PR is similar to https://github.com/google/googletest/pull/4118#pullrequestreview-1611267844

Differences:
- Uses newer versions of modules
- Uses `archive_ovrride` to support live at head philosophy
- Update checkout action (v3 -> v4) in GitHub workflow
- Reformates old WORKSPACE file using `buildifier`

Further remarks:
- [module_dot_bazel.patch](https://github.com/google/googletest/pull/4368/files#diff-e208d606896d1d6088d3b4a50b0657bc53aa829efc32d2995bc5d9d2c345da7e) is needed since abseil-cpp does not provide a `MODULE.bazel` file unit now - this is a chicken egg situation between the public GitHub repos of googletest and abseil

I recommend closing https://github.com/google/googletest/pull/4118#pullrequestreview-1611267844 and merging this PR