### PR TITLE
Fix constness of StringStreamToString parameter

### DIFF
--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -1602,7 +1602,7 @@ AssertionResult CmpHelperFloatingPointEQ(const char* lhs_expression,
   rhs_ss << rhs_value;
 
   return EqFailure(lhs_expression, rhs_expression,
-                   StringStreamToString(&lhs_ss), StringStreamToString(&rhs_ss),
+                   StringStreamToString(lhs_ss), StringStreamToString(rhs_ss),
                    false);
 }
 

--- a/googletest/include/gtest/internal/gtest-string.h
+++ b/googletest/include/gtest/internal/gtest-string.h
@@ -170,7 +170,7 @@ class GTEST_API_ [[nodiscard]] String {
 
 // Gets the content of the stringstream's buffer as an std::string.  Each '\0'
 // character in the buffer is replaced with "\\0".
-GTEST_API_ std::string StringStreamToString(::std::stringstream* stream);
+GTEST_API_ std::string StringStreamToString(const ::std::stringstream& stream);
 
 }  // namespace internal
 }  // namespace testing

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -1369,7 +1369,7 @@ Message& Message::operator<<(const ::std::wstring& wstr) {
 // Gets the text streamed to this object so far as an std::string.
 // Each '\0' character in the buffer is replaced with "\\0".
 std::string Message::GetString() const {
-  return internal::StringStreamToString(ss_.get());
+  return internal::StringStreamToString(*ss_);
 }
 
 namespace internal {
@@ -1788,8 +1788,8 @@ AssertionResult FloatingPointLE(const char* expr1, const char* expr2,
 
   return AssertionFailure()
          << "Expected: (" << expr1 << ") <= (" << expr2 << ")\n"
-         << "  Actual: " << StringStreamToString(&val1_ss) << " vs "
-         << StringStreamToString(&val2_ss);
+         << "  Actual: " << StringStreamToString(val1_ss) << " vs "
+         << StringStreamToString(val2_ss);
 }
 
 }  // namespace internal
@@ -2157,7 +2157,7 @@ std::string WideStringToUtf8(const wchar_t* str, int num_chars) {
 
     stream << CodePointToUtf8(unicode_code_point);
   }
-  return StringStreamToString(&stream);
+  return StringStreamToString(stream);
 }
 
 // Converts a wide C string to an std::string using the UTF-8 encoding.
@@ -2298,8 +2298,8 @@ std::string String::FormatByte(unsigned char value) {
 
 // Converts the buffer in a stringstream to an std::string, converting NUL
 // bytes to "\\0" along the way.
-std::string StringStreamToString(::std::stringstream* ss) {
-  const ::std::string& str = ss->str();
+std::string StringStreamToString(const ::std::stringstream& ss) {
+  const ::std::string& str = ss.str();
   const char* const start = str.c_str();
   const char* const end = start + str.length();
 
@@ -4085,7 +4085,7 @@ void XmlUnitTestResultPrinter::OnTestIterationEnd(const UnitTest& unit_test,
   FILE* xmlout = OpenFileForWriting(output_file_);
   std::stringstream stream;
   PrintXmlUnitTest(&stream, unit_test);
-  fprintf(xmlout, "%s", StringStreamToString(&stream).c_str());
+  fprintf(xmlout, "%s", StringStreamToString(stream).c_str());
   fclose(xmlout);
 }
 
@@ -4094,7 +4094,7 @@ void XmlUnitTestResultPrinter::ListTestsMatchingFilter(
   FILE* xmlout = OpenFileForWriting(output_file_);
   std::stringstream stream;
   PrintXmlTestsList(&stream, test_suites);
-  fprintf(xmlout, "%s", StringStreamToString(&stream).c_str());
+  fprintf(xmlout, "%s", StringStreamToString(stream).c_str());
   fclose(xmlout);
 }
 
@@ -4612,7 +4612,7 @@ void JsonUnitTestResultPrinter::OnTestIterationEnd(const UnitTest& unit_test,
   FILE* jsonout = OpenFileForWriting(output_file_);
   std::stringstream stream;
   PrintJsonUnitTest(&stream, unit_test);
-  fprintf(jsonout, "%s", StringStreamToString(&stream).c_str());
+  fprintf(jsonout, "%s", StringStreamToString(stream).c_str());
   fclose(jsonout);
 }
 
@@ -6435,7 +6435,7 @@ void UnitTestImpl::ListTestsMatchingFilter() {
           UnitTestOptions::GetAbsolutePathToOutputFile().c_str())
           .PrintJsonTestList(&stream, test_suites_);
     }
-    fprintf(fileout, "%s", StringStreamToString(&stream).c_str());
+    fprintf(fileout, "%s", StringStreamToString(stream).c_str());
     fclose(fileout);
   }
 #endif  // GTEST_HAS_FILE_SYSTEM

--- a/googletest/test/googletest-message-test.cc
+++ b/googletest/test/googletest-message-test.cc
@@ -173,7 +173,7 @@ TEST(MessageTest, StreamsToOStream) {
   Message msg("Hello");
   ::std::stringstream ss;
   ss << msg;
-  EXPECT_EQ("Hello", testing::internal::StringStreamToString(&ss));
+  EXPECT_EQ("Hello", testing::internal::StringStreamToString(ss));
 }
 
 // Tests that a Message object doesn't take up too much stack space.


### PR DESCRIPTION
Came across this due to a C26461 warning of MSVC:
> The pointer argument 'ss' for function 'testing::internal::StringStreamToString' can be marked as a pointer to const (con.3).

As the method is defined as internal method, a breaking adjustment should be okay. So I switched to const reference, to make clear that the method doesn't accept a `nullptr`.