### PR TITLE
Add missing include for raise(3)

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -43,6 +43,7 @@
 #include <algorithm>
 #include <chrono>  // NOLINT
 #include <cmath>
+#include <csignal>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
If SIGTRAP is defined, this file may end up using raise(3), which is defined in csignal, leading to a compilation failure on at least OpenBSD/sparc64 with gcc 8.