### PR TITLE
Add public interface for XmlUnitTestResultPrinter

### DIFF
--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1018,6 +1018,23 @@ class EmptyTestEventListener : public TestEventListener {
   void OnTestProgramEnd(const UnitTest& /*unit_test*/) override {}
 };
 
+class XmlUnitTestResultPrinter : public EmptyTestEventListener {
+ public:
+  XmlUnitTestResultPrinter(const char* output_file);
+
+  XmlUnitTestResultPrinter(std::ostream* output_stream);
+
+  XmlUnitTestResultPrinter(const XmlUnitTestResultPrinter&) = delete;
+  XmlUnitTestResultPrinter& operator=(const XmlUnitTestResultPrinter&) = delete;
+
+  void OnTestIterationEnd(const UnitTest& unit_test, int iteration) override;
+  void ListTestsMatchingFilter(const std::vector<TestSuite*>& test_suites);
+
+ private:
+  const std::string output_file_;
+  std::ostream* output_stream_;
+};
+
 // TestEventListeners lets users add listeners to track events in Google Test.
 class GTEST_API_ TestEventListeners {
  public:

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1020,7 +1020,9 @@ class EmptyTestEventListener : public TestEventListener {
 
 class XmlUnitTestResultPrinter : public EmptyTestEventListener {
  public:
+#if GTEST_HAS_FILE_SYSTEM
   XmlUnitTestResultPrinter(const char* output_file);
+#endif  // GTEST_HAS_FILE_SYSTEM
 
   XmlUnitTestResultPrinter(std::ostream* output_stream);
 
@@ -1031,7 +1033,9 @@ class XmlUnitTestResultPrinter : public EmptyTestEventListener {
   void ListTestsMatchingFilter(const std::vector<TestSuite*>& test_suites);
 
  private:
+#if GTEST_HAS_FILE_SYSTEM
   const std::string output_file_;
+#endif  // GTEST_HAS_FILE_SYSTEM
   std::ostream* output_stream_;
 };
 

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -2342,7 +2342,6 @@ static std::vector<std::string> GetReservedAttributesForElement(
   return std::vector<std::string>();
 }
 
-#if GTEST_HAS_FILE_SYSTEM
 // TODO(jdesprez): Merge the two getReserved attributes once skip is improved
 // This function is only used when file systems are enabled.
 static std::vector<std::string> GetReservedOutputAttributesForElement(
@@ -2359,7 +2358,6 @@ static std::vector<std::string> GetReservedOutputAttributesForElement(
   // This code is unreachable but some compilers may not realizes that.
   return std::vector<std::string>();
 }
-#endif
 
 static std::string FormatWordList(const std::vector<std::string>& words) {
   Message word_list;
@@ -3893,7 +3891,6 @@ void TestEventRepeater::OnTestIterationEnd(const UnitTest& unit_test,
 
 // End TestEventRepeater
 
-#if GTEST_HAS_FILE_SYSTEM
 // This class generates an XML output file.
 class XmlUnitTestResultPrinter : public EmptyTestEventListener {
  public:
@@ -4414,7 +4411,6 @@ void XmlUnitTestResultPrinter::OutputXmlTestProperties(
 }
 
 // End XmlUnitTestResultPrinter
-#endif  // GTEST_HAS_FILE_SYSTEM
 
 #if GTEST_HAS_FILE_SYSTEM
 // This class generates an JSON output file.
@@ -5111,6 +5107,7 @@ void TestEventListeners::SuppressEventForwarding(bool suppress) {
   repeater_->set_forwarding_enabled(!suppress);
 }
 
+#if GTEST_HAS_FILE_SYSTEM
 // Creates a new XmlUnitTestResultPrinter.
 XmlUnitTestResultPrinter::XmlUnitTestResultPrinter(const char* output_file)
     : output_file_(output_file) {
@@ -5118,6 +5115,7 @@ XmlUnitTestResultPrinter::XmlUnitTestResultPrinter(const char* output_file)
     GTEST_LOG_(FATAL) << "XML output file may not be null";
   }
 }
+#endif  // GTEST_HAS_FILE_SYSTEM
 
 // Creates a new XmlUnitTestResultPrinter.
 XmlUnitTestResultPrinter::XmlUnitTestResultPrinter(std::ostream* output_stream)
@@ -5130,38 +5128,46 @@ XmlUnitTestResultPrinter::XmlUnitTestResultPrinter(std::ostream* output_stream)
 // Called after the unit test ends.
 void XmlUnitTestResultPrinter::OnTestIterationEnd(const UnitTest& unit_test,
                                                   int /*iteration*/) {
+#if GTEST_HAS_FILE_SYSTEM
   FILE* xmlout = 0;
   if(!output_stream_) {
       xmlout = internal::OpenFileForWriting(output_file_);
       output_stream_ = new std::stringstream;
   }
+#endif  // GTEST_HAS_FILE_SYSTEM
 
   internal::XmlUnitTestResultPrinter::PrintXmlUnitTest(output_stream_, unit_test);
 
+#if GTEST_HAS_FILE_SYSTEM
   if(xmlout) {
       fprintf(xmlout, "%s", internal::StringStreamToString(static_cast<std::stringstream*>(output_stream_)).c_str());
       fclose(xmlout);
       delete output_stream_;
       output_stream_ = 0;
   }
+#endif  // GTEST_HAS_FILE_SYSTEM
 }
 
 void XmlUnitTestResultPrinter::ListTestsMatchingFilter(
       const std::vector<TestSuite*>& test_suites) {
+#if GTEST_HAS_FILE_SYSTEM
   FILE* xmlout = 0;
   if(!output_stream_) {
       xmlout = internal::OpenFileForWriting(output_file_);
       output_stream_ = new std::stringstream;
   }
+#endif  // GTEST_HAS_FILE_SYSTEM
 
   internal::XmlUnitTestResultPrinter::PrintXmlTestsList(output_stream_, test_suites);
 
+#if GTEST_HAS_FILE_SYSTEM
   if(xmlout) {
       fprintf(xmlout, "%s", internal::StringStreamToString(static_cast<std::stringstream*>(output_stream_)).c_str());
       fclose(xmlout);
       delete output_stream_;
       output_stream_ = 0;
   }
+#endif  // GTEST_HAS_FILE_SYSTEM
 }
 
 // class UnitTest

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -3897,10 +3897,7 @@ void TestEventRepeater::OnTestIterationEnd(const UnitTest& unit_test,
 // This class generates an XML output file.
 class XmlUnitTestResultPrinter : public EmptyTestEventListener {
  public:
-  explicit XmlUnitTestResultPrinter(const char* output_file);
-
-  void OnTestIterationEnd(const UnitTest& unit_test, int iteration) override;
-  void ListTestsMatchingFilter(const std::vector<TestSuite*>& test_suites);
+  XmlUnitTestResultPrinter() = delete;
 
   // Prints an XML summary of all unit tests.
   static void PrintXmlTestsList(std::ostream* stream,
@@ -3982,39 +3979,8 @@ class XmlUnitTestResultPrinter : public EmptyTestEventListener {
   static void OutputXmlTestProperties(std::ostream* stream,
                                       const TestResult& result);
 
-  // The output file.
-  const std::string output_file_;
-
-  XmlUnitTestResultPrinter(const XmlUnitTestResultPrinter&) = delete;
-  XmlUnitTestResultPrinter& operator=(const XmlUnitTestResultPrinter&) = delete;
+  friend ::testing::XmlUnitTestResultPrinter;
 };
-
-// Creates a new XmlUnitTestResultPrinter.
-XmlUnitTestResultPrinter::XmlUnitTestResultPrinter(const char* output_file)
-    : output_file_(output_file) {
-  if (output_file_.empty()) {
-    GTEST_LOG_(FATAL) << "XML output file may not be null";
-  }
-}
-
-// Called after the unit test ends.
-void XmlUnitTestResultPrinter::OnTestIterationEnd(const UnitTest& unit_test,
-                                                  int /*iteration*/) {
-  FILE* xmlout = OpenFileForWriting(output_file_);
-  std::stringstream stream;
-  PrintXmlUnitTest(&stream, unit_test);
-  fprintf(xmlout, "%s", StringStreamToString(&stream).c_str());
-  fclose(xmlout);
-}
-
-void XmlUnitTestResultPrinter::ListTestsMatchingFilter(
-    const std::vector<TestSuite*>& test_suites) {
-  FILE* xmlout = OpenFileForWriting(output_file_);
-  std::stringstream stream;
-  PrintXmlTestsList(&stream, test_suites);
-  fprintf(xmlout, "%s", StringStreamToString(&stream).c_str());
-  fclose(xmlout);
-}
 
 // Returns an XML-escaped copy of the input string str.  If is_attribute
 // is true, the text is meant to appear as an attribute value, and
@@ -5145,6 +5111,59 @@ void TestEventListeners::SuppressEventForwarding(bool suppress) {
   repeater_->set_forwarding_enabled(!suppress);
 }
 
+// Creates a new XmlUnitTestResultPrinter.
+XmlUnitTestResultPrinter::XmlUnitTestResultPrinter(const char* output_file)
+    : output_file_(output_file) {
+  if (output_file_.empty()) {
+    GTEST_LOG_(FATAL) << "XML output file may not be null";
+  }
+}
+
+// Creates a new XmlUnitTestResultPrinter.
+XmlUnitTestResultPrinter::XmlUnitTestResultPrinter(std::ostream* output_stream)
+    : output_stream_(output_stream) {
+  if (!output_stream->good()) {
+    GTEST_LOG_(FATAL) << "XML output is not good";
+  }
+}
+
+// Called after the unit test ends.
+void XmlUnitTestResultPrinter::OnTestIterationEnd(const UnitTest& unit_test,
+                                                  int /*iteration*/) {
+  FILE* xmlout = 0;
+  if(!output_stream_) {
+      xmlout = internal::OpenFileForWriting(output_file_);
+      output_stream_ = new std::stringstream;
+  }
+
+  internal::XmlUnitTestResultPrinter::PrintXmlUnitTest(output_stream_, unit_test);
+
+  if(xmlout) {
+      fprintf(xmlout, "%s", internal::StringStreamToString(static_cast<std::stringstream*>(output_stream_)).c_str());
+      fclose(xmlout);
+      delete output_stream_;
+      output_stream_ = 0;
+  }
+}
+
+void XmlUnitTestResultPrinter::ListTestsMatchingFilter(
+      const std::vector<TestSuite*>& test_suites) {
+  FILE* xmlout = 0;
+  if(!output_stream_) {
+      xmlout = internal::OpenFileForWriting(output_file_);
+      output_stream_ = new std::stringstream;
+  }
+
+  internal::XmlUnitTestResultPrinter::PrintXmlTestsList(output_stream_, test_suites);
+
+  if(xmlout) {
+      fprintf(xmlout, "%s", internal::StringStreamToString(static_cast<std::stringstream*>(output_stream_)).c_str());
+      fclose(xmlout);
+      delete output_stream_;
+      output_stream_ = 0;
+  }
+}
+
 // class UnitTest
 
 // Gets the singleton UnitTest object.  The first time this method is
@@ -5630,7 +5649,7 @@ void UnitTestImpl::ConfigureXmlOutput() {
   const std::string& output_format = UnitTestOptions::GetOutputFormat();
 #if GTEST_HAS_FILE_SYSTEM
   if (output_format == "xml") {
-    listeners()->SetDefaultXmlGenerator(new XmlUnitTestResultPrinter(
+    listeners()->SetDefaultXmlGenerator(new ::testing::XmlUnitTestResultPrinter(
         UnitTestOptions::GetAbsolutePathToOutputFile().c_str()));
   } else if (output_format == "json") {
     listeners()->SetDefaultXmlGenerator(new JsonUnitTestResultPrinter(
@@ -6206,9 +6225,7 @@ void UnitTestImpl::ListTestsMatchingFilter() {
         UnitTestOptions::GetAbsolutePathToOutputFile().c_str());
     std::stringstream stream;
     if (output_format == "xml") {
-      XmlUnitTestResultPrinter(
-          UnitTestOptions::GetAbsolutePathToOutputFile().c_str())
-          .PrintXmlTestsList(&stream, test_suites_);
+      XmlUnitTestResultPrinter::PrintXmlTestsList(&stream, test_suites_);
     } else if (output_format == "json") {
       JsonUnitTestResultPrinter(
           UnitTestOptions::GetAbsolutePathToOutputFile().c_str())


### PR DESCRIPTION
Allowing custom gtest_main implementations to instantiate the XmlUnitTestResultPrinter with either a given file path or any other kind of std::ostream to write to.

This is useful for e.g. embedded cases where an XML report is still wanted, but not file system is available, by instantiating with a std::stringstream and delivering the data via any custom mean.

Related to #1930

This clearly needs some more polishing (e.g. docs in the header), but before I'll do the chores, I'd like some feedback :)