### PR TITLE
[#4384] CMake FetchContent_* does not work with GTest as dependency name on Windows

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -65,12 +65,13 @@ endif()
 config_compiler_and_linker() # from ${gtest_dir}/cmake/internal_utils.cmake
 
 # Adds Google Mock's and Google Test's header directories to the search path.
+# Get Google Test's include dirs from the target, gtest_SOURCE_DIR is broken
+# when using fetch-content with the name "GTest".
+get_target_property(gtest_include_dirs gtest INCLUDE_DIRECTORIES)
 set(gmock_build_include_dirs
   "${gmock_SOURCE_DIR}/include"
   "${gmock_SOURCE_DIR}"
-  "${gtest_SOURCE_DIR}/include"
-  # This directory is needed to build directly from Google Test sources.
-  "${gtest_SOURCE_DIR}")
+  "${gtest_include_dirs}")
 include_directories(${gmock_build_include_dirs})
 
 ########################################################################


### PR DESCRIPTION
CMakeLists.txt for gmock uses `gtest_SOURCE_DIR` for setting the include paths. When using fetch content with the name "GTest", the value of `gtest_SOURCE_DIR` is updated to the repository root instead of the googletest subdirectory. As a result, gmock will fail to compile due to invalid include paths.

This can be fixed by not relying on `gtest_SOURCE_DIR` but reading the include directories from the gtest target.

It used to work for other compilers because gmock depends on gtest (using `target_link_libraries`). So gmock had the broken include paths from `gtest_SOURCE_DIR` plus the working paths from the target. For MSVC, gmock does not depend on gtest.

fixed  #4384