### PR TITLE
Remove auto-detection of Python toolchain from MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,7 +32,7 @@
 
 module(
     name = "googletest",
-    version = "1.15.0",
+    version = "1.15.1",
     compatibility_level = 1,
 )
 
@@ -51,11 +51,19 @@ bazel_dep(name = "re2",
           version = "2024-07-02")
 
 bazel_dep(name = "rules_python",
-          version = "0.29.0")
+          version = "0.34.0",
+          dev_dependency = True)
 
+# https://rules-python.readthedocs.io/en/stable/toolchains.html#library-modules-with-dev-only-python-usage
+python = use_extension(
+    "@rules_python//python/extensions:python.bzl",
+    "python",
+    dev_dependency = True
+)
+
+python.toolchain(python_version = "3.12",
+                 is_default = True,
+                 ignore_root_user_error = True)
 
 fake_fuchsia_sdk = use_repo_rule("//:fake_fuchsia_sdk.bzl", "fake_fuchsia_sdk")
 fake_fuchsia_sdk(name = "fuchsia_sdk")
-
-# https://github.com/bazelbuild/rules_python/blob/main/BZLMOD_SUPPORT.md#default-toolchain-is-not-the-local-system-python
-register_toolchains("@bazel_tools//tools/python:autodetecting_toolchain")

--- a/ci/windows-presubmit.bat
+++ b/ci/windows-presubmit.bat
@@ -46,8 +46,13 @@ RMDIR /S /Q cmake_msvc2022
 :: ----------------------------------------------------------------------------
 :: Bazel
 
+:: The default home directory on Kokoro is a long path which causes errors
+:: because of Windows limitations on path length.
+:: --output_user_root=C:\tmp causes Bazel to use a shorter path.
 SET BAZEL_VS=C:\Program Files\Microsoft Visual Studio\2022\Community
-%BAZEL_EXE% test ... ^
+%BAZEL_EXE% ^
+  --output_user_root=C:\tmp ^
+  test ... ^
   --compilation_mode=dbg ^
   --copt=/std:c++14 ^
   --copt=/WX ^


### PR DESCRIPTION
since it affects downstream users

The correct solution appears to be
https://rules-python.readthedocs.io/en/stable/toolchains.html#library-modules-with-dev-only-python-usage

This change also includes a workaround for the new mechanism creating paths that are too long for Windows to handle.

Backport of 3e3b44c300b21eb996a2957782421bc0f157af18