### PR TITLE
Fix compile warnings in gmock-function-mocker.h

### DIFF
--- a/googlemock/include/gmock/gmock-function-mocker.h
+++ b/googlemock/include/gmock/gmock-function-mocker.h
@@ -69,22 +69,22 @@ constexpr bool PrefixOf(const char* a, const char* b) {
   return *a == 0 || (*a == *b && internal::PrefixOf(a + 1, b + 1));
 }
 
-template <int N, int M>
+template <size_t N, size_t M>
 constexpr bool StartsWith(const char (&prefix)[N], const char (&str)[M]) {
   return N <= M && internal::PrefixOf(prefix, str);
 }
 
-template <int N, int M>
+template <size_t N, size_t M>
 constexpr bool EndsWith(const char (&suffix)[N], const char (&str)[M]) {
   return N <= M && internal::PrefixOf(suffix, str + M - N);
 }
 
-template <int N, int M>
+template <size_t N, size_t M>
 constexpr bool Equals(const char (&a)[N], const char (&b)[M]) {
   return N == M && internal::PrefixOf(a, b);
 }
 
-template <int N>
+template <size_t N>
 constexpr bool ValidateSpec(const char (&spec)[N]) {
   return internal::Equals("const", spec) ||
          internal::Equals("override", spec) ||


### PR DESCRIPTION
This fixes compile warning `conversion to ‘long unsigned int’ from ‘int’ may change the sign of the result` in gmock-function-mocker.h.
Template type int changed to size_t.