### PR TITLE
[#4294] --gtest_break_on_failure conflicts with EXPECT_NONFATAL_FAILURE.

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -5342,7 +5342,8 @@ void UnitTest::AddTestPartResult(TestPartResult::Type result_type,
       result);
 
   if (result_type != TestPartResult::kSuccess &&
-      result_type != TestPartResult::kSkip) {
+      result_type != TestPartResult::kSkip &&
+      result_type != TestPartResult::kNonFatalFailure) {
     // gtest_break_on_failure takes precedence over
     // gtest_throw_on_failure.  This allows a user to set the latter
     // in the code (perhaps in order to use Google Test assertions


### PR DESCRIPTION
Changes the behavior so that the flags **--gtest_break_on_failure** and **--gtest_throw_on_failure** no longer throw or raise signals for non-fatal failure, thus allowing execution to continue.