### PR TITLE
Fix help text for stream_result_to flag.

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -379,7 +379,7 @@ GTEST_DEFINE_string_(
     testing::internal::StringFromGTestEnv("stream_result_to", ""),
     "This flag specifies the host name and the port number on which to stream "
     "test results. Example: \"localhost:555\". The flag is effective only on "
-    "Linux.");
+    "Linux and Mac.");
 
 GTEST_DEFINE_bool_(
     throw_on_failure,


### PR DESCRIPTION
Support for Mac was previously added, in addition to Linux. Fix the help text to match the code.