### PR TITLE
fix: Take the C++ standard version into account when using `__has_cpp_attribute`

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -757,7 +757,7 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 #if defined(__has_cpp_attribute)
 // NOTE: requiring __cplusplus above should not be necessary, but
 // works around https://bugs.llvm.org/show_bug.cgi?id=23435.
-#define GTEST_INTERNAL_HAVE_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
+#define GTEST_INTERNAL_HAVE_CPP_ATTRIBUTE(x) GTEST_INTERNAL_CPLUSPLUS_LANG >= __has_cpp_attribute(x)
 #else
 #define GTEST_INTERNAL_HAVE_CPP_ATTRIBUTE(x) 0
 #endif


### PR DESCRIPTION
Resolves #4605

As elaborated in the issue, `GTEST_INTERNAL_HAVE_CPP_ATTRIBUTE(maybe_unused)` failing to consider the C++ standard can cause `-Wc++17-attribute-extensions` warning in C++14.

This PR applies the patch equivalent to what the issue proposed, but uses `GTEST_INTERNAL_CPLUSPLUS_LANG` instead of `__cplusplus`.