### PR TITLE
Use `TempDir()` in `CapturedStream` on all non‐Windows platforms

### DIFF
--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -1054,16 +1054,6 @@ GTestLog::~GTestLog() {
 // this class (creat, dup, dup2, and close)
 GTEST_DISABLE_MSC_DEPRECATED_PUSH_()
 
-namespace {
-
-#if defined(GTEST_OS_LINUX_ANDROID) || defined(GTEST_OS_IOS)
-bool EndsWithPathSeparator(const std::string& path) {
-  return !path.empty() && path.back() == GTEST_PATH_SEP_[0];
-}
-#endif
-
-}  // namespace
-
 // Object that captures an output stream (stdout/stderr).
 class CapturedStream {
  public:
@@ -1088,46 +1078,8 @@ class CapturedStream {
     // directory, so we create the temporary file in a temporary directory.
     std::string name_template;
 
-#ifdef GTEST_OS_LINUX_ANDROID
-    // Note: Android applications are expected to call the framework's
-    // Context.getExternalStorageDirectory() method through JNI to get
-    // the location of the world-writable SD Card directory. However,
-    // this requires a Context handle, which cannot be retrieved
-    // globally from native code. Doing so also precludes running the
-    // code as part of a regular standalone executable, which doesn't
-    // run in a Dalvik process (e.g. when running it through 'adb shell').
-    //
-    // The location /data/local/tmp is directly accessible from native code.
-    // '/sdcard' and other variants cannot be relied on, as they are not
-    // guaranteed to be mounted, or may have a delay in mounting.
-    //
-    // However, prefer using the TMPDIR environment variable if set, as newer
-    // devices may have /data/local/tmp read-only.
+#if defined(GTEST_OS_LINUX_ANDROID) || defined(GTEST_OS_IOS)
     name_template = TempDir();
-    if (!EndsWithPathSeparator(name_template))
-      name_template.push_back(GTEST_PATH_SEP_[0]);
-
-#elif defined(GTEST_OS_IOS)
-    char user_temp_dir[PATH_MAX + 1];
-
-    // Documented alternative to NSTemporaryDirectory() (for obtaining creating
-    // a temporary directory) at
-    // https://developer.apple.com/library/archive/documentation/Security/Conceptual/SecureCodingGuide/Articles/RaceConditions.html#//apple_ref/doc/uid/TP40002585-SW10
-    //
-    // _CS_DARWIN_USER_TEMP_DIR (as well as _CS_DARWIN_USER_CACHE_DIR) is not
-    // documented in the confstr() man page at
-    // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/confstr.3.html#//apple_ref/doc/man/3/confstr
-    // but are still available, according to the WebKit patches at
-    // https://trac.webkit.org/changeset/262004/webkit
-    // https://trac.webkit.org/changeset/263705/webkit
-    //
-    // The confstr() implementation falls back to getenv("TMPDIR"). See
-    // https://opensource.apple.com/source/Libc/Libc-1439.100.3/gen/confstr.c.auto.html
-    ::confstr(_CS_DARWIN_USER_TEMP_DIR, user_temp_dir, sizeof(user_temp_dir));
-
-    name_template = user_temp_dir;
-    if (!EndsWithPathSeparator(name_template))
-      name_template.push_back(GTEST_PATH_SEP_[0]);
 #else
     name_template = "/tmp/";
 #endif

--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -1076,13 +1076,7 @@ class CapturedStream {
 #else
     // There's no guarantee that a test has write access to the current
     // directory, so we create the temporary file in a temporary directory.
-    std::string name_template;
-
-#if defined(GTEST_OS_LINUX_ANDROID) || defined(GTEST_OS_IOS)
-    name_template = TempDir();
-#else
-    name_template = "/tmp/";
-#endif
+    std::string name_template = TempDir();
     name_template.append("gtest_captured_stream.XXXXXX");
 
     // mkstemp() modifies the string bytes in place, and does not go beyond the


### PR DESCRIPTION
This is more consistent and makes tests using output capture behave as expected in environments with custom values of `$TEST_TMPDIR` or `$TMPDIR`, including fixing them in ones where `/tmp` may not be accessible, such as sandboxed build environments on macOS.