### PR TITLE
Add GTEST_HAS_ABSL support into gmock cmake for MSVC

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -93,6 +93,26 @@ if (MSVC)
               "${gtest_dir}/src/gtest-all.cc"
               src/gmock-all.cc
               src/gmock_main.cc)
+
+  if(GTEST_HAS_ABSL)
+    target_compile_definitions(gmock PUBLIC GTEST_HAS_ABSL=1)
+    target_compile_definitions(gmock_main PUBLIC GTEST_HAS_ABSL=1)
+    set(gmock_DEPENDENCIES
+          absl::failure_signal_handler
+          absl::stacktrace
+          absl::symbolize
+          absl::flags_parse
+          absl::flags_reflection
+          absl::flags_usage
+          absl::strings
+          absl::any
+          absl::optional
+          absl::variant
+          re2::re2
+    )
+    target_link_libraries(gmock PUBLIC ${gmock_DEPENDENCIES})
+    target_link_libraries(gmock_main PUBLIC ${gmock_DEPENDENCIES})
+  endif ()
 else()
   cxx_library(gmock "${cxx_strict}" src/gmock-all.cc)
   target_link_libraries(gmock PUBLIC gtest)


### PR DESCRIPTION
### Why this change

When building with MSVC, the sources of `gtest` are included directly in `gmock` rather than linking to `gtest` as a separate library. This resulted in `GTEST_HAS_ABSL` not being defined, causing `gmock` to miss linking with the necessary Abseil and RE2 libraries.

### How this change fix this issue

- Added conditional compilation definitions for `GTEST_HAS_ABSL` when building with MSVC.
- Configured `gmock` and `gmock_main` to link with Abseil and RE2 dependencies explicitly.
- Ensured that the dependencies are linked correctly by defining `GTEST_HAS_ABSL` and specifying the required libraries, thus resolving build and runtime issues.