### PR TITLE
Fix build error with GCC 12: Remove extra semicolon after member function definition

### DIFF
--- a/googlemock/test/gmock-actions_test.cc
+++ b/googlemock/test/gmock-actions_test.cc
@@ -188,7 +188,7 @@ TEST(TypeTraits, IsInvocableRV) {
   struct C {
     int operator()() const { return 0; }
     void operator()(int) & {}
-    std::string operator()(int) && { return ""; };
+    std::string operator()(int) && { return ""; }
   };
 
   // The first overload is callable for const and non-const rvalues and lvalues.


### PR DESCRIPTION
This pull request fixes a build error encountered when compiling GoogleMock tests with GCC 12 on the Steam Runtime (SteamRT) distribution.
The error was caused by an extra semicolon (;) following a member function definition, which triggers `-Wextra-semi ` warnings treated as errors under stricter compiler settings.