### PR TITLE
Minor fixes to gtest_build_tests=ON

### DIFF
--- a/googlemock/test/gmock_test.cc
+++ b/googlemock/test/gmock_test.cc
@@ -87,10 +87,10 @@ TEST(InitGoogleMockTest, ParsesSingleFlag) {
 
 TEST(InitGoogleMockTest, ParsesMultipleFlags) {
   int old_default_behavior = GMOCK_FLAG_GET(default_mock_behavior);
-  const wchar_t* argv[] = {L"foo.exe", L"--gmock_verbose=info",
-                           L"--gmock_default_mock_behavior=2", nullptr};
+  const char* argv[] = {"foo.exe", "--gmock_verbose=info",
+                        "--gmock_default_mock_behavior=2", nullptr};
 
-  const wchar_t* new_argv[] = {L"foo.exe", nullptr};
+  const char* new_argv[] = {"foo.exe", nullptr};
 
   TestInitGoogleMock(argv, new_argv, "info");
   EXPECT_EQ(2, GMOCK_FLAG_GET(default_mock_behavior));

--- a/googletest/test/googletest-output-test.py
+++ b/googletest/test/googletest-output-test.py
@@ -175,7 +175,7 @@ def RemoveTestCounts(output):
   output = re.sub(r'\d+ tests?, listed below', '? tests, listed below', output)
   output = re.sub(r'\d+ FAILED TESTS', '? FAILED TESTS', output)
   output = re.sub(
-      r'\d+ tests? from \d+ test cases?', '? tests from ? test cases', output
+      r'\d+ tests? from \d+ test suites?', '? tests from ? test suites', output
   )
   output = re.sub(r'\d+ tests? from ([a-zA-Z_])', r'? tests from \1', output)
   return re.sub(r'\d+ tests?\.', '? tests.', output)


### PR DESCRIPTION
Fix some failures identified in gtest_build_tests=ON when trying to build googletest with winegcc for a [winelib](https://wiki.winehq.org/Winelib) application (i.e. when using a POSIX libc/libstdc++, but with some win32 API available).

Context: I have additional patches in the branch https://github.com/puetzk/googletest/commits/wine/, but I don't think their maturity (or popularity) makes sense to upstream at this time. But these two commits are stand-alone fixes that seem generally applicable, so I've cherry-picked them.
