### PR TITLE
Add CMake interface library `GTest::gtest_prod`

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -116,10 +116,14 @@ include_directories(${gtest_build_include_dirs})
 #
 # Defines the gtest & gtest_main libraries. User tests should link
 # with one of them.
+# Production code that includes <gtest/gtest_prod.h> should link with the
+# interface library gtest_prod.
 
 # Google Test libraries. We build them using more strict warnings than what
 # are used for other targets, to ensure that gtest can be compiled by a user
 # aggressive about warnings.
+add_library_and_alias(gtest_prod INTERFACE)
+set_target_properties(gtest_prod PROPERTIES VERSION ${GOOGLETEST_VERSION})
 cxx_library(gtest "${cxx_strict}" src/gtest-all.cc)
 set_target_properties(gtest PROPERTIES VERSION ${GOOGLETEST_VERSION})
 if(GTEST_HAS_ABSL)
@@ -141,6 +145,9 @@ endif()
 cxx_library(gtest_main "${cxx_strict}" src/gtest_main.cc)
 set_target_properties(gtest_main PROPERTIES VERSION ${GOOGLETEST_VERSION})
 string(REPLACE ";" "$<SEMICOLON>" dirs "${gtest_build_include_dirs}")
+target_include_directories(gtest_prod SYSTEM INTERFACE
+  "$<BUILD_INTERFACE:${dirs}>"
+  "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
 target_include_directories(gtest SYSTEM INTERFACE
   "$<BUILD_INTERFACE:${dirs}>"
   "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
@@ -155,7 +162,7 @@ target_link_libraries(gtest_main PUBLIC gtest)
 ########################################################################
 #
 # Install rules.
-install_project(gtest gtest_main)
+install_project(gtest_prod gtest gtest_main)
 
 ########################################################################
 #

--- a/googletest/cmake/gtest_prod.pc.in
+++ b/googletest/cmake/gtest_prod.pc.in
@@ -1,0 +1,7 @@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: gtest_prod
+Description: GoogleTest (header for production code)
+Version: @PROJECT_VERSION@
+URL: https://github.com/google/googletest
+Cflags: -I${includedir}

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -157,13 +157,17 @@ macro(config_compiler_and_linker)
   set(cxx_strict "${cxx_default} ${cxx_strict_flags}")
 endmacro()
 
+function(add_library_and_alias name type)
+  add_library(${name} ${type} ${ARGN})
+  add_library(${cmake_package_name}::${name} ALIAS ${name})
+endfunction()
+
 # Defines the gtest & gtest_main libraries. User tests should link
 # with one of them.
 function(cxx_library_with_type name type cxx_flags)
   # type can be either STATIC or SHARED to denote a static or shared library.
   # ARGN refers to additional arguments after 'cxx_flags'.
-  add_library(${name} ${type} ${ARGN})
-  add_library(${cmake_package_name}::${name} ALIAS ${name})
+  add_library_and_alias(${name} ${type} ${ARGN})
   set_target_properties(${name}
     PROPERTIES
     COMPILE_FLAGS "${cxx_flags}")


### PR DESCRIPTION
Production code that contains `#include <gtest/gtest_prod.h>` should link against this interface library: it sets the correct include path for the compiler but does not instruct the linker to pull in any GoogleTest library code.

Fixes #4673.