### PR TITLE
Fix: Update Google Mock community link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,8 @@ PR is acceptable as an alternative.
 The Google Test community exists primarily through the
 [discussion group](https://groups.google.com/group/googletestframework) and the
 GitHub repository. Likewise, the Google Mock community exists primarily through
-their own [discussion group](https://groups.google.com/group/googlemock). You
+the GitHub repository and the Google Test
+[discussion group](https://groups.google.com/group/googletestframework). You
 are definitely encouraged to contribute to the discussion and you can also help
 us to keep the effectiveness of the group high by following and promoting the
 guidelines listed here.


### PR DESCRIPTION
The Google Mock discussion group is no longer active. This commit updates `CONTRIBUTING.md` to direct you to the Google Test discussion group and the GitHub repository for Google Mock community discussions.
@calumr @shlomif 