### PR TITLE
Cleanup include paths

### DIFF
--- a/googletest/src/gtest-death-test.cc
+++ b/googletest/src/gtest-death-test.cc
@@ -87,7 +87,7 @@
 
 #include "gtest/gtest-message.h"
 #include "gtest/internal/gtest-string.h"
-#include "src/gtest-internal-inl.h"
+#include "gtest-internal-inl.h"
 
 namespace testing {
 

--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -91,7 +91,7 @@
 #include "gtest/gtest-spi.h"
 #include "gtest/internal/gtest-internal.h"
 #include "gtest/internal/gtest-string.h"
-#include "src/gtest-internal-inl.h"
+#include "gtest-internal-inl.h"
 
 namespace testing {
 namespace internal {

--- a/googletest/src/gtest-printers.cc
+++ b/googletest/src/gtest-printers.cc
@@ -54,7 +54,7 @@
 #include <type_traits>
 
 #include "gtest/internal/gtest-port.h"
-#include "src/gtest-internal-inl.h"
+#include "gtest-internal-inl.h"
 
 namespace testing {
 

--- a/googletest/src/gtest-test-part.cc
+++ b/googletest/src/gtest-test-part.cc
@@ -36,7 +36,7 @@
 #include <string>
 
 #include "gtest/internal/gtest-port.h"
-#include "src/gtest-internal-inl.h"
+#include "gtest-internal-inl.h"
 
 namespace testing {
 

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -129,7 +129,7 @@
 #include <sys/types.h>   // NOLINT
 #endif
 
-#include "src/gtest-internal-inl.h"
+#include "gtest-internal-inl.h"
 
 #ifdef GTEST_OS_WINDOWS
 #define vsnprintf _vsnprintf


### PR DESCRIPTION
Used local path instead of additional include directories to find needed gtest-internal-inl.h (improves compatibility with other build methods)