### PR TITLE
[OG-164] add configuration as a zephyr module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,36 +1,17 @@
-# Note: CMake support is community-based. The maintainers do not use CMake
-# internally.
-
 cmake_minimum_required(VERSION 3.16)
-
 project(googletest-distribution)
 set(GOOGLETEST_VERSION 1.16.0)
 
-if(NOT CYGWIN AND NOT MSYS AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL QNX)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
+if(CONFIG_GTEST)
+    zephyr_library()
 
-enable_testing()
+    zephyr_include_directories(
+        ${CMAKE_CURRENT_SOURCE_DIR}/googletest/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/googlemock/include
+    )
 
-include(CMakeDependentOption)
-include(GNUInstallDirs)
-
-# Note that googlemock target already builds googletest.
-option(BUILD_GMOCK "Builds the googlemock subproject" ON)
-option(INSTALL_GTEST "Enable installation of googletest. (Projects embedding googletest may want to turn this OFF.)" ON)
-option(GTEST_HAS_ABSL "Use Abseil and RE2. Requires Abseil and RE2 to be separately added to the build." OFF)
-
-if(GTEST_HAS_ABSL)
-  if(NOT TARGET absl::base)
-    find_package(absl REQUIRED)
-  endif()
-  if(NOT TARGET re2::re2)
-    find_package(re2 REQUIRED)
-  endif()
-endif()
-
-if(BUILD_GMOCK)
-  add_subdirectory( googlemock )
-else()
-  add_subdirectory( googletest )
+    zephyr_library_sources(
+        googletest/src/gtest-all.cc
+        googlemock/src/gmock-all.cc
+    )
 endif()

--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,11 @@
+mainmenu "Googletest"
+
+menu "Gtest configuration"
+
+  config GTEST
+    bool "Enable Gtest"
+    default n
+    help
+      Enables installation of googletest.
+
+endmenu

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,4 @@
+name: gtest
+build:
+  cmake: .
+  kconfig: Kconfig


### PR DESCRIPTION
|Related issue|
|---|
|[OG-164](https://owl-services.atlassian.net/browse/OG-164)

## Description
This pull request aims to configure the repository as a zephyr module.

## DoD
- [x] Code involved.
- [x] Unit tests
- [x] Documentation 

## Reviewers
- @gebowl
- @konangc87