### PR TITLE
Feature add EXPECT/ASSERT_FLOAT/DOUBLE_NE (not equal)

### DIFF
--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1601,6 +1601,29 @@ AssertionResult CmpHelperFloatingPointEQ(const char* lhs_expression,
                    false);
 }
 
+template <typename RawType>
+AssertionResult CmpHelperFloatingPointNE(const char* lhs_expression,
+                                         const char* rhs_expression,
+                                         RawType lhs_value, RawType rhs_value) {
+  const FloatingPoint<RawType> lhs(lhs_value), rhs(rhs_value);
+
+  if (!lhs.AlmostEquals(rhs)) {
+    return AssertionSuccess();
+  }
+
+  ::std::stringstream lhs_ss;
+  lhs_ss.precision(std::numeric_limits<RawType>::digits10 + 2);
+  lhs_ss << lhs_value;
+
+  ::std::stringstream rhs_ss;
+  rhs_ss.precision(std::numeric_limits<RawType>::digits10 + 2);
+  rhs_ss << rhs_value;
+
+  return NeFailure(lhs_expression, rhs_expression,
+                   StringStreamToString(&lhs_ss), StringStreamToString(&rhs_ss),
+                   false);
+}
+
 // Helper function for implementing ASSERT_NEAR.
 //
 // INTERNAL IMPLEMENTATION - DO NOT USE IN A USER PROGRAM.
@@ -1996,6 +2019,22 @@ class TestWithParam : public Test, public WithParamInterface<T> {};
 
 #define ASSERT_DOUBLE_EQ(val1, val2)                                         \
   ASSERT_PRED_FORMAT2(::testing::internal::CmpHelperFloatingPointEQ<double>, \
+                      val1, val2)
+
+#define EXPECT_FLOAT_NE(val1, val2)                                         \
+  EXPECT_PRED_FORMAT2(::testing::internal::CmpHelperFloatingPointNE<float>, \
+                      val1, val2)
+
+#define EXPECT_DOUBLE_NE(val1, val2)                                         \
+  EXPECT_PRED_FORMAT2(::testing::internal::CmpHelperFloatingPointNE<double>, \
+                      val1, val2)
+
+#define ASSERT_FLOAT_NE(val1, val2)                                         \
+  ASSERT_PRED_FORMAT2(::testing::internal::CmpHelperFloatingPointNE<float>, \
+                      val1, val2)
+
+#define ASSERT_DOUBLE_NE(val1, val2)                                         \
+  ASSERT_PRED_FORMAT2(::testing::internal::CmpHelperFloatingPointNE<double>, \
                       val1, val2)
 
 #define EXPECT_NEAR(val1, val2, abs_error)                                   \

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -207,6 +207,12 @@ GTEST_API_ AssertionResult EqFailure(const char* expected_expression,
                                      const std::string& actual_value,
                                      bool ignoring_case);
 
+GTEST_API_ AssertionResult NeFailure(const char* expected_expression,
+                                     const char* actual_expression,
+                                     const std::string& expected_value,
+                                     const std::string& actual_value,
+                                     bool ignoring_case);
+
 // Constructs a failure message for Boolean assertions such as EXPECT_TRUE.
 GTEST_API_ std::string GetBoolAssertionFailureMessage(
     const AssertionResult& assertion_result, const char* expression_text,

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -1647,6 +1647,37 @@ AssertionResult EqFailure(const char* lhs_expression,
   return AssertionFailure() << msg;
 }
 
+AssertionResult NeFailure(const char* lhs_expression,
+                          const char* rhs_expression,
+                          const std::string& lhs_value,
+                          const std::string& rhs_value, bool ignoring_case) {
+  Message msg;
+  msg << "Expected inequality of these values:";
+  msg << "\n  " << lhs_expression;
+  if (lhs_value != lhs_expression) {
+    msg << "\n    Which is: " << lhs_value;
+  }
+  msg << "\n  " << rhs_expression;
+  if (rhs_value != rhs_expression) {
+    msg << "\n    Which is: " << rhs_value;
+  }
+
+  if (ignoring_case) {
+    msg << "\nIgnoring case";
+  }
+
+  if (!lhs_value.empty() && !rhs_value.empty()) {
+    const std::vector<std::string> lhs_lines = SplitEscapedString(lhs_value);
+    const std::vector<std::string> rhs_lines = SplitEscapedString(rhs_value);
+    if (lhs_lines.size() > 1 || rhs_lines.size() > 1) {
+      msg << "\nWith diff:\n"
+          << edit_distance::CreateUnifiedDiff(lhs_lines, rhs_lines);
+    }
+  }
+
+  return AssertionFailure() << msg;
+}
+
 // Constructs a failure message for Boolean assertions such as EXPECT_TRUE.
 std::string GetBoolAssertionFailureMessage(
     const AssertionResult& assertion_result, const char* expression_text,

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -2826,6 +2826,10 @@ TEST_F(FloatTest, Zeros) {
   EXPECT_FLOAT_EQ(0.0, -0.0);
   EXPECT_NONFATAL_FAILURE(EXPECT_FLOAT_EQ(-0.0, 1.0), "1.0");
   EXPECT_FATAL_FAILURE(ASSERT_FLOAT_EQ(0.0, 1.5), "1.5");
+
+  EXPECT_FLOAT_NE(-0.0, 1.0);
+  EXPECT_NONFATAL_FAILURE(EXPECT_FLOAT_NE(-0.0,0.0), "0.0");
+  EXPECT_FATAL_FAILURE(ASSERT_FLOAT_NE(-0.0, 0.0), "0.0");
 }
 
 // Tests comparing numbers close to 0.
@@ -2851,6 +2855,23 @@ TEST_F(FloatTest, AlmostZeros) {
         ASSERT_FLOAT_EQ(v.close_to_positive_zero, v.further_from_negative_zero);
       },
       "v.further_from_negative_zero");
+
+  EXPECT_FLOAT_NE(v.close_to_positive_zero, v.further_from_negative_zero);
+  
+  EXPECT_FATAL_FAILURE(
+      {  // NOLINT
+        ASSERT_FLOAT_NE(0.0, v.close_to_positive_zero);
+        ASSERT_FLOAT_NE(v.close_to_negative_zero, v.close_to_positive_zero);
+      },
+      "v.close_to_positive_zero");
+
+  EXPECT_FATAL_FAILURE(
+      {  // NOLINT
+        ASSERT_FLOAT_NE(-0.0, v.close_to_negative_zero);
+        ASSERT_FLOAT_NE(v.close_to_positive_zero, v.close_to_negative_zero);
+      },
+      "v.close_to_negative_zero");
+
 }
 
 // Tests comparing numbers close to each other.
@@ -2858,11 +2879,17 @@ TEST_F(FloatTest, SmallDiff) {
   EXPECT_FLOAT_EQ(1.0, values_.close_to_one);
   EXPECT_NONFATAL_FAILURE(EXPECT_FLOAT_EQ(1.0, values_.further_from_one),
                           "values_.further_from_one");
+
+  EXPECT_FLOAT_NE(1.0, values_.further_from_one);
+  EXPECT_NONFATAL_FAILURE(EXPECT_FLOAT_NE(1.0, values_.close_to_one), 
+                          "values_.close_to_one");
 }
 
 // Tests comparing numbers far apart.
 TEST_F(FloatTest, LargeDiff) {
   EXPECT_NONFATAL_FAILURE(EXPECT_FLOAT_EQ(2.5, 3.0), "3.0");
+
+  EXPECT_FLOAT_NE(2.5, 3.5);
 }
 
 // Tests comparing with infinity.
@@ -2920,6 +2947,12 @@ TEST_F(FloatTest, Commutative) {
   // We already tested EXPECT_FLOAT_EQ(1.0, values_.further_from_one).
   EXPECT_NONFATAL_FAILURE(EXPECT_FLOAT_EQ(values_.further_from_one, 1.0),
                           "1.0");
+
+  // We already tested EXPECT_FLOAT_NE(1.0, values_.close_to_one).
+  EXPECT_NONFATAL_FAILURE(EXPECT_FLOAT_NE(values_.close_to_one, 1.0), "1.0");
+
+  // We already tested EXPECT_FLOAT_NE(1.0, values_.further_from_one).
+  EXPECT_FLOAT_NE(values_.further_from_one, 1.0);
 }
 
 // Tests EXPECT_NEAR.
@@ -3007,6 +3040,10 @@ TEST_F(DoubleTest, Zeros) {
   EXPECT_DOUBLE_EQ(0.0, -0.0);
   EXPECT_NONFATAL_FAILURE(EXPECT_DOUBLE_EQ(-0.0, 1.0), "1.0");
   EXPECT_FATAL_FAILURE(ASSERT_DOUBLE_EQ(0.0, 1.0), "1.0");
+
+  EXPECT_DOUBLE_NE(-0.0, 1.0);
+  EXPECT_NONFATAL_FAILURE(EXPECT_DOUBLE_NE(-0.0, 0.0), "0.0");
+  EXPECT_FATAL_FAILURE(ASSERT_DOUBLE_NE(-0.0, 0.0), "0.0");
 }
 
 // Tests comparing numbers close to 0.
@@ -3033,6 +3070,26 @@ TEST_F(DoubleTest, AlmostZeros) {
                          v.further_from_negative_zero);
       },
       "v.further_from_negative_zero");
+
+  EXPECT_DOUBLE_NE(v.close_to_positive_zero, v.further_from_negative_zero);
+
+  EXPECT_FATAL_FAILURE(
+      {  // NOLINT
+        ASSERT_DOUBLE_NE(0.0, 
+                         v.close_to_positive_zero);
+        ASSERT_DOUBLE_NE(v.close_to_negative_zero, 
+                         v.close_to_positive_zero);
+      },
+      "v.close_to_positive_zero");
+
+  EXPECT_FATAL_FAILURE(
+      {  // NOLINT
+        ASSERT_DOUBLE_NE(-0.0, 
+                         v.close_to_negative_zero);
+        ASSERT_DOUBLE_NE(v.close_to_positive_zero, 
+                         v.close_to_negative_zero);
+      },
+      "v.close_to_negative_zero");
 }
 
 // Tests comparing numbers close to each other.
@@ -3040,11 +3097,17 @@ TEST_F(DoubleTest, SmallDiff) {
   EXPECT_DOUBLE_EQ(1.0, values_.close_to_one);
   EXPECT_NONFATAL_FAILURE(EXPECT_DOUBLE_EQ(1.0, values_.further_from_one),
                           "values_.further_from_one");
+
+  EXPECT_DOUBLE_NE(1.0, values_.further_from_one);
+  EXPECT_NONFATAL_FAILURE(EXPECT_DOUBLE_NE(1.0, values_.close_to_one),
+                          "values_.close_to_one");
 }
 
 // Tests comparing numbers far apart.
 TEST_F(DoubleTest, LargeDiff) {
   EXPECT_NONFATAL_FAILURE(EXPECT_DOUBLE_EQ(2.0, 3.0), "3.0");
+
+  EXPECT_DOUBLE_NE(2.0, 3.0);
 }
 
 // Tests comparing with infinity.
@@ -3097,6 +3160,12 @@ TEST_F(DoubleTest, Commutative) {
   // We already tested EXPECT_DOUBLE_EQ(1.0, values_.further_from_one).
   EXPECT_NONFATAL_FAILURE(EXPECT_DOUBLE_EQ(values_.further_from_one, 1.0),
                           "1.0");
+
+  // We already tested EXPECT_DOUBLE_NE(1.0, values_.close_to_one).
+  EXPECT_NONFATAL_FAILURE(EXPECT_DOUBLE_NE(values_.close_to_one, 1.0), "1.0");
+
+  // We already tested EXPECT_FLOAT_NE(1.0, values_.further_from_one).
+  EXPECT_DOUBLE_NE(values_.further_from_one, 1.0);
 }
 
 // Tests EXPECT_NEAR.


### PR DESCRIPTION
A "not equal" feature was added to complement the "equal" feature for float and double. A simple way to negate the *_EQ is to use an internal macro, EXPECT_NONFATAL_FAILURE(stmt, substr):
```
// A macro for testing Google Test assertions or code that's expected to
// generate Google Test non-fatal failures (e.g. a failure from an EXPECT_EQ,
// but not from an ASSERT_EQ). It asserts that the given statement will cause
// exactly one non-fatal Google Test failure with 'substr' being part of the
// failure message.
```
This is not meant to be used when using gtest. Instead, what is proposed is a way of testing for inequality that follows equality. Test cases were made that test the semantics of the macro. Test cases were not made where the internal testing is computed, since the underlying code for both are the same, except for minor adjustments that don't modify the underlying flow of the program.

The following macros were created:
```
EXPECT_FLOAT_NE
EXPECT_DOUBLE_NE
ASSERT_FLOAT_NE
ASSERT_DOUBLE_NE
```
Two helper functions were created:
```
::testing::internal::CmpHelperFloatingPointNE<float>
::testing::internal::CmpHelperFloatingPointNE<double>
```