### PR TITLE
exclude tuple-like types from OnceAction forwarding constructors

### DIFF
--- a/googlemock/include/gmock/gmock-actions.h
+++ b/googlemock/include/gmock/gmock-actions.h
@@ -302,6 +302,16 @@ struct disjunction<P1, Ps...>
 template <typename...>
 using void_t = void;
 
+template <template <class...> class Template, class T>
+struct is_specialization_of : std::false_type {};
+
+template <template <class...> class Template, class... Ts>
+struct is_specialization_of<Template, Template<Ts...>> : std::true_type {};
+
+template <typename T>
+using is_tuple_like = is_specialization_of<std::tuple,
+                                           typename std::decay<T>::type>;
+
 // Detects whether an expression of type `From` can be implicitly converted to
 // `To` according to [conv]. In C++17, [conv]/3 defines this as follows:
 //
@@ -456,6 +466,8 @@ class OnceAction<Result(Args...)> final {
                     // traits above.
                     internal::negation<std::is_same<
                         OnceAction, typename std::decay<Callable>::type>>,
+                    // Never treat tuple wrappers as callables.
+                    internal::negation<internal::is_tuple_like<Callable>>,
                     IsDirectlyCompatible<Callable>>  //
                 ::value,
                 int>::type = 0>
@@ -473,6 +485,8 @@ class OnceAction<Result(Args...)> final {
                     // traits above.
                     internal::negation<std::is_same<
                         OnceAction, typename std::decay<Callable>::type>>,
+                    // Never treat tuple wrappers as callables.
+                    internal::negation<internal::is_tuple_like<Callable>>,
                     // Exclude callables for which the overload above works.
                     // We'd rather provide the arguments if possible.
                     internal::negation<IsDirectlyCompatible<Callable>>,


### PR DESCRIPTION
Fixes https://github.com/google/googletest/issues/3947

**Problem**
- `OnceAction` has templated forwarding constructors constrained for callable types.
- On QNX SDK versions prior to 8.0, `std::tuple<OnceAction>` can incorrectly satisfy those constraints because of how that libc++ implements `std::tuple` converting constructors.
- Upstream, most libc++/libstdc++/MSVC versions short-circuit correctly, so the bug is only visible on QNX. But nothing about `OnceAction` should ever allow a tuple to be treated as a callable.
- Note existence of QNX downstream patch to achieve the same thing at https://github.com/qnx/googletest/commit/ceebbad256fef7541ab5432d1730427827171cc9#diff-91a00bafe0b6186545af81d16fdc9a5fd0afccfc336bdbbcab5deb7de63a57f6L475

**Solution**
- Update `OnceAction` forwarding constructors to exclude tuple-like types.