### PR TITLE
Update quickstart-bazel.md to new version of GoogleTest

### DIFF
--- a/docs/quickstart-bazel.md
+++ b/docs/quickstart-bazel.md
@@ -50,8 +50,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
   name = "com_google_googletest",
-  urls = ["https://github.com/google/googletest/archive/5ab508a01f9eb089207ee87fd547d290da39d015.zip"],
-  strip_prefix = "googletest-5ab508a01f9eb089207ee87fd547d290da39d015",
+  urls = ["https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip"],
+  strip_prefix = "googletest-1.14.0",
 )
 ```
 


### PR DESCRIPTION
previous url pointed to release that no longer builds