### PR TITLE
use rules_license for defining the license of this repository

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -31,12 +31,22 @@
 #   Bazel Build for Google C++ Testing Framework(Google Test)
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_license//rules:license.bzl", "license")
 
-package(default_visibility = ["//visibility:public"])
+package(
+    default_applicable_licenses = [":license"],
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])
 
 exports_files(["LICENSE"])
+
+license(
+    name = "license",
+    license_kinds = ["@rules_license//licenses/spdx:BSD-3-Clause"],
+    license_text = "LICENSE",
+)
 
 config_setting(
     name = "qnx",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -62,6 +62,11 @@ bazel_dep(
     dev_dependency = True,
 )
 
+bazel_dep(
+    name = "rules_license",
+    version = "1.0.0",
+)
+
 # https://rules-python.readthedocs.io/en/stable/toolchains.html#library-modules-with-dev-only-python-usage
 python = use_extension(
     "@rules_python//python/extensions:python.bzl",


### PR DESCRIPTION
This helps with generating better SBOMs than the old built-in `licenses` attribute