### PR TITLE
Do not print skipped test's messages in brief mode

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -2463,7 +2463,7 @@ void TestResult::Clear() {
   elapsed_time_ = 0;
 }
 
-// Returns true off the test part was skipped.
+// Returns true if the test part was skipped.
 static bool TestPartSkipped(const TestPartResult& result) {
   return result.skipped();
 }
@@ -3754,6 +3754,8 @@ void BriefUnitTestResultPrinter::OnTestPartResult(
   switch (result.type()) {
     // If the test part succeeded, we don't need to do anything.
     case TestPartResult::kSuccess:
+      return;
+    case TestPartResult::kSkip:
       return;
     default:
       // Print failure message from the assertion

--- a/googletest/test/gtest_skip_check_output_test.py
+++ b/googletest/test/gtest_skip_check_output_test.py
@@ -37,7 +37,7 @@ import re
 
 from googletest.test import gtest_test_utils
 
-# Path to the gtest_skip_in_environment_setup_test binary
+# Path to the gtest_skip_test binary
 EXE_PATH = gtest_test_utils.GetTestExecutablePath('gtest_skip_test')
 
 OUTPUT = gtest_test_utils.Subprocess([EXE_PATH]).output
@@ -54,6 +54,17 @@ class SkipEntireEnvironmentTest(gtest_test_utils.TestCase):
         repr(OUTPUT),
     )
     self.assertNotIn('FAILED', OUTPUT)
+
+  def testSkipTestWithBriefFlag(self):
+    brief_output = gtest_test_utils.Subprocess([EXE_PATH, "--gtest_brief=1"]).output
+    self.assertNotIn('Skipped\nskipping single test\n', brief_output)
+    skip_fixture = 'Skipped\nskipping all tests for this fixture\n'
+    self.assertIsNone(
+        re.search(skip_fixture + '.*' + skip_fixture, brief_output, flags=re.DOTALL),
+        repr(brief_output),
+    )
+    self.assertIn('SKIPPED', brief_output)
+    self.assertNotIn('FAILED', brief_output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Prevents messages from skipped tests being displayed when the `--gtest_brief` flag is set.

Resolves #4548

Using this example:

```cpp
// test.cpp
#include <gtest/gtest.h>

TEST(Test, TwoAndTwoIsFour) { 
  GTEST_SKIP();
  EXPECT_EQ(2 + 2, 4); 
}

TEST(Test, FiveAndFiveIsTen) {
  GTEST_SKIP() << "user message";
  EXPECT_EQ(5 + 5, 10);
}
```

**Before:**

```console
$ ./test --gtest_brief=1
.../test.cpp:5: Skipped


.../test.cpp:10: Skipped
user message

[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.
[  SKIPPED ] 2 tests.
```

**After:**

```console
$ ./test --gtest_brief=1
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.
[  SKIPPED ] 2 tests.
```