### PR TITLE
Fix/ci build system improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(googletest-distribution)
-set(GOOGLETEST_VERSION 1.16.0)
+set(GOOGLETEST_VERSION 1.17.0)
 
 if(NOT CYGWIN AND NOT MSYS AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL QNX)
   set(CMAKE_CXX_EXTENSIONS OFF)

--- a/ci/macos-presubmit.sh
+++ b/ci/macos-presubmit.sh
@@ -49,8 +49,8 @@ for cmake_off_on in OFF ON; do
     -Dgmock_build_tests=ON \
     -Dcxx_no_exception=${cmake_off_on} \
     -Dcxx_no_rtti=${cmake_off_on}
-  time make -j$(nproc)
-  time ctest -j$(nproc) --output-on-failure
+  time make -j$(sysctl -n hw.ncpu)
+  time ctest -j$(sysctl -n hw.ncpu) --output-on-failure
 done
 
 # Test the Bazel build

--- a/ci/windows-presubmit.bat
+++ b/ci/windows-presubmit.bat
@@ -2,8 +2,8 @@ SETLOCAL ENABLEDELAYEDEXPANSION
 
 SET BAZEL_EXE=%KOKORO_GFILE_DIR%\bazel-8.2.1-windows-x86_64.exe
 
-SET PATH=C:\Python34;%PATH%
-SET BAZEL_PYTHON=C:\python34\python.exe
+SET PATH=C:\Python312;%PATH%
+SET BAZEL_PYTHON=C:\python312\python.exe
 SET BAZEL_SH=C:\tools\msys64\usr\bin\bash.exe
 SET CMAKE_BIN="cmake.exe"
 SET CTEST_BIN="ctest.exe"
@@ -23,9 +23,9 @@ CD %CMAKE_BUILD_PATH%
 %CMAKE_BIN% %GTEST_ROOT% ^
   -G "Visual Studio 17 2022" ^
   -DCMAKE_CXX_STANDARD=17 ^
-  -DPYTHON_EXECUTABLE:FILEPATH=c:\python37\python.exe ^
-  -DPYTHON_INCLUDE_DIR:PATH=c:\python37\include ^
-  -DPYTHON_LIBRARY:FILEPATH=c:\python37\lib\site-packages\pip ^
+  -DPYTHON_EXECUTABLE:FILEPATH=c:\python312\python.exe ^
+  -DPYTHON_INCLUDE_DIR:PATH=c:\python312\include ^
+  -DPYTHON_LIBRARY:FILEPATH=c:\python312\lib\site-packages\pip ^
   -Dgtest_build_samples=ON ^
   -Dgtest_build_tests=ON ^
   -Dgmock_build_tests=ON

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -2144,7 +2144,7 @@ GTEST_DISABLE_MSC_DEPRECATED_POP_()
 #ifdef GTEST_OS_WINDOWS_MOBILE
 // Windows CE has no C library. The abort() function is used in
 // several places in Google Test. This implementation provides a reasonable
-// imitation of standard behaviour.
+// imitation of standard behavior.
 [[noreturn]] void Abort();
 #else
 [[noreturn]] inline void Abort() { abort(); }

--- a/googletest/include/gtest/internal/gtest-string.h
+++ b/googletest/include/gtest/internal/gtest-string.h
@@ -84,7 +84,7 @@ class GTEST_API_ String {
   // input is NULL.
   //
   // The wide string is created using the ANSI codepage (CP_ACP) to
-  // match the behaviour of the ANSI versions of Win32 calls and the
+  // match the behavior of the ANSI versions of Win32 calls and the
   // C runtime.
   static LPCWSTR AnsiToUtf16(const char* c_str);
 
@@ -94,7 +94,7 @@ class GTEST_API_ String {
   // input is NULL.
   //
   // The returned string is created using the ANSI codepage (CP_ACP) to
-  // match the behaviour of the ANSI versions of Win32 calls and the
+  // match the behavior of the ANSI versions of Win32 calls and the
   // C runtime.
   static const char* Utf16ToAnsi(LPCWSTR utf16_str);
 #endif


### PR DESCRIPTION
- Update CMakeLists.txt version from 1.16.0 to 1.17.0 to match current release
- Fix macOS CI script to use 'sysctl -n hw.ncpu' instead of Linux 'nproc' command  
- Modernize Windows CI Python paths from outdated Python 3.4/3.7 to Python 3.12
