### PR TITLE
docs: add NaggyMock documentation to gmock cookbook

### DIFF
--- a/docs/gmock_cook_book.md
+++ b/docs/gmock_cook_book.md
@@ -457,6 +457,21 @@ TEST(...) {
   // is called.
 }
 ```
+The default behavior for mock objects in gMock is *naggy*. That is, if you use
+`MockFoo` directly (without wrapping it in `NiceMock` or `StrictMock`),
+uninteresting calls will be allowed but will generate warnings.
+
+You can also explicitly state this behavior using `NaggyMock`:
+
+```cpp
+using ::testing::NaggyMock;
+
+TEST(...) {
+  NaggyMock<MockFoo> mock_foo;
+  EXPECT_CALL(mock_foo, DoThis());
+  ... code that uses mock_foo ...
+}
+```
 
 {: .callout .note}
 NOTE: `NiceMock` and `StrictMock` only affects *uninteresting* calls (calls of


### PR DESCRIPTION
This PR adds documentation for `NaggyMock` to the “The Nice, the Strict, and the Naggy” section of the GoogleMock cookbook.
The behavior was previously undocumented in this section, which could be confusing for readers, despite being described elsewhere.
Fixes #4842