### PR TITLE
Print the error code when unable to create a temporary file on Windows

### DIFF
--- a/googletest/samples/sample1_unittest.cc
+++ b/googletest/samples/sample1_unittest.cc
@@ -76,6 +76,7 @@ namespace {
 TEST(FactorialTest, Negative) {
   // This test is named "Negative", and belongs to the "FactorialTest"
   // test case.
+  testing::internal::CaptureStdout();
   EXPECT_EQ(1, Factorial(-5));
   EXPECT_EQ(1, Factorial(-1));
   EXPECT_GT(Factorial(-10), 0);

--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -1042,7 +1042,7 @@ class CapturedStream {
                                             0,  // Generate unique file name.
                                             temp_file_path);
     GTEST_CHECK_(success != 0)
-        << "Unable to create a temporary file in " << temp_dir_path;
+        << "Unable to create a temporary file in " << temp_dir_path << ". Error message: " << ::GetLastError();
     const int captured_fd = creat(temp_file_path, _S_IREAD | _S_IWRITE);
     GTEST_CHECK_(captured_fd != -1)
         << "Unable to open temporary file " << temp_file_path;


### PR DESCRIPTION
Help root cause a sporadic error seen when running gtest applications