### PR TITLE
avoid `-lpthread` link option when building with emscripten without threads

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -58,6 +58,16 @@ config_setting(
     constraint_values = ["@platforms//os:openbsd"],
 )
 
+config_setting(
+    name = "emscripten_without_threads",
+    constraint_values = [
+        "@platforms//os:emscripten",
+    ],
+    values = {
+        "features": "-use_pthreads",
+    },
+)
+
 # NOTE: Fuchsia is not an officially supported platform.
 config_setting(
     name = "fuchsia",
@@ -113,10 +123,12 @@ cc_library(
     copts = select({
         ":qnx": [],
         ":windows": [],
+        ":emscripten_without_threads": [],
         "//conditions:default": ["-pthread"],
     }),
     defines = select({
         ":has_absl": ["GTEST_HAS_ABSL=1"],
+        ":emscripten_without_threads": ["GTEST_HAS_PTHREAD=0"],
         "//conditions:default": [],
     }),
     features = select({
@@ -140,6 +152,7 @@ cc_library(
             "-lm",
             "-pthread",
         ],
+        ":emscripten_without_threads": [],
         "//conditions:default": ["-pthread"],
     }),
     deps = select({


### PR DESCRIPTION
Having this flag causes emscripten to generate a binary with pthread support, which is not compatible with browsers that do not support pthreads or with web pages that do not enable pthread support