### PR TITLE
Address Issue #4289 by setting CMake policy CMP0135 to the new (recommended) behavior when CMake version supports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@
 
 cmake_minimum_required(VERSION 3.13)
 
+if(cmake_VERSION VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW)
+endif()
+
 project(googletest-distribution)
 set(GOOGLETEST_VERSION 1.15.2)
 


### PR DESCRIPTION
select new behavior for CMP0135 when supported by cmake so that: "CMake 3.24 and above prefers to set the timestamps of all extracted contents to the time of the extraction. This ensures that anything that depends on the extracted contents will be rebuilt whenever the URL changes."