### PR TITLE
feat: add EXPECT_NO_COREFILE_DEATH

### DIFF
--- a/googletest/include/gtest/gtest-death-test.h
+++ b/googletest/include/gtest/gtest-death-test.h
@@ -189,6 +189,17 @@ GTEST_API_ bool InDeathTestChild();
 #define EXPECT_DEATH(statement, matcher) \
   EXPECT_EXIT(statement, ::testing::internal::ExitedUnsuccessfully, matcher)
 
+// check if it is a child of ExceptionTest
+#define EXPECT_NO_COREFILE_DEATH(statement, matcher)                           \
+  do {                                                                         \
+    if (dynamic_cast<::testing::ExceptionTest *>(this)) {                      \
+      EXPECT_DEATH(statement, matcher);                                        \
+    } else {                                                                   \
+      EXPECT_TRUE(false) << "EXPECT_NO_COREFILE_DEATH can only be used in "    \
+                            "::testing::ExceptionTest and its subclass";       \
+    }                                                                          \
+  } while (0)
+
 // Two predicate classes that can be used in {ASSERT,EXPECT}_EXIT*:
 
 // Tests that an exit code describes a normal exit with a given exit code.

--- a/googletest/src/gtest_main.cc
+++ b/googletest/src/gtest_main.cc
@@ -59,7 +59,7 @@ GTEST_API_ int main() {
 // Normal platforms: program entry point is main, argc/argv are initialized.
 
 GTEST_API_ int main(int argc, char **argv) {
-  printf("Running main() from %s\n", __FILE__);
+  // printf("Running main() from %s\n", __FILE__);
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
If we use expect_death, we really know it will coredump or raise signal, EXPECT_NO_COREFILE_DEATH is a helper for user to use expect_death but do not genreate core file.
EXPECT_NO_COREFILE_DEATH depends on ::testing::ExceptionTest, who will set rlimit to suppress core file generated.

printf in main is not good idea for all test.