### PR TITLE
Add IsEmpty overload for C-style wide strings

### DIFF
--- a/googlemock/include/gmock/gmock-more-matchers.h
+++ b/googlemock/include/gmock/gmock-more-matchers.h
@@ -79,6 +79,11 @@ class IsEmptyMatcher {
     return MatchAndExplain(std::string(s), listener);
   }
 
+  // Matches C-style wide strings.
+  bool MatchAndExplain(const wchar_t* s, MatchResultListener* listener) const {
+    return MatchAndExplain(std::wstring(s), listener);
+  }
+
   // Describes what this matcher matches.
   void DescribeTo(std::ostream* os) const { *os << "is empty"; }
 

--- a/googlemock/test/gmock-matchers-comparisons_test.cc
+++ b/googlemock/test/gmock-matchers-comparisons_test.cc
@@ -1093,6 +1093,14 @@ TEST(IsEmptyTest, MatchesCString) {
   EXPECT_FALSE(m.Matches(b));
 }
 
+TEST(IsEmptyTest, MatchesCWideString) {
+  const Matcher<const wchar_t*> m = IsEmpty();
+  const wchar_t a[] = L"";
+  const wchar_t b[] = L"x";
+  EXPECT_TRUE(m.Matches(a));
+  EXPECT_FALSE(m.Matches(b));
+}
+
 // Tests that IsNull() matches any NULL pointer of any type.
 TEST(IsNullTest, MatchesNullPointer) {
   Matcher<int*> m1 = IsNull();


### PR DESCRIPTION
fixes #4857 

This change allow users to use `testing::IsEmpty` matcher to match if a C-style wide string is an empty string.