### PR TITLE
Add common clang warnings to `cxx_base_flags` and fix existing warnings

### DIFF
--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -5777,7 +5777,7 @@ PolymorphicMatcher<internal::ExceptionMatcherImpl<Err>> ThrowsMessage(
   }                                                                           \
   template <typename arg_type>                                                \
   bool name##Matcher::gmock_Impl<arg_type>::MatchAndExplain(                  \
-      const arg_type& arg,                                                    \
+      [[maybe_unused]] const arg_type& arg,                                                    \
       [[maybe_unused]] ::testing::MatchResultListener* result_listener) const
 
 #define MATCHER_P(name, p0, description) \
@@ -5862,7 +5862,7 @@ PolymorphicMatcher<internal::ExceptionMatcherImpl<Err>> ThrowsMessage(
   template <typename arg_type>                                                 \
   bool full_name<GMOCK_INTERNAL_MATCHER_TYPE_PARAMS(args)>::                   \
       gmock_Impl<arg_type>::MatchAndExplain(                                   \
-          const arg_type& arg,                                                 \
+          [[maybe_unused]] const arg_type& arg,                                                 \
           [[maybe_unused]] ::testing::MatchResultListener* result_listener)    \
           const
 

--- a/googlemock/src/gmock-matchers.cc
+++ b/googlemock/src/gmock-matchers.cc
@@ -301,6 +301,8 @@ void UnorderedElementsAreMatcherImplBase::DescribeToImpl(
     case UnorderedMatcherRequire::Subset:
       *os << "an injection from elements to requirements exists such that:\n";
       break;
+    default:
+      break;
   }
 
   const char* sep = "";
@@ -342,6 +344,8 @@ void UnorderedElementsAreMatcherImplBase::DescribeNegationToImpl(
       break;
     case UnorderedMatcherRequire::Subset:
       *os << "no injection from elements to requirements exists such that:\n";
+      break;
+    default:
       break;
   }
   const char* sep = "";

--- a/googlemock/src/gmock-spec-builders.cc
+++ b/googlemock/src/gmock-spec-builders.cc
@@ -301,6 +301,7 @@ void ReportUninterestingCall(CallReaction reaction, const std::string& msg) {
               "knowing-when-to-expect-useoncall for details.\n",
           stack_frames_to_skip);
       break;
+    case kFail:
     default:  // FAIL
       Expect(false, nullptr, -1, msg);
   }

--- a/googlemock/test/gmock-function-mocker_test.cc
+++ b/googlemock/test/gmock-function-mocker_test.cc
@@ -73,7 +73,7 @@ class TemplatedCopyable {
   TemplatedCopyable() = default;
 
   template <typename U>
-  TemplatedCopyable(const U& other) {}  // NOLINT
+  TemplatedCopyable(const U&) {}  // NOLINT
 };
 
 class FooInterface {

--- a/googlemock/test/gmock-matchers-containers_test.cc
+++ b/googlemock/test/gmock-matchers-containers_test.cc
@@ -2829,6 +2829,8 @@ class PredicateFormatterFromMatcherTest : public ::testing::Test {
           // an "interested" listener; so this will return |true|, thus
           // simulating a flaky matcher.
           return listener->IsInterested();
+        default:
+          break;
       }
 
       GTEST_LOG_(FATAL) << "This should never be reached";

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -91,7 +91,17 @@ macro(config_compiler_and_linker)
     endif()
   elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
       CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
-    set(cxx_base_flags "-Wall -Wshadow -Wconversion -Wundef")
+    set(cxx_base_flags "-Wall \
+                        -Wshadow \
+                        -Wconversion \
+                        -Wundef \
+                        -Wswitch-default \
+                        -Wswitch-enum \
+                        -Wextra \
+                        -Wcast-align \
+                        -Wunused \
+                        -Wunreachable-code \
+    ")
     set(cxx_exception_flags "-fexceptions")
     set(cxx_no_exception_flags "-fno-exceptions")
     set(cxx_strict_flags "-W -Wpointer-arith -Wreturn-type -Wcast-qual -Wwrite-strings -Wswitch -Wunused-parameter -Wcast-align -Winline -Wredundant-decls")

--- a/googletest/include/gtest/internal/gtest-death-test-internal.h
+++ b/googletest/include/gtest/internal/gtest-death-test-internal.h
@@ -243,6 +243,8 @@ GTEST_API_ bool ExitedUnsuccessfully(int exit_status);
           gtest_dt->Abort(::testing::internal::DeathTest::TEST_DID_NOT_DIE);   \
           break;                                                               \
         }                                                                      \
+        default:                                                               \
+          break;                                                               \
       }                                                                        \
     }                                                                          \
   } else                                                                       \

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -1471,6 +1471,8 @@ class Hunk {
         ++adds_;
         hunk_adds_.push_back(std::make_pair('+', line));
         break;
+      default:
+        break;
     }
   }
 
@@ -3281,6 +3283,7 @@ static const char* GetAnsiColorCode(GTestColor color) {
       return "2";
     case GTestColor::kYellow:
       return "3";
+    case GTestColor::kDefault:
     default:
       assert(false);
       return "9";
@@ -3537,6 +3540,9 @@ void PrettyUnitTestResultPrinter::OnTestPartResult(
     // If the test part succeeded, we don't need to do anything.
     case TestPartResult::kSuccess:
       return;
+    case TestPartResult::kNonFatalFailure:
+    case TestPartResult::kFatalFailure:
+    case TestPartResult::kSkip:
     default:
       // Print failure message from the assertion
       // (e.g. expected this and got that).
@@ -3755,6 +3761,9 @@ void BriefUnitTestResultPrinter::OnTestPartResult(
     // If the test part succeeded, we don't need to do anything.
     case TestPartResult::kSuccess:
       return;
+    case TestPartResult::kNonFatalFailure:
+    case TestPartResult::kFatalFailure:
+    case TestPartResult::kSkip:
     default:
       // Print failure message from the assertion
       // (e.g. expected this and got that).

--- a/googletest/test/googletest-death-test-test.cc
+++ b/googletest/test/googletest-death-test-test.cc
@@ -346,7 +346,7 @@ TEST_F(TestForDeathTest, SwitchStatement) {
     ASSERT_DEATH(_Exit(1), "") << "exit in default switch handler";
 
   switch (0)
-  case 0:
+  default:
     EXPECT_DEATH(_Exit(1), "") << "exit in switch case";
 
   GTEST_DISABLE_MSC_WARNINGS_POP_()
@@ -1499,7 +1499,7 @@ TEST(ConditionalDeathMacrosSyntaxDeathTest, SwitchStatement) {
     ASSERT_DEATH_IF_SUPPORTED(_Exit(1), "") << "exit in default switch handler";
 
   switch (0)
-  case 0:
+  default:
     EXPECT_DEATH_IF_SUPPORTED(_Exit(1), "") << "exit in switch case";
 
   GTEST_DISABLE_MSC_WARNINGS_POP_()

--- a/googletest/test/googletest-port-test.cc
+++ b/googletest/test/googletest-port-test.cc
@@ -239,7 +239,7 @@ TEST(GtestCheckSyntaxTest, WorksWithSwitch) {
   }
 
   switch (0)
-  case 0:
+  default:
     GTEST_CHECK_(true) << "Check failed in switch case";
 }
 

--- a/googletest/test/gtest_environment_test.cc
+++ b/googletest/test/gtest_environment_test.cc
@@ -63,6 +63,7 @@ class MyEnvironment : public testing::Environment {
       case FATAL_FAILURE:
         FAIL() << "Expected fatal failure in global set-up.";
         break;
+      case NO_FAILURE:
       default:
         break;
     }

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -4253,7 +4253,7 @@ TEST(AssertionSyntaxTest, WorksWithSwitch) {
   }
 
   switch (0)
-  case 0:
+  default:
     EXPECT_FALSE(false) << "EXPECT_FALSE failed in switch case";
 
   // Binary assertions are implemented using a different code path
@@ -4265,7 +4265,7 @@ TEST(AssertionSyntaxTest, WorksWithSwitch) {
   }
 
   switch (0)
-  case 0:
+  default:
     EXPECT_NE(1, 2);
 }
 


### PR DESCRIPTION
Fixes #3627.

This commit fixes several clang warnings and updates `cxx_base_flags` in cmake to always enable those flags, ensuring consistent warning coverage in the future.

Enabled additional warnings:
- `-Wswitch-default`
- `-Wswitch-enum`
- `-Wextra`
- `-Wcast-align`
- `-Wunused`
- `-Wunreachable-code`