### PR TITLE
Better exception printing for multi-line exceptions #4387

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -2571,7 +2571,14 @@ static std::string FormatCxxExceptionMessage(const char* description,
                                              const char* location) {
   Message message;
   if (description != nullptr) {
-    message << "C++ exception with description \"" << description << "\"";
+    std::string desc(description);
+    if (desc.find('\n') == std::string::npos) {
+      message << "C++ exception with description \"" << desc << "\"";
+    } else {
+      message << "C++ exception with description\n> ";
+      std::replace(desc.begin(), desc.end(), '\n', '\n> ');
+      message << desc;
+    }
   } else {
     message << "Unknown C++ exception";
   }
@@ -2579,6 +2586,7 @@ static std::string FormatCxxExceptionMessage(const char* description,
 
   return message.GetString();
 }
+
 
 static std::string PrintTestPartResultToString(
     const TestPartResult& test_part_result);


### PR DESCRIPTION
This makes GTest easier to use, by making its messages slightly more readable. This is clearly nice-to-have. The patch is probably only 15 additional lines of code + test cases. We are happy to provide a patch for it.


For exceptions with multi-line e.what() descriptions, GTest currently prints:
```
C++ exception with description "Error: 22000
Error while communicating with S3
DETAIL: aws-s3-bucket-name: mybucket
INTERNAL DETAIL: aws-s3-bucket-name: mybucket" thrown in the test body.
```

Modifications:
```
C++ exception with description
> Error: 22000
> Error while communicating with S3
> DETAIL: aws-s3-bucket-name: mybucket
> INTERNAL DETAIL: aws-s3-bucket-name: mybucket
thrown in the test body.
```

The `FormatCxxExceptionMessage` function will detect if the description contains any newline characters. If it contains no newlines, keep the logic as is it was previously (i.e. print the error message on the same line). If the description contains newlines, print the exception with newlines in it and replace every `\n` by `\n>`  before printing (of course, with special handling to correctly handle the potential presence/absence of a trailing `\n`).
