### PR TITLE
Unnecessary cast warnings when compiling tests with option `-Wuseless-cast`

### DIFF
--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -1105,7 +1105,7 @@ class StreamingListener : public EmptyTestEventListener {
       GTEST_CHECK_(sockfd_ != -1)
           << "Send() can be called only when there is a connection.";
 
-      const auto len = static_cast<size_t>(message.length());
+      const auto len = message.length();
       if (write(sockfd_, message.c_str(), len) != static_cast<ssize_t>(len)) {
         GTEST_LOG_(WARNING) << "stream_result_to: failed to stream to "
                             << host_name_ << ":" << port_num_;

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -1165,7 +1165,7 @@ int UnitTestImpl::test_to_run_count() const {
 // trace but Bar() and CurrentOsStackTraceExceptTop() won't.
 std::string UnitTestImpl::CurrentOsStackTraceExceptTop(int skip_count) {
   return os_stack_trace_getter()->CurrentStackTrace(
-      static_cast<int>(GTEST_FLAG_GET(stack_trace_depth)), skip_count + 1
+      GTEST_FLAG_GET(stack_trace_depth), skip_count + 1
       // Skips the user-specified number of frames plus this function
       // itself.
   );  // NOLINT
@@ -4198,8 +4198,7 @@ void XmlUnitTestResultPrinter::OutputXmlCDataSection(::std::ostream* stream,
   for (;;) {
     const char* const next_segment = strstr(segment, "]]>");
     if (next_segment != nullptr) {
-      stream->write(segment,
-                    static_cast<std::streamsize>(next_segment - segment));
+      stream->write(segment, next_segment - segment);
       *stream << "]]>]]&gt;<![CDATA[";
       segment = next_segment + strlen("]]>");
     } else {


### PR DESCRIPTION
I've found some warnings when compiling my tests using the `-Wuseless-cast` flag. The proposed changes seems to fix it.

```
--- stderr: robot_health_checker                                                                                                                                              
In file included from /opt/ros/humble/src/gtest_vendor/./src/gtest.cc:122,
                 from /opt/ros/humble/src/gtest_vendor/src/gtest-all.cc:41:
/opt/ros/humble/src/gtest_vendor/./src/gtest-internal-inl.h: In member function ‘virtual void testing::internal::StreamingListener::SocketWriter::Send(const string&)’:
/opt/ros/humble/src/gtest_vendor/./src/gtest-internal-inl.h:1091:24: warning: useless cast to type ‘size_t’ {aka ‘long unsigned int’} [-Wuseless-cast]
 1091 |       const auto len = static_cast<size_t>(message.length());
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /opt/ros/humble/src/gtest_vendor/src/gtest-all.cc:41:
/opt/ros/humble/src/gtest_vendor/./src/gtest.cc: In member function ‘std::string testing::internal::UnitTestImpl::CurrentOsStackTraceExceptTop(int)’:
/opt/ros/humble/src/gtest_vendor/./src/gtest.cc:821:7: warning: useless cast to type ‘int’ [-Wuseless-cast]
  821 |       static_cast<int>(GTEST_FLAG(stack_trace_depth)),
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/ros/humble/src/gtest_vendor/./src/gtest.cc: In static member function ‘static void testing::internal::XmlUnitTestResultPrinter::OutputXmlCDataSection(std::ostream*, const char*)’:
/opt/ros/humble/src/gtest_vendor/./src/gtest.cc:3754:20: warning: useless cast to type ‘std::streamsize’ {aka ‘long int’} [-Wuseless-cast]
 3754 |           segment, static_cast<std::streamsize>(next_segment - segment));
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
---
```