### PR TITLE
Launder dereferencing type-punned address

### DIFF
--- a/googletest/include/gtest/gtest-matchers.h
+++ b/googletest/include/gtest/gtest-matchers.h
@@ -42,6 +42,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <new>
 #include <ostream>
 #include <string>
 #include <type_traits>
@@ -402,11 +403,9 @@ class [[nodiscard]] MatcherBase : private MatcherDescriberInterface {
   template <typename M, bool = MatcherBase::IsInlined<M>()>
   struct ValuePolicy {
     static const M& Get(const MatcherBase& m) {
-      // When inlined along with Init, need to be explicit to avoid violating
+      // When inlined along with Init, need to be laundered to avoid violating
       // strict aliasing rules.
-      const M* ptr =
-          static_cast<const M*>(static_cast<const void*>(&m.buffer_));
-      return *ptr;
+      return *std::launder(reinterpret_cast<const M*>(&m.buffer_));
     }
     static void Init(MatcherBase& m, M impl) {
       ::new (static_cast<void*>(&m.buffer_)) M(impl);


### PR DESCRIPTION
This is a small patch to avoid strict aliasing issues manifested in GCC I came across a while ago.

The test case was complex and the failing assertion with a matcher was present only with `-O3`, so I don't have a standalone test. However, I manually confirmed adding `-fno-strict-aliasing` fixed the issue before this patch, and `-O3` behaved as intended after this patch without turning strict-aliasing off.

There is a similar previous change in https://github.com/google/googletest/commit/50ce52016139a4346a94df71249c14c5d286e000.

For the relevant clause from the C++17 standard, refer to below note from https://timsong-cpp.github.io/cppwp/n4659/basic.life#8:

> [ Note: If these conditions are not met, a pointer to the new object can be obtained from a pointer that represents the address of its storage by calling std::launder ([support.dynamic]).  — end note ]