### PR TITLE
Fixed gcc linker error 58

### DIFF
--- a/googletest/src/gtest-death-test.cc
+++ b/googletest/src/gtest-death-test.cc
@@ -630,13 +630,23 @@ bool DeathTestImpl::Passed(bool status_ok) {
 #ifndef GTEST_OS_WINDOWS
 // Note: The return value points into args, so the return value's lifetime is
 // bound to that of args.
-static std::unique_ptr<char*[]> CreateArgvFromArgs(
-    std::vector<std::string>& args) {
-  auto result = std::make_unique<char*[]>(args.size() + 1);
-  for (size_t i = 0; i < args.size(); ++i) {
-    result[i] = &args[i][0];
+static std::vector<char*> CreateArgvFromArgs(
+    std::vector<std::string>& args){
+  std::vector<char*> result;
+
+  size_t arg_size = args.size();
+  //if(arg_size >= std::numeric_limits<ssize_t>::max()){
+  //  result.resize(1);
+  //  result[0] = nullptr;
+  //  return result;
+  //}
+
+  result.resize(arg_size + 1);
+  for (size_t i = 0; i < arg_size; ++i) {
+	  result[i] = args[i].data();
   }
-  result[args.size()] = nullptr;  // extra null terminator
+
+  result[arg_size] = nullptr;  // extra null terminator
   return result;
 }
 #endif
@@ -1036,8 +1046,8 @@ DeathTest::TestRole FuchsiaDeathTest::AssumeRole() {
   // "Fuchsia Test Component" which contains a "Fuchsia Component Manifest")
   // Launching processes is a privileged operation in Fuchsia, and the
   // declaration indicates that the ability is required for the component.
-  std::unique_ptr<char*[]> argv = CreateArgvFromArgs(args);
-  status = fdio_spawn_etc(child_job, FDIO_SPAWN_CLONE_ALL, argv[0], argv.get(),
+  std::vector<char*> argv = CreateArgvFromArgs(args);
+  status = fdio_spawn_etc(child_job, FDIO_SPAWN_CLONE_ALL, argv[0], argv.data(),
                           nullptr, 2, spawn_actions,
                           child_process_.reset_and_get_address(), nullptr);
   GTEST_DEATH_TEST_CHECK_(status == ZX_OK);
@@ -1388,8 +1398,8 @@ DeathTest::TestRole ExecDeathTest::AssumeRole() {
   // is necessary.
   FlushInfoLog();
 
-  std::unique_ptr<char*[]> argv = CreateArgvFromArgs(args);
-  const pid_t child_pid = ExecDeathTestSpawnChild(argv.get(), pipe_fd[0]);
+  std::vector<char*> argv = CreateArgvFromArgs(args);
+  const pid_t child_pid = ExecDeathTestSpawnChild(argv.data(), pipe_fd[0]);
   GTEST_DEATH_TEST_CHECK_SYSCALL_(close(pipe_fd[1]));
   set_child_pid(child_pid);
   set_read_fd(pipe_fd[0]);


### PR DESCRIPTION
Fixed gcc linker error 58:

How to reproduce:
Step1. Build the library with a test project deployed on gcc 12.3 on Ubuntu
Step2. Look at the following linker error:
```
lto-wrapper : warning : using serial compilation of 8 LTRANS jobs
lto-wrapper : message : see the ‘-flto’ option documentation for more information
lto-wrapper : message : In function ‘make_unique’,
E: from ‘CreateArgvFromArgs’ at \mnt\d\Code\utilities\submodules\googletest\googletest\src\gtest-death-test.cc(635): error : 58,
E: from ‘AssumeRole’ at \mnt\d\Code\utilities\submodules\googletest\googletest\src\gtest-death-test.cc(1391): error : 58:
/usr/include/c++/12/bits/unique_ptr.h(1080): error : 30: warning: argument 1 value ‘18446744073709551615’ exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
/usr/include/c++/12/bits/unique_ptr.h(1080): error :  1080 |     { return unique_ptr<_Tp>(new remove_extent_t<_Tp>[__num]()); }
/usr/include/c++/12/bits/unique_ptr.h(1080): error :       |                              ^
/usr/include/c++/12/new : error : In member function ‘AssumeRole’:
/usr/include/c++/12/new(128): error : 26: note: in a call to allocation function ‘operator new []’ declared here
128 | _GLIBCXX_NODISCARD void* operator new[](std : error : size_t) _GLIBCXX_THROW (std::bad_alloc)
128 | _GLIBCXX_NODISCARD void* operator new[](std : error :       |                          ^
```
This is traced back line 365: https://github.com/google/googletest/pull/4477/files#diff-97f768d897442b94f24002f6bcff7124e3c73d05b3916fb492ee29436ce0701fL635
specifically the `args.size() + 1`
where the code analysis tool sees the potential issue of overflowing the storage limits when expanding std::unique_ptr<[]>.
This is easily fixable by abandoning the awkward std::unique_ptr<[]>, since it can be better represented by an std::vector.

granted, likely a bug in the gcc code generation, but it has been there for at least 6 months, someone should have noticed by now. std::unique_ptr<[]> is not great, should have used a std::vector anyways.
