### PR TITLE
Put the fake Fuchsia SDK in a module extension

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -39,29 +39,37 @@ module(
 # Only direct dependencies need to be listed below.
 # Please keep the versions in sync with the versions in the WORKSPACE file.
 
-bazel_dep(name = "abseil-cpp",
-          version = "20240116.2")
+bazel_dep(
+    name = "abseil-cpp",
+    version = "20240116.2",
+)
+bazel_dep(
+    name = "platforms",
+    version = "0.0.10",
+)
+bazel_dep(
+    name = "re2",
+    version = "2024-07-02",
+)
 
-bazel_dep(name = "platforms",
-          version = "0.0.10")
-
-bazel_dep(name = "re2",
-          version = "2024-07-02")
-
-bazel_dep(name = "rules_python",
-          version = "0.34.0",
-          dev_dependency = True)
+bazel_dep(
+    name = "rules_python",
+    version = "0.34.0",
+    dev_dependency = True,
+)
 
 # https://rules-python.readthedocs.io/en/stable/toolchains.html#library-modules-with-dev-only-python-usage
 python = use_extension(
     "@rules_python//python/extensions:python.bzl",
     "python",
-    dev_dependency = True
+    dev_dependency = True,
+)
+python.toolchain(
+    ignore_root_user_error = True,
+    is_default = True,
+    python_version = "3.12",
 )
 
-python.toolchain(python_version = "3.12",
-                 is_default = True,
-                 ignore_root_user_error = True)
-
-fake_fuchsia_sdk = use_repo_rule("//:fake_fuchsia_sdk.bzl", "fake_fuchsia_sdk")
-fake_fuchsia_sdk(name = "fuchsia_sdk")
+fuchsia_sdk = use_extension("//:fake_fuchsia_sdk.bzl", "fuchsia_sdk")
+fuchsia_sdk.create_fake()
+use_repo(fuchsia_sdk, "fuchsia_sdk")

--- a/fake_fuchsia_sdk.bzl
+++ b/fake_fuchsia_sdk.bzl
@@ -31,3 +31,21 @@ fake_fuchsia_sdk = repository_rule(
         ),
     },
 )
+
+_create_fake = tag_class()
+
+def _fuchsia_sdk_impl(module_ctx):
+    create_fake_sdk = False
+    for mod in module_ctx.modules:
+        for _ in mod.tags.create_fake:
+            create_fake_sdk = True
+
+    if create_fake_sdk:
+        fake_fuchsia_sdk(name = "fuchsia_sdk")
+
+    return module_ctx.extension_metadata(reproducible = True)
+
+fuchsia_sdk = module_extension(
+    implementation = _fuchsia_sdk_impl,
+    tag_classes = {"create_fake": _create_fake},
+)


### PR DESCRIPTION
This allows users to override the fake SDK with a real one using https://bazel.build/rules/lib/globals/module#override_repo.

Without this change, it is impossible for a project that depends on googletest as a `bazel_dep` to build tests using the "real" Fuchsia SDK, because any references to `@fuchsia_sdk` within googletest `BUILD.bazel` files unconditionally resolve to the "fake" Fuchsia SDK. With this change, if you have the real Fuchsia SDK declared in your `MODULE.bazel`, you can add the following lines to coerce googletest to use the real Fuchsia SDK as well:

    fake_fuchsia_sdk_extension = use_extension("@com_google_googletest//:fake_fuchsia_sdk.bzl", "fuchsia_sdk")
    override_repo(fake_fuchsia_sdk_extension, "fuchsia_sdk")