### PR TITLE
Make FilePath::GetCurrentDir() not returning trailing slash on Windows

### DIFF
--- a/googletest/src/gtest-filepath.cc
+++ b/googletest/src/gtest-filepath.cc
@@ -109,7 +109,10 @@ FilePath FilePath::GetCurrentDir() {
   return FilePath(kCurrentDirectoryString);
 #elif defined(GTEST_OS_WINDOWS)
   char cwd[GTEST_PATH_MAX_ + 1] = {'\0'};
-  return FilePath(_getcwd(cwd, sizeof(cwd)) == nullptr ? "" : cwd);
+  if (_getcwd(cwd, sizeof(cwd)) == nullptr) return {};
+  auto len = std::strlen(cwd);
+  if (len > 0 && cwd[len - 1] == '\\') cwd[--len] = 0;
+  return FilePath({cwd, len});
 #else
   char cwd[GTEST_PATH_MAX_ + 1] = {'\0'};
   char* result = getcwd(cwd, sizeof(cwd));


### PR DESCRIPTION
It returned the trailing backslash if the current working directory was a root directory. It should be consistent w/ all cases.

[_getcwd, _wgetcwd](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/getcwd-wgetcwd?view=msvc-170)
> _getcwd returns a string that represents the path of the current
> working directory. If the current working directory is the root,
> the string ends with a backslash (\). If the current working
> directory is a directory other than the root, the string ends with
> the directory name and not with a backslash.