### PR TITLE
Allow use of `import std;`

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -26,6 +26,13 @@ option(
   "Build gtest with internal symbols hidden in shared libraries."
   OFF)
 
+# set(GTEST_BUILD_USING_STD_MODULE ON)
+# set(CMAKE_CXX_STANDARD 23)
+# set(CMAKE_CXX_EXTENSIONS OFF)
+# set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD ON)
+# set(CMAKE_CXX_SCAN_FOR_MODULES ON)
+
 # Defines pre_project_set_up_hermetic_build() and set_up_hermetic_build().
 include(cmake/hermetic_build.cmake OPTIONAL)
 
@@ -120,7 +127,44 @@ include_directories(${gtest_build_include_dirs})
 # Google Test libraries. We build them using more strict warnings than what
 # are used for other targets, to ensure that gtest can be compiled by a user
 # aggressive about warnings.
-cxx_library(gtest "${cxx_strict}" src/gtest-all.cc)
+
+cxx_library(gtest "${cxx_strict}" 
+    src/gtest-all.cc
+    # src/gtest.cc
+    # src/gtest-port.cc
+    # src/gtest-assertion-result.cc
+    # src/gtest-death-test.cc
+    # src/gtest-filepath.cc
+    # src/gtest-internal-inl.h
+    # src/gtest-matchers.cc
+    # src/gtest-port.cc
+    # src/gtest-printers.cc
+    # src/gtest-test-part.cc
+    # src/gtest-typed-test.cc 
+    include/gtest/gtest.h
+    include/gtest/gtest_pred_impl.h
+    include/gtest/gtest_prod.h
+    include/gtest/gtest-assertion-result.h
+    include/gtest/gtest-death-test.h
+    include/gtest/gtest-matchers.h
+    include/gtest/gtest-message.h
+    include/gtest/gtest-param-test.h
+    include/gtest/gtest-printers.h
+    include/gtest/gtest-spi.h
+    include/gtest/gtest-test-part.h
+    include/gtest/gtest-typed-test.h
+    include/gtest/internal/gtest-death-test-internal.h                                                                                 
+    include/gtest/internal/gtest-filepath.h                                                                                            
+    include/gtest/internal/gtest-internal.h                                                                                            
+    include/gtest/internal/gtest-param-util.h                                                                                          
+    include/gtest/internal/gtest-port-arch.h                                                                                           
+    include/gtest/internal/gtest-port.h                                                                                                
+    include/gtest/internal/gtest-string.h                                                                                              
+    include/gtest/internal/gtest-type-util.h 
+    include/gtest/internal/custom/gtest.h 
+    include/gtest/internal/custom/gtest-port.h 
+    include/gtest/internal/custom/gtest-printers.h 
+  )
 set_target_properties(gtest PROPERTIES VERSION ${GOOGLETEST_VERSION})
 if(GTEST_HAS_ABSL)
   target_compile_definitions(gtest PUBLIC GTEST_HAS_ABSL=1)
@@ -135,6 +179,11 @@ if(GTEST_HAS_ABSL)
     re2::re2
   )
 endif()
+if(GTEST_BUILD_USING_STD_MODULE)
+  message(STATUS GTEST_BUILD_USING_STD_MODULE=${GTEST_BUILD_USING_STD_MODULE})
+  target_compile_definitions(gtest PRIVATE GTEST_BUILD_USING_STD_MODULE)
+endif()
+
 cxx_library(gtest_main "${cxx_strict}" src/gtest_main.cc)
 set_target_properties(gtest_main PROPERTIES VERSION ${GOOGLETEST_VERSION})
 string(REPLACE ";" "$<SEMICOLON>" dirs "${gtest_build_include_dirs}")

--- a/googletest/include/gtest/gtest-assertion-result.h
+++ b/googletest/include/gtest/gtest-assertion-result.h
@@ -38,10 +38,14 @@
 #ifndef GOOGLETEST_INCLUDE_GTEST_GTEST_ASSERTION_RESULT_H_
 #define GOOGLETEST_INCLUDE_GTEST_GTEST_ASSERTION_RESULT_H_
 
-#include <memory>
-#include <ostream>
-#include <string>
-#include <type_traits>
+#if defined(GTEST_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <memory>
+    #include <ostream>
+    #include <string>
+    #include <type_traits>
+#endif
 
 #include "gtest/gtest-message.h"
 #include "gtest/internal/gtest-port.h"

--- a/googletest/include/gtest/gtest-matchers.h
+++ b/googletest/include/gtest/gtest-matchers.h
@@ -39,12 +39,16 @@
 #ifndef GOOGLETEST_INCLUDE_GTEST_GTEST_MATCHERS_H_
 #define GOOGLETEST_INCLUDE_GTEST_GTEST_MATCHERS_H_
 
-#include <atomic>
-#include <functional>
-#include <memory>
-#include <ostream>
-#include <string>
-#include <type_traits>
+#if defined(GTEST_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <atomic>
+    #include <functional>
+    #include <memory>
+    #include <ostream>
+    #include <string>
+    #include <type_traits>
+#endif
 
 #include "gtest/gtest-printers.h"
 #include "gtest/internal/gtest-internal.h"

--- a/googletest/include/gtest/gtest-message.h
+++ b/googletest/include/gtest/gtest-message.h
@@ -48,11 +48,15 @@
 #ifndef GOOGLETEST_INCLUDE_GTEST_GTEST_MESSAGE_H_
 #define GOOGLETEST_INCLUDE_GTEST_GTEST_MESSAGE_H_
 
-#include <limits>
-#include <memory>
-#include <ostream>
-#include <sstream>
-#include <string>
+#if defined(GTEST_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <limits>
+    #include <memory>
+    #include <ostream>
+    #include <sstream>
+    #include <string>
+#endif
 
 #include "gtest/internal/gtest-port.h"
 

--- a/googletest/include/gtest/gtest-param-test.h
+++ b/googletest/include/gtest/gtest-param-test.h
@@ -174,9 +174,13 @@ TEST_P(DerivedTest, DoesBlah) {
 
 #endif  // 0
 
-#include <functional>
-#include <iterator>
-#include <utility>
+#if defined(GTEST_BUILD_USING_STD_MODULE)
+    import std;
+#else
+   #include <functional>
+   #include <iterator>
+   #include <utility>
+#endif
 
 #include "gtest/internal/gtest-internal.h"
 #include "gtest/internal/gtest-param-util.h"  // IWYU pragma: export

--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -104,20 +104,24 @@
 #ifndef GOOGLETEST_INCLUDE_GTEST_GTEST_PRINTERS_H_
 #define GOOGLETEST_INCLUDE_GTEST_GTEST_PRINTERS_H_
 
-#include <any>
-#include <functional>
-#include <memory>
-#include <optional>
-#include <ostream>  // NOLINT
-#include <sstream>
-#include <string>
-#include <string_view>
-#include <tuple>
-#include <type_traits>
-#include <typeinfo>
-#include <utility>
-#include <variant>
-#include <vector>
+#if defined(GTEST_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <any>
+    #include <functional>
+    #include <memory>
+    #include <optional>
+    #include <ostream>  // NOLINT
+    #include <sstream>
+    #include <string>
+    #include <string_view>
+    #include <tuple>
+    #include <type_traits>
+    #include <typeinfo>
+    #include <utility>
+    #include <variant>
+    #include <vector>
+#endif
 
 #ifdef GTEST_HAS_ABSL
 #include "absl/strings/has_absl_stringify.h"
@@ -127,11 +131,15 @@
 #include "gtest/internal/gtest-port.h"
 
 #if GTEST_INTERNAL_HAS_STD_SPAN
-#include <span>  // NOLINT
+#if !defined(GTEST_BUILD_USING_STD_MODULE)
+    #include <span>  // NOLINT
+#endif
 #endif           // GTEST_INTERNAL_HAS_STD_SPAN
 
 #if GTEST_INTERNAL_HAS_COMPARE_LIB
-#include <compare>  // NOLINT
+#if !defined(GTEST_BUILD_USING_STD_MODULE)
+    #include <compare>  // NOLINT
+#endif
 #endif              // GTEST_INTERNAL_HAS_COMPARE_LIB
 
 namespace testing {

--- a/googletest/include/gtest/gtest-spi.h
+++ b/googletest/include/gtest/gtest-spi.h
@@ -33,7 +33,11 @@
 #ifndef GOOGLETEST_INCLUDE_GTEST_GTEST_SPI_H_
 #define GOOGLETEST_INCLUDE_GTEST_GTEST_SPI_H_
 
-#include <string>
+#if defined(GTEST_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <string>
+#endif
 
 #include "gtest/gtest.h"
 

--- a/googletest/include/gtest/gtest-test-part.h
+++ b/googletest/include/gtest/gtest-test-part.h
@@ -34,10 +34,14 @@
 #ifndef GOOGLETEST_INCLUDE_GTEST_GTEST_TEST_PART_H_
 #define GOOGLETEST_INCLUDE_GTEST_GTEST_TEST_PART_H_
 
-#include <iosfwd>
-#include <ostream>
-#include <string>
-#include <vector>
+#if defined(GTEST_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <iosfwd>
+    #include <ostream>
+    #include <string>
+    #include <vector>
+#endif
 
 #include "gtest/internal/gtest-internal.h"
 #include "gtest/internal/gtest-string.h"

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -49,16 +49,20 @@
 #ifndef GOOGLETEST_INCLUDE_GTEST_GTEST_H_
 #define GOOGLETEST_INCLUDE_GTEST_GTEST_H_
 
-#include <cstddef>
-#include <cstdint>
-#include <limits>
-#include <memory>
-#include <ostream>
-#include <set>
-#include <sstream>
-#include <string>
-#include <type_traits>
-#include <vector>
+#if defined(GTEST_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <cstddef>
+    #include <cstdint>
+    #include <limits>
+    #include <memory>
+    #include <ostream>
+    #include <set>
+    #include <sstream>
+    #include <string>
+    #include <type_traits>
+    #include <vector>
+#endif
 
 #include "gtest/gtest-assertion-result.h"  // IWYU pragma: export
 #include "gtest/gtest-death-test.h"  // IWYU pragma: export

--- a/googletest/include/gtest/internal/gtest-death-test-internal.h
+++ b/googletest/include/gtest/internal/gtest-death-test-internal.h
@@ -41,8 +41,12 @@
 
 #include <stdio.h>
 
-#include <memory>
-#include <string>
+#if defined(GTEST_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <memory>
+    #include <string>
+#endif
 
 #include "gtest/gtest-matchers.h"
 #include "gtest/internal/gtest-internal.h"

--- a/googletest/include/gtest/internal/gtest-filepath.h
+++ b/googletest/include/gtest/internal/gtest-filepath.h
@@ -42,8 +42,12 @@
 #ifndef GOOGLETEST_INCLUDE_GTEST_INTERNAL_GTEST_FILEPATH_H_
 #define GOOGLETEST_INCLUDE_GTEST_INTERNAL_GTEST_FILEPATH_H_
 
-#include <string>
-#include <utility>
+#if defined(GTEST_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <string>
+    #include <utility>
+#endif
 
 #include "gtest/internal/gtest-port.h"
 #include "gtest/internal/gtest-string.h"

--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -48,23 +48,28 @@
 #include <unistd.h>
 #endif  // GTEST_OS_LINUX
 
-#if GTEST_HAS_EXCEPTIONS
-#include <stdexcept>
-#endif
-
 #include <ctype.h>
 #include <float.h>
 #include <string.h>
 
-#include <cstdint>
-#include <functional>
-#include <limits>
-#include <map>
-#include <set>
-#include <string>
-#include <type_traits>
-#include <utility>
-#include <vector>
+#if defined(GTEST_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #if GTEST_HAS_EXCEPTIONS
+    #include <stdexcept>
+    #endif
+
+    #include <cstdint>
+    #include <functional>
+    #include <limits>
+    #include <map>
+    #include <set>
+    #include <string>
+    #include <type_traits>
+    #include <utility>
+    #include <vector>
+#endif
+
 
 #include "gtest/gtest-message.h"
 #include "gtest/internal/gtest-filepath.h"

--- a/googletest/include/gtest/internal/gtest-param-util.h
+++ b/googletest/include/gtest/internal/gtest-param-util.h
@@ -36,21 +36,25 @@
 #ifndef GOOGLETEST_INCLUDE_GTEST_INTERNAL_GTEST_PARAM_UTIL_H_
 #define GOOGLETEST_INCLUDE_GTEST_INTERNAL_GTEST_PARAM_UTIL_H_
 
-#include <ctype.h>
-
-#include <cassert>
-#include <functional>
-#include <iterator>
-#include <map>
-#include <memory>
-#include <ostream>
-#include <set>
-#include <string>
-#include <tuple>
-#include <type_traits>
-#include <unordered_map>
-#include <utility>
-#include <vector>
+#if defined(GTEST_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <ctype.h>
+    
+    #include <cassert>
+    #include <functional>
+    #include <iterator>
+    #include <map>
+    #include <memory>
+    #include <ostream>
+    #include <set>
+    #include <string>
+    #include <tuple>
+    #include <type_traits>
+    #include <unordered_map>
+    #include <utility>
+    #include <vector>
+#endif
 
 #include "gtest/gtest-printers.h"
 #include "gtest/gtest-test-part.h"

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -247,6 +247,10 @@
 //   Int32FromGTestEnv()  - parses an int32_t environment variable.
 //   StringFromGTestEnv() - parses a string environment variable.
 
+#if defined(GTEST_BUILD_USING_STD_MODULE)
+    import std;
+#endif
+
 // The definition of GTEST_INTERNAL_CPLUSPLUS_LANG comes first because it can
 // potentially be used as an #include guard.
 #if defined(_MSVC_LANG)
@@ -285,20 +289,22 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <cerrno>
-// #include <condition_variable>  // Guarded by GTEST_IS_THREADSAFE below
-#include <cstdint>
-#include <iostream>
-#include <limits>
-#include <locale>
-#include <memory>
-#include <ostream>
-#include <string>
-// #include <mutex>  // Guarded by GTEST_IS_THREADSAFE below
-#include <tuple>
-#include <type_traits>
-#include <vector>
+    
+#if !defined(GTEST_BUILD_USING_STD_MODULE)
+    #include <cerrno>
+    // #include <condition_variable>  // Guarded by GTEST_IS_THREADSAFE below
+    #include <cstdint>
+    #include <iostream>
+    #include <limits>
+    #include <locale>
+    #include <memory>
+    #include <ostream>
+    #include <string>
+    // #include <mutex>  // Guarded by GTEST_IS_THREADSAFE below
+    #include <tuple>
+    #include <type_traits>
+    #include <vector>
+#endif
 
 #ifndef _WIN32_WCE
 #include <sys/stat.h>
@@ -575,8 +581,10 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 
 // It's this header's responsibility to #include <typeinfo> when RTTI
 // is enabled.
+#if !defined(GTEST_BUILD_USING_STD_MODULE)
 #if GTEST_HAS_RTTI
 #include <typeinfo>
+#endif
 #endif
 
 // Determines whether Google Test can use the pthreads library.
@@ -810,11 +818,13 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
 
 #endif  // GTEST_IS_THREADSAFE
 
+#if !defined(GTEST_BUILD_USING_STD_MODULE)
 #ifdef GTEST_IS_THREADSAFE
 // Some platforms don't support including these threading related headers.
 #include <condition_variable>  // NOLINT
 #include <mutex>               // NOLINT
 #endif                         // GTEST_IS_THREADSAFE
+#endif
 
 // GTEST_API_ qualifies all symbols that must be exported. The definitions below
 // are guarded by #ifndef to give embedders a chance to define GTEST_API_ in
@@ -2355,7 +2365,9 @@ using StringView = ::absl::string_view;
 // Otherwise for C++17 and higher use std::string_view for Matcher<>
 // specializations.
 #define GTEST_INTERNAL_HAS_STRING_VIEW 1
+#if !defined(GTEST_BUILD_USING_STD_MODULE)
 #include <string_view>
+#endif
 namespace testing {
 namespace internal {
 using StringView = ::std::string_view;

--- a/googletest/include/gtest/internal/gtest-string.h
+++ b/googletest/include/gtest/internal/gtest-string.h
@@ -50,9 +50,13 @@
 
 #include <string.h>
 
-#include <cstdint>
-#include <sstream>
-#include <string>
+#if defined(GTEST_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <cstdint>
+    #include <sstream>
+    #include <string>
+#endif
 
 #include "gtest/internal/gtest-port.h"
 

--- a/googletest/include/gtest/internal/gtest-type-util.h
+++ b/googletest/include/gtest/internal/gtest-type-util.h
@@ -37,9 +37,13 @@
 #ifndef GOOGLETEST_INCLUDE_GTEST_INTERNAL_GTEST_TYPE_UTIL_H_
 #define GOOGLETEST_INCLUDE_GTEST_INTERNAL_GTEST_TYPE_UTIL_H_
 
-#include <string>
-#include <type_traits>
-#include <typeinfo>
+#if defined(GTEST_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <string>
+    #include <type_traits>
+    #include <typeinfo>
+#endif
 
 #include "gtest/internal/gtest-port.h"
 

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -41,13 +41,17 @@
 #include <stdlib.h>  // For strtoll/_strtoul64/malloc/free.
 #include <string.h>  // For memmove.
 
-#include <algorithm>
-#include <cstdint>
-#include <memory>
-#include <set>
-#include <string>
-#include <unordered_map>
-#include <vector>
+#if defined(GTEST_BUILD_USING_STD_MODULE)
+    import std;
+#else
+    #include <algorithm>
+    #include <cstdint>
+    #include <memory>
+    #include <set>
+    #include <string>
+    #include <unordered_map>
+    #include <vector>
+#endif
 
 #include "gtest/internal/gtest-port.h"
 


### PR DESCRIPTION
fixes #4851 

This is the changes required to allow users to use 'import std;` in their code and still include GoogleTest headers