### PR TITLE
Improve support for printing std::basic_string_view

### DIFF
--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -725,6 +725,49 @@ inline void PrintTo(const ::std::wstring& s, ::std::ostream* os) {
 }
 #endif  // GTEST_HAS_STD_WSTRING
 
+#if defined(__cpp_lib_string_view) || GTEST_INTERNAL_CPLUSPLUS_LANG >= 201703L
+#include <string_view>
+
+// Overloads for ::std::string_view.
+#ifdef GTEST_HAS_ABSL
+// Otherwise internal::StringView is implemented using ::std::string_view
+// and has already overloaded PrintTo for it below.
+GTEST_API_ void PrintStringTo(const ::std::string_view& sv, ::std::ostream* os);
+inline void PrintTo(const ::std::string_view& sv, ::std::ostream* os) {
+  PrintStringTo(sv, os);
+}
+#endif  // GTEST_HAS_ABSL
+
+// Overloads for ::std::u8string_view
+#ifdef __cpp_lib_char8_t
+GTEST_API_ void PrintU8StringTo(const ::std::u8string_view& sv, ::std::ostream* os);
+inline void PrintTo(const ::std::u8string_view& sv, ::std::ostream* os) {
+  PrintU8StringTo(sv, os);
+}
+#endif
+
+// Overloads for ::std::u16string_view
+GTEST_API_ void PrintU16StringTo(const ::std::u16string_view& sv, ::std::ostream* os);
+inline void PrintTo(const ::std::u16string_view& sv, ::std::ostream* os) {
+  PrintU16StringTo(sv, os);
+}
+
+// Overloads for ::std::u32string_view
+GTEST_API_ void PrintU32StringTo(const ::std::u32string_view& sv, ::std::ostream* os);
+inline void PrintTo(const ::std::u32string_view& sv, ::std::ostream* os) {
+  PrintU32StringTo(sv, os);
+}
+
+// Overloads for ::std::wstring_view.
+#if GTEST_HAS_STD_WSTRING
+GTEST_API_ void PrintWideStringTo(const ::std::wstring_view& sv, ::std::ostream* os);
+inline void PrintTo(const ::std::wstring_view& sv, ::std::ostream* os) {
+  PrintWideStringTo(sv, os);
+}
+#endif  // GTEST_HAS_STD_WSTRING
+#endif  // __cpp_lib_string_view
+
+
 #if GTEST_INTERNAL_HAS_STRING_VIEW
 // Overload for internal::StringView.
 inline void PrintTo(internal::StringView sp, ::std::ostream* os) {

--- a/googletest/src/gtest-printers.cc
+++ b/googletest/src/gtest-printers.cc
@@ -550,6 +550,39 @@ void PrintWideStringTo(const ::std::wstring& s, ostream* os) {
 }
 #endif  // GTEST_HAS_STD_WSTRING
 
+#if defined(__cpp_lib_string_view) || GTEST_INTERNAL_CPLUSPLUS_LANG >= 201703L
+
+#ifdef GTEST_HAS_ABSL
+void PrintStringTo(const ::std::string_view& sv, ostream* os) {
+  if (PrintCharsAsStringTo(sv.data(), sv.size(), os) == kHexEscape) {
+    if (GTEST_FLAG_GET(print_utf8)) {
+      ConditionalPrintAsText(sv.data(), sv.size(), os);
+    }
+  }
+}
+#endif
+
+#ifdef __cpp_lib_char8_t
+void PrintU8StringTo(const ::std::u8string_view& sv, ostream* os) {
+  PrintCharsAsStringTo(sv.data(), sv.size(), os);
+}
+#endif
+
+void PrintU16StringTo(const ::std::u16string_view& sv, ostream* os) {
+  PrintCharsAsStringTo(sv.data(), sv.size(), os);
+}
+
+void PrintU32StringTo(const ::std::u32string_view& sv, ostream* os) {
+  PrintCharsAsStringTo(sv.data(), sv.size(), os);
+}
+
+#if GTEST_HAS_STD_WSTRING
+void PrintWideStringTo(const ::std::wstring_view& sv, ::std::ostream* os) {
+  PrintCharsAsStringTo(sv.data(), sv.size(), os);
+}
+#endif  // GTEST_HAS_STD_WSTRING
+#endif  // __cpp_lib_string_view
+
 }  // namespace internal
 
 }  // namespace testing

--- a/googletest/test/googletest-printers-test.cc
+++ b/googletest/test/googletest-printers-test.cc
@@ -984,6 +984,108 @@ TEST(PrintStringTest, U32String) {
   EXPECT_EQ("U\"Hello, \\x1F5FA\\xFE0F\"", Print(str));
 }
 
+#if GTEST_HAS_STD_WSTRING
+TEST(PrintStringTest, WString) {
+  std::wstring str = L"Hello, 世界";
+  EXPECT_EQ(str, str);  // Verify EXPECT_EQ compiles with this type.
+  EXPECT_EQ("L\"Hello, \\x4E16\\x754C\"", Print(str));
+}
+#endif
+
+
+// Tests printing ::std::basic_string_view's
+
+#if defined(__cpp_lib_string_view) || GTEST_INTERNAL_CPLUSPLUS_LANG >= 201703L
+#include <string_view>
+
+// Tests printing ::std::string_view
+#ifdef GTEST_HAS_ABSL
+
+TEST(PrintStringViewTest, StringViewInStdNamespace) {
+  const char s[] = "'\"?\\\a\b\f\n\0\r\t\v\x7F\xFF a";
+  const ::std::string_view str(s, sizeof(s));
+  EXPECT_EQ("\"'\\\"?\\\\\\a\\b\\f\\n\\0\\r\\t\\v\\x7F\\xFF a\\0\"",
+            Print(str));
+}
+#endif  // GTEST_HAS_ABSL
+
+// Tests printing ::std::u8string_view
+#ifdef __cpp_lib_char8_t
+TEST(PrintStringViewTest, U8StringViewInStdNamespace) {
+  const char8_t s[] = u8"'\"?\\\a\b\f\n\0\r\t\v\x7F\xFF a";
+  const ::std::u8string_view str(s, sizeof(s));
+  EXPECT_EQ("u8\"'\\\"?\\\\\\a\\b\\f\\n\\0\\r\\t\\v\\x7F\\xFF a\\0\"",
+            Print(str));
+}
+#endif
+
+// Tests printing ::std::u16string_view
+TEST(PrintStringViewTest, U16StringViewInStdNamespace) {
+  const char16_t s[] = u"'\"?\\\a\b\f\n\0\r\t\v\x7F\xFF a";
+  const ::std::u16string_view str(s, sizeof(s) / sizeof(char16_t));
+  EXPECT_EQ("u\"'\\\"?\\\\\\a\\b\\f\\n\\0\\r\\t\\v\\x7F\\xFF a\\0\"",
+            Print(str));
+}
+
+// Tests printing ::std::u32string_view
+TEST(PrintStringViewTest, U32StringViewInStdNamespace) {
+  const char32_t s[] = U"'\"?\\\a\b\f\n\0\r\t\v\x7F\xFF a";
+  const ::std::u32string_view str(s, sizeof(s) / sizeof(char32_t));
+  EXPECT_EQ("U\"'\\\"?\\\\\\a\\b\\f\\n\\0\\r\\t\\v\\x7F\\xFF a\\0\"",
+            Print(str));
+}
+
+// Tests printing ::std::wstring_view
+#if GTEST_HAS_STD_WSTRING
+TEST(PrintStringViewTest, WStringViewInStdNamespace) {
+  const wchar_t s[] = L"'\"?\\\a\b\f\n\0\r\t\v\x7F\xFF a";
+  const ::std::wstring_view str(s, sizeof(s) / sizeof(wchar_t));
+  EXPECT_EQ("L\"'\\\"?\\\\\\a\\b\\f\\n\\0\\r\\t\\v\\x7F\\xFF a\\0\"",
+            Print(str));
+}
+#endif  // GTEST_HAS_STD_WSTRING
+
+
+#ifdef GTEST_HAS_ABSL
+TEST(PrintStringViewTest, StringView) {
+  std::string_view sv = "Hello, world";
+  EXPECT_EQ(sv, sv);  // Verify EXPECT_EQ compiles with this type.
+  EXPECT_EQ("\"Hello, world\"", Print(sv));
+}
+#endif  // GTEST_HAS_ABSL
+
+#ifdef __cpp_lib_char8_t
+TEST(PrintStringViewTest, U8StringView) {
+  std::u8string_view sv = u8"Hello, 世界";
+  EXPECT_EQ(sv, sv);  // Verify EXPECT_EQ compiles with this type.
+  EXPECT_EQ("u8\"Hello, \\xE4\\xB8\\x96\\xE7\\x95\\x8C\"", Print(sv));
+}
+#endif
+
+TEST(PrintStringViewTest, U16StringView) {
+  std::u16string_view sv = u"Hello, 世界";
+  EXPECT_EQ(sv, sv);  // Verify EXPECT_EQ compiles with this type.
+  EXPECT_EQ("u\"Hello, \\x4E16\\x754C\"", Print(sv));
+}
+
+TEST(PrintStringViewTest, U32StringView) {
+  std::u32string_view sv = U"Hello, 🗺️";
+  EXPECT_EQ(sv, sv);  // Verify EXPECT_EQ compiles with this type
+  EXPECT_EQ("U\"Hello, \\x1F5FA\\xFE0F\"", Print(sv));
+}
+
+#if GTEST_HAS_STD_WSTRING
+TEST(PrintStringViewTest, WStringView) {
+  std::wstring_view sv = L"Hello, 世界";
+  EXPECT_EQ(sv, sv);  // Verify EXPECT_EQ compiles with this type.
+  EXPECT_EQ("L\"Hello, \\x4E16\\x754C\"", Print(sv));
+}
+#endif
+
+
+#endif  // __cpp_lib_string_view
+
+
 // Tests printing types that support generic streaming (i.e. streaming
 // to std::basic_ostream<Char, CharTraits> for any valid Char and
 // CharTraits types).


### PR DESCRIPTION
### Extend printing capabilities for std::basic_string_view

#### What is std::basic_string_view?

std::basic_string_view ([spec](https://en.cppreference.com/w/cpp/string/basic_string_view)) is a relatively new (since C++17) form of manipulating string objects in C++.

The language also provides a suffix for it, so the following line will create and initiate a new `std::string_view` (synonym for `std::basic_string_view<char>`) object:

```c++
const auto str_view = "hello world"sv;
```

#### Does GTest support it?

Currently, GTest has some means of outputting these objects. It will be handled by the `ContainerPrinter` with one exception.

It will look a bit ugly though. Printing `L"w"sv` will produce `{ L'w' (119, 0x77) }`.

##### Exception

`GTest` [declares](https://github.com/google/googletest/blob/main/googletest/include/gtest/internal/gtest-port.h#L2466-L2492) its own `StringView` which depending on the build parameters will be either `absl::string_view` or `std::string_view`.

Besides that `GTest` implements printing capability for that `StringView` type. Unfortunately, in the best case scenario it covers only one of the subtypes of the `std::basic_string_view` family. That is why in the #4295 author mentioned that the issue appears only for non-char basic_string_view's.