### PR TITLE
Remove C from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(googletest-distribution)
+project(googletest-distribution LANGUAGES CXX)
 set(GOOGLETEST_VERSION 1.16.0)
 
 if(NOT CYGWIN AND NOT MSYS AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL QNX)

--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -35,9 +35,9 @@ endif()
 # CMake files in this project can refer to the root source directory
 # as ${gmock_SOURCE_DIR} and to the root binary directory as
 # ${gmock_BINARY_DIR}.
-# Language "C" is required for find_package(Threads).
+
 cmake_minimum_required(VERSION 3.13)
-project(gmock VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
+project(gmock VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX)
 
 if (COMMAND set_up_hermetic_build)
   set_up_hermetic_build()

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -42,12 +42,11 @@ endif()
 # CMake files in this project can refer to the root source directory
 # as ${gtest_SOURCE_DIR} and to the root binary directory as
 # ${gtest_BINARY_DIR}.
-# Language "C" is required for find_package(Threads).
 
 # Project version.
 
 cmake_minimum_required(VERSION 3.13)
-project(gtest VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
+project(gtest VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX)
 
 if (COMMAND set_up_hermetic_build)
   set_up_hermetic_build()


### PR DESCRIPTION
There is no need to declare C as a needed language in cmake to build the project. Inspecting the compile_commands.json also indicates that everything is built with a C++ compiler. This PR removes the requirement to detect a valid C compiler on the build system. For projects that include googletest as a dependency, there are subtle reasons why we would not want to initialise a C compiler.

The comments indicate that C was only used for `find_package(Threads)` but I can see no reference to it in the code so this comment must no longer be relevant. This leads me to believe it should be safe to make GoogleTest a purely CXX project.