### PR TITLE
Enable "make package" and "make package_source"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,3 +34,8 @@ if(BUILD_GMOCK)
 else()
   add_subdirectory( googletest )
 endif()
+
+set(CPACK_VERBATIM_VARIABLES YES)
+set(CPACK_SOURCE_GENERATOR "TGZ")
+set(CPACK_SOURCE_IGNORE_FILES "build;/\\.git/;.*~")
+include(CPack)


### PR DESCRIPTION
Dear Google Team,

With this pull request, it will be possible to run "make package_source" (e.g. googletest-distribution-0.1.1-Source.tar.gz to be included in a docker container):

```
$ make package_source
Run CPack packaging tool for source...
CPack: Create package using TGZ
CPack: Install projects
CPack: - Install directory: ~/install/googletest
CPack: Create package
CPack: - package: ~/install/googletest-build/googletest-distribution-0.1.1-Source.tar.gz generated.
```

Reinhard