### PR TITLE
Add codespell configuration, fix a few other typos

### DIFF
--- a/.codespell.ignore
+++ b/.codespell.ignore
@@ -1,0 +1,7 @@
+afile
+assertIn
+AtLeast
+AtMost
+fo
+SEH
+Seh

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+ignore-words = .codespell.ignore

--- a/googlemock/src/gmock-internal-utils.cc
+++ b/googlemock/src/gmock-internal-utils.cc
@@ -162,7 +162,7 @@ GTEST_API_ void Log(LogSeverity severity, const std::string& message,
     // Prints a GMOCK WARNING marker to make the warnings easily searchable.
     std::cout << "\nGMOCK WARNING:";
   }
-  // Pre-pends a new-line to message if it doesn't start with one.
+  // Prepends a new-line to message if it doesn't start with one.
   if (message.empty() || message[0] != '\n') {
     std::cout << "\n";
   }

--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -1142,7 +1142,7 @@ void UniversalTersePrint(const T& value, ::std::ostream* os) {
 // NUL-terminated string.
 template <typename T>
 void UniversalPrint(const T& value, ::std::ostream* os) {
-  // A workarond for the bug in VC++ 7.1 that prevents us from instantiating
+  // A workaround for the bug in VC++ 7.1 that prevents us from instantiating
   // UniversalPrinter with T directly.
   typedef T T1;
   UniversalPrinter<T1>::Print(value, os);

--- a/googletest/include/gtest/internal/gtest-param-util.h
+++ b/googletest/include/gtest/internal/gtest-param-util.h
@@ -760,7 +760,7 @@ class ParameterizedTestSuiteRegistry {
 };
 
 // Keep track of what type-parameterized test suite are defined and
-// where as well as which are intatiated. This allows susequently
+// where as well as which are intatiated. This allows subsequently
 // identifying suits that are defined but never used.
 class TypeParameterizedTestSuiteRegistry {
  public:

--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -712,7 +712,7 @@ bool RE::PartialMatch(const char* str, const RE& re) {
 void RE::Init(const char* regex) {
   pattern_ = regex;
 
-  // NetBSD (and Android, which takes its regex implemntation from NetBSD) does
+  // NetBSD (and Android, which takes its regex implementation from NetBSD) does
   // not include the GNU regex extensions (such as Perl style character classes
   // like \w) in REG_EXTENDED. REG_EXTENDED is only specified to include the
   // [[:alpha:]] style character classes. Enable REG_GNU wherever it is defined


### PR DESCRIPTION
This PR adds a configuration for [codespell](https://github.com/codespell-project/codespell), a tool that has been used [a number of times in this project](https://github.com/search?q=repo%3Agoogle%2Fgoogletest+codespell&type=pullrequests). A few more typos are identified and corrected.

A CI code quality check can be added to use this configuration to run `codespell`, but I'm not sure how the CI is configured for this project.