### PR TITLE
Modify README for shared library compilation flags

### DIFF
--- a/googletest/README.md
+++ b/googletest/README.md
@@ -177,7 +177,7 @@ as a DLL on Windows) if you prefer.
 To compile *gtest* as a shared library, add
 
 ```
--DGTEST_CREATE_SHARED_LIBRARY=1
+-DBUILD_SHARED_LIBS=1
 ```
 
 to the compiler flags. You'll also need to tell the linker to produce a shared


### PR DESCRIPTION
Update instructions for building gtest as a shared library

The previous flag `GTEST_CREATE_SHARED_LIBRARY` is not supported and triggers the following CMake warning:

  Manually-specified variables were not used by the project:
    GTEST_CREATE_SHARED_LIBRARY

Remove this obsolete flag and update the build instructions accordingly.