### PR TITLE
Only apply -lregex for qnx710 and newer

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -147,7 +147,7 @@ target_include_directories(gtest SYSTEM INTERFACE
 target_include_directories(gtest_main SYSTEM INTERFACE
   "$<BUILD_INTERFACE:${dirs}>"
   "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
-if(CMAKE_SYSTEM_NAME MATCHES "QNX")
+if(CMAKE_SYSTEM_NAME MATCHES "QNX" AND CMAKE_SYSTEM_VERSION VERSION_GREATER_EQUAL 7.1)
   target_link_libraries(gtest PUBLIC regex)
 endif()
 target_link_libraries(gtest_main PUBLIC gtest)


### PR DESCRIPTION
In QNX versions prior to 7.1, the regex functionality was located in `libc.a` and no extra linker flag was required. In QNX 7.1 and newer, we do need to link against the new `libregex`, which is what the current approach does always, breaking builds against older QNX versions.

Add check of `CMAKE_SYSTEM_VERSION` to handle this. QNX 7.0 is admittedly long in the tooth but it would be nice to keep this in good shape until it's commercially EOL'd in 2027.