### PR TITLE
Replace __builtin_trap with __builtin_debugtrap (Fixes #4786)

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -5478,7 +5478,7 @@ void UnitTest::AddTestPartResult(TestPartResult::Type result_type,
       // with clang/gcc we can achieve the same effect on x86 by invoking int3
       asm("int3");
 #elif GTEST_HAS_BUILTIN(__builtin_trap)
-      __builtin_trap();
+      __builtin_debugtrap();
 #elif defined(SIGTRAP)
       raise(SIGTRAP);
 #else


### PR DESCRIPTION
Fixes #4786
