### PR TITLE
CMake: Do not enable the C language (unnecessary)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(googletest-distribution)
+project(googletest-distribution CXX)
 set(GOOGLETEST_VERSION 1.16.0)
 
 if(NOT CYGWIN AND NOT MSYS AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL QNX)

--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -37,7 +37,7 @@ endif()
 # ${gmock_BINARY_DIR}.
 # Language "C" is required for find_package(Threads).
 cmake_minimum_required(VERSION 3.13)
-project(gmock VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
+project(gmock VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX)
 
 if (COMMAND set_up_hermetic_build)
   set_up_hermetic_build()

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
 # Project version.
 
 cmake_minimum_required(VERSION 3.13)
-project(gtest VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
+project(gtest VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX)
 
 if (COMMAND set_up_hermetic_build)
   set_up_hermetic_build()


### PR DESCRIPTION
The project() command in the top-level CMakeLists.txt was not specifying languages which default to enabling C and CXX.
The googlemock and googletest project() commands were explicitly enabing both the C and CXX languages in their respective subdirectories, although all their source file are correctly identified as CXX and the C language is effectively never used.

Enabling the C language forces CXX-only projects downstream that embed this repo (via FetchContent or add subdirectory) to detect a C compiler at configuration-time.

This PR proposes to properly only enable the CXX language.