### PR TITLE
Optimize Bazel dependency management for GoogleTest

### DIFF
--- a/googletest_deps.bzl
+++ b/googletest_deps.bzl
@@ -1,28 +1,34 @@
-"""Load dependencies needed to use the googletest library as a 3rd-party consumer."""
+"""Load dependencies required for using the GoogleTest library as a third-party consumer."""
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//:fake_fuchsia_sdk.bzl", "fake_fuchsia_sdk")
 
+def maybe_http_archive(name, sha256, strip_prefix, urls):
+    """Helper function to conditionally load an http_archive if it doesn't exist."""
+    if not native.existing_rule(name):
+        http_archive(
+            name = name,
+            sha256 = sha256,
+            strip_prefix = strip_prefix,
+            urls = urls,
+        )
+
 def googletest_deps():
-    """Loads common dependencies needed to use the googletest library."""
+    """Loads required dependencies for using GoogleTest."""
 
-    if not native.existing_rule("re2"):
-        http_archive(
-            name = "re2",
-            sha256 = "eb2df807c781601c14a260a507a5bb4509be1ee626024cb45acbd57cb9d4032b",
-            strip_prefix = "re2-2024-07-02",
-            urls = ["https://github.com/google/re2/releases/download/2024-07-02/re2-2024-07-02.tar.gz"],
-        )
+    maybe_http_archive(
+        name = "re2",
+        sha256 = "eb2df807c781601c14a260a507a5bb4509be1ee626024cb45acbd57cb9d4032b",
+        strip_prefix = "re2-2024-07-02",
+        urls = ["https://github.com/google/re2/releases/download/2024-07-02/re2-2024-07-02.tar.gz"],
+    )
 
-    if not native.existing_rule("abseil-cpp"):
-        http_archive(
-            name = "abseil-cpp",
-            sha256 = "733726b8c3a6d39a4120d7e45ea8b41a434cdacde401cba500f14236c49b39dc",
-            strip_prefix = "abseil-cpp-20240116.2",
-            urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.2/abseil-cpp-20240116.2.tar.gz"],
-        )
+    maybe_http_archive(
+        name = "abseil-cpp",
+        sha256 = "733726b8c3a6d39a4120d7e45ea8b41a434cdacde401cba500f14236c49b39dc",
+        strip_prefix = "abseil-cpp-20240116.2",
+        urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.2/abseil-cpp-20240116.2.tar.gz"],
+    )
 
     if not native.existing_rule("fuchsia_sdk"):
-        fake_fuchsia_sdk(
-            name = "fuchsia_sdk",
-        )
+        fake_fuchsia_sdk(name = "fuchsia_sdk")


### PR DESCRIPTION
This PR optimizes the Bazel dependency loading script for GoogleTest by introducing a helper function (maybe_http_archive) to reduce redundancy and improve maintainability.