### PR TITLE
Update CMakeLists.txt to prevent source tree corruption when building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,13 @@
 # Note: CMake support is community-based. The maintainers do not use CMake
 # internally.
 
+if(" ${CMAKE_SOURCE_DIR}" STREQUAL " ${CMAKE_BINARY_DIR}")
+  message(FATAL_ERROR "
+FATAL: In-source builds are not allowed.
+       You should create a separate directory for build files.
+")
+endif()
+
 cmake_minimum_required(VERSION 3.13)
 
 project(googletest-distribution)


### PR DESCRIPTION
## Prevent In-Source Builds

To prevent source tree corruption, this project does not allow in-source builds. The `CMakeLists.txt` file has been updated to enforce this restriction.

### Behavior

If you attempt to build in the source directory, you will see the following error message:
> **CMake Error at CMakeLists.txt:5 (message):**
>
> **FATAL: In-source builds are not allowed.**
> **You should create a separate directory for build files.**
