### PR TITLE
fix multi construct of g_gmock_implicit_sequence

### DIFF
--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -666,7 +666,7 @@ namespace internal {
 
 // Points to the implicit sequence introduced by a living InSequence
 // object (if any) in the current thread or NULL.
-GTEST_API_ extern ThreadLocal<Sequence*> g_gmock_implicit_sequence;
+GTEST_API_ ThreadLocal<Sequence*>& GetGMockImplicitSequence(void);
 
 // Base class for implementing expectations.
 //
@@ -1580,7 +1580,7 @@ class FunctionMocker<R(Args...)> final : public UntypedFunctionMockerBase {
     untyped_expectations_.push_back(untyped_expectation);
 
     // Adds this expectation into the implicit sequence if there is one.
-    Sequence* const implicit_sequence = g_gmock_implicit_sequence.get();
+    Sequence* const implicit_sequence = GetGMockImplicitSequence().get();
     if (implicit_sequence != nullptr) {
       implicit_sequence->AddExpectation(Expectation(untyped_expectation));
     }

--- a/googlemock/src/gmock-spec-builders.cc
+++ b/googlemock/src/gmock-spec-builders.cc
@@ -277,7 +277,12 @@ void ExpectationBase::UntypedTimes(const Cardinality& a_cardinality) {
 
 // Points to the implicit sequence introduced by a living InSequence
 // object (if any) in the current thread or NULL.
-GTEST_API_ ThreadLocal<Sequence*> g_gmock_implicit_sequence;
+
+GTEST_API_ ThreadLocal<Sequence*>& GetGMockImplicitSequence(void)
+{
+  static ThreadLocal<Sequence*> implicit_sequence;
+  return implicit_sequence;
+}
 
 // Reports an uninteresting call (whose description is in msg) in the
 // manner specified by 'reaction'.
@@ -768,8 +773,8 @@ void Sequence::AddExpectation(const Expectation& expectation) const {
 
 // Creates the implicit sequence if there isn't one.
 InSequence::InSequence() {
-  if (internal::g_gmock_implicit_sequence.get() == nullptr) {
-    internal::g_gmock_implicit_sequence.set(new Sequence);
+  if (internal::GetGMockImplicitSequence().get() == nullptr) {
+    internal::GetGMockImplicitSequence().set(new Sequence);
     sequence_created_ = true;
   } else {
     sequence_created_ = false;
@@ -780,8 +785,8 @@ InSequence::InSequence() {
 // of this object.
 InSequence::~InSequence() {
   if (sequence_created_) {
-    delete internal::g_gmock_implicit_sequence.get();
-    internal::g_gmock_implicit_sequence.set(nullptr);
+    delete internal::GetGMockImplicitSequence().get();
+    internal::GetGMockImplicitSequence().set(nullptr);
   }
 }
 


### PR DESCRIPTION
When libgmock.a is linked to a multitude of shared libraries, g_gmock_implicit_sequence will be constructed multiple times. For instance:
```
libgmock.a is linked to libA.so
libgmock.a is linked to libB.so
libA.so and libB.so are linked to BinaryC
```

When BinaryC executes, `g_gmock_implicit_sequence` is constructed and destroyed twice, and the private member `const pthread_key_t key_` in `ThreadLocal` will be called in `pthread_key_delete` twice, resulting in the failure of `GTEST_CHECK_POSIX_SUCCESS_(pthread_key_delete(key_))`.

Furthermore, `ThreadLocal<Sequence*> g_gmock_implicit_sequence` is not [trivially destructible](http://en.cppreference.com/w/cpp/types/is_destructible), which violates the [google code style](https://google.github.io/styleguide/cppguide.html#Run-Time_Type_Information__RTTI_).