### PR TITLE
[#4387] Better exception printing for multi-line exceptions.

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -60,6 +60,7 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <regex>
 
 #include "gtest/gtest-assertion-result.h"
 #include "gtest/gtest-spi.h"
@@ -2571,11 +2572,20 @@ static std::string FormatCxxExceptionMessage(const char* description,
                                              const char* location) {
   Message message;
   if (description != nullptr) {
-    message << "C++ exception with description \"" << description << "\"";
+    auto desc = std::regex_replace(description, std::regex("\n"), "\n> ");
+    auto leading_desc = desc.substr(0, 3);
+    if (leading_desc != "\n> ") {
+      desc = "\n> " + desc;
+    }
+    auto trailing_desc = desc.substr(desc.size()-3);
+    if (trailing_desc == "\n> ") {
+      desc = desc.substr(0, desc.size()-3);
+    }
+      message << "C++ exception with description " << desc;
   } else {
     message << "Unknown C++ exception";
   }
-  message << " thrown in " << location << ".";
+  message << "\nthrown in " << location << ".";
 
   return message.GetString();
 }


### PR DESCRIPTION
Solution for multi-line exceptions:

- regex replace
- adds leading \n if it does not exist, does not add another otherwise
- deals with trailing \n -> same output with or without a trailing \n, but note that two trailing \n\n will result in a line that starts with >
- changes default behavior to use a line with >

Examples

New line after each segment:

```
C++ exception with description 
> Error: 22000
> Error while communicating with S3
> DETAIL: aws-s3-bucket-name: mybucket
> INTERNAL DETAIL: aws-s3-bucket-name: mybucket
thrown in the test body.
```

Default behavior if no \n chars detected:
```

C++ exception with description
> Error: 22000 Error while communicating with S3 DETAIL: aws-s3-bucket-name: mybucket INTERNAL DETAIL: aws-s3-bucket-name: mybucket
```
thrown in the test body.

For more info please see my comment on https://github.com/google/googletest/issues/4387