### PR TITLE
Add CPack support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,13 @@
 
 cmake_minimum_required(VERSION 3.13)
 
-project(googletest-distribution)
 set(GOOGLETEST_VERSION 1.15.2)
+project(googletest-distribution
+  VERSION ${GOOGLETEST_VERSION}
+  DESCRIPTION "Google's C++ test framework"
+  HOMEPAGE_URL "https://google.github.io/googletest"
+  LANGUAGES CXX
+)
 
 if(NOT CYGWIN AND NOT MSYS AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL QNX)
   set(CMAKE_CXX_EXTENSIONS OFF)
@@ -33,4 +38,13 @@ if(BUILD_GMOCK)
   add_subdirectory( googlemock )
 else()
   add_subdirectory( googletest )
+endif()
+
+if(INSTALL_GTEST)
+  set(CPACK_PACKAGE_NAME "GTest") # same as the name in `find_package`
+  set(CPACK_PACKAGE_VENDOR "Google")
+  set(CPACK_GENERATOR "TGZ")
+  set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
+  set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+  include(CPack)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ project(googletest-distribution
   LANGUAGES CXX
 )
 
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+  set(PROJECT_IS_TOP_LEVEL TRUE)
+endif()
+
 if(NOT CYGWIN AND NOT MSYS AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL QNX)
   set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
@@ -22,7 +26,7 @@ include(GNUInstallDirs)
 
 # Note that googlemock target already builds googletest.
 option(BUILD_GMOCK "Builds the googlemock subproject" ON)
-option(INSTALL_GTEST "Enable installation of googletest. (Projects embedding googletest may want to turn this OFF.)" ON)
+option(INSTALL_GTEST "Enable installation of googletest. (Projects embedding googletest may want to turn this OFF.)" ${PROJECT_IS_TOP_LEVEL})
 option(GTEST_HAS_ABSL "Use Abseil and RE2. Requires Abseil and RE2 to be separately added to the build." OFF)
 
 if(GTEST_HAS_ABSL)
@@ -40,7 +44,7 @@ else()
   add_subdirectory( googletest )
 endif()
 
-if(INSTALL_GTEST)
+if(PROJECT_IS_TOP_LEVEL)
   set(CPACK_PACKAGE_NAME "GTest") # same as the name in `find_package`
   set(CPACK_PACKAGE_VENDOR "Google")
   set(CPACK_GENERATOR "TGZ")


### PR DESCRIPTION
1. Add `PROJECT_IS_TOP_LEVEL variable`, to decide whether need to install/package
2. Add the main information of `project()` that CPack uses
3. Set the package name (GTest) as same as the name in `find_package`
4. Enable the CPack functionality

The package will be: i.e. `GTest-1.15.2-win64.tar.gz`

Ref: #2530
(I'm not familiar with RPM/DEB, so I just enable the basic CPack functionalities.)