### PR TITLE
Use "test suite" rather than "test case" in error about mixing TEST and TEST_F

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -2600,7 +2600,7 @@ bool Test::HasSameFixtureClass() {
           << "test " << TEST_F_name << " is defined using TEST_F but\n"
           << "test " << TEST_name << " is defined using TEST.  You probably\n"
           << "want to change the TEST to TEST_F or move it to another test\n"
-          << "case.";
+          << "suite.";
     } else {
       // Two fixture classes with the same name appear in two different
       // namespaces, which is not allowed. Tell the user how to fix this.


### PR DESCRIPTION
I'm pretty sure that this was missed when changing terminology since moving to another test case doesn't seem to make sense in context.