### PR TITLE
fix(docs): correct typos found during code review

### DIFF
--- a/ci/linux-presubmit.sh
+++ b/ci/linux-presubmit.sh
@@ -40,7 +40,7 @@ fi
 
 # Use Bazel Vendor mode to reduce reliance on external dependencies.
 # See https://bazel.build/external/vendor and the Dockerfile for
-# an explaination of how this works.
+# an explanation of how this works.
 if [[ ${KOKORO_GFILE_DIR:-} ]] && [[ -f "${KOKORO_GFILE_DIR}/distdir/googletest_vendor.tar.gz" ]]; then
   DOCKER_EXTRA_ARGS="--mount type=bind,source=${KOKORO_GFILE_DIR}/distdir,target=/distdir,readonly --env=BAZEL_VENDOR_ARCHIVE=/distdir/googletest_vendor.tar.gz ${DOCKER_EXTRA_ARGS:-}"
   BAZEL_EXTRA_ARGS="--vendor_dir=/googletest_vendor ${BAZEL_EXTRA_ARGS:-}"

--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -1187,7 +1187,7 @@ void UniversalTersePrint(const T& value, ::std::ostream* os) {
 // NUL-terminated string.
 template <typename T>
 void UniversalPrint(const T& value, ::std::ostream* os) {
-  // A workarond for the bug in VC++ 7.1 that prevents us from instantiating
+  // A workaround for the bug in VC++ 7.1 that prevents us from instantiating
   // UniversalPrinter with T directly.
   typedef T T1;
   UniversalPrinter<T1>::Print(value, os);

--- a/googletest/include/gtest/internal/gtest-param-util.h
+++ b/googletest/include/gtest/internal/gtest-param-util.h
@@ -760,7 +760,7 @@ class ParameterizedTestSuiteRegistry {
 };
 
 // Keep track of what type-parameterized test suite are defined and
-// where as well as which are intatiated. This allows susequently
+// where as well as which are intatiated. This allows subsequently
 // identifying suits that are defined but never used.
 class TypeParameterizedTestSuiteRegistry {
  public:

--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -712,7 +712,7 @@ bool RE::PartialMatch(const char* str, const RE& re) {
 void RE::Init(const char* regex) {
   pattern_ = regex;
 
-  // NetBSD (and Android, which takes its regex implemntation from NetBSD) does
+  // NetBSD (and Android, which takes its regex implementation from NetBSD) does
   // not include the GNU regex extensions (such as Perl style character classes
   // like \w) in REG_EXTENDED. REG_EXTENDED is only specified to include the
   // [[:alpha:]] style character classes. Enable REG_GNU wherever it is defined


### PR DESCRIPTION
Non-functional changes only:
- Fixed minor spelling mistakes in comments
- Corrected typos in user-facing strings
- No variables, logic, or functional code was modified.

Signed-off-by: Marcel Petrick <mail@marcelpetrick.it>