### PR TITLE
Implement `std::ranges` view support in matchers

### DIFF
--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -2603,7 +2603,7 @@ class [[nodiscard]] WhenSortedByMatcher {
     // Transforms std::pair<const Key, Value> into std::pair<Key, Value>
     // so that we can match associative containers.
     typedef
-        typename RemoveConstFromKey<typename LhsStlContainer::value_type>::type
+        typename RemoveConstFromKey<internal::ValueType<LhsStlContainer>>::type
             LhsValue;
 
     Impl(const Comparator& comparator, const ContainerMatcher& matcher)
@@ -2670,7 +2670,7 @@ class [[nodiscard]] PointwiseMatcher {
  public:
   typedef internal::StlContainerView<RhsContainer> RhsView;
   typedef typename RhsView::type RhsStlContainer;
-  typedef typename RhsStlContainer::value_type RhsValue;
+  typedef internal::ValueType<RhsStlContainer> RhsValue;
 
   static_assert(!std::is_const<RhsContainer>::value,
                 "RhsContainer type must not be const");
@@ -2700,7 +2700,7 @@ class [[nodiscard]] PointwiseMatcher {
         LhsView;
     typedef typename LhsView::type LhsStlContainer;
     typedef typename LhsView::const_reference LhsStlContainerReference;
-    typedef typename LhsStlContainer::value_type LhsValue;
+    typedef internal::ValueType<LhsStlContainer> LhsValue;
     // We pass the LHS value and the RHS value to the inner matcher by
     // reference, as they may be expensive to copy.  We must use tuple
     // instead of pair here, as a pair cannot hold references (C++ 98,
@@ -2786,7 +2786,7 @@ class [[nodiscard]] QuantifierMatcherImpl : public MatcherInterface<Container> {
   typedef StlContainerView<RawContainer> View;
   typedef typename View::type StlContainer;
   typedef typename View::const_reference StlContainerReference;
-  typedef typename StlContainer::value_type Element;
+  typedef internal::ValueType<StlContainer> Element;
 
   template <typename InnerMatcher>
   explicit QuantifierMatcherImpl(InnerMatcher inner_matcher)
@@ -3600,7 +3600,7 @@ class [[nodiscard]] ElementsAreMatcherImpl
   typedef internal::StlContainerView<RawContainer> View;
   typedef typename View::type StlContainer;
   typedef typename View::const_reference StlContainerReference;
-  typedef typename StlContainer::value_type Element;
+  typedef internal::ValueType<StlContainer> Element;
 
   // Constructs the matcher from a sequence of element values or
   // element matchers.
@@ -3875,7 +3875,7 @@ class [[nodiscard]] UnorderedElementsAreMatcherImpl
   typedef internal::StlContainerView<RawContainer> View;
   typedef typename View::type StlContainer;
   typedef typename View::const_reference StlContainerReference;
-  typedef typename StlContainer::value_type Element;
+  typedef internal::ValueType<StlContainer> Element;
 
   template <typename InputIter>
   UnorderedElementsAreMatcherImpl(UnorderedMatcherRequire::Flags matcher_flags,
@@ -3964,7 +3964,7 @@ class [[nodiscard]] UnorderedElementsAreMatcher {
   operator Matcher<Container>() const {
     typedef GTEST_REMOVE_REFERENCE_AND_CONST_(Container) RawContainer;
     typedef typename internal::StlContainerView<RawContainer>::type View;
-    typedef typename View::value_type Element;
+    typedef internal::ValueType<View> Element;
     typedef ::std::vector<Matcher<const Element&>> MatcherVec;
     MatcherVec matchers;
     matchers.reserve(::std::tuple_size<MatcherTuple>::value);
@@ -3995,7 +3995,7 @@ class [[nodiscard]] ElementsAreMatcher {
 
     typedef GTEST_REMOVE_REFERENCE_AND_CONST_(Container) RawContainer;
     typedef typename internal::StlContainerView<RawContainer>::type View;
-    typedef typename View::value_type Element;
+    typedef internal::ValueType<View> Element;
     typedef ::std::vector<Matcher<const Element&>> MatcherVec;
     MatcherVec matchers;
     matchers.reserve(::std::tuple_size<MatcherTuple>::value);
@@ -4166,7 +4166,7 @@ class [[nodiscard]] OptionalMatcher {
   class Impl : public MatcherInterface<Optional> {
    public:
     typedef GTEST_REMOVE_REFERENCE_AND_CONST_(Optional) OptionalView;
-    typedef typename OptionalView::value_type ValueType;
+    typedef internal::ValueType<OptionalView> ValueType;
     explicit Impl(const ValueMatcher& value_matcher)
         : value_matcher_(MatcherCast<ValueType>(value_matcher)) {}
 
@@ -4493,7 +4493,7 @@ inline internal::UnorderedElementsAreArrayMatcher<T> UnorderedElementsAreArray(
 
 template <typename Container>
 inline internal::UnorderedElementsAreArrayMatcher<
-    typename Container::value_type>
+    internal::ValueType<Container>>
 UnorderedElementsAreArray(const Container& container) {
   return UnorderedElementsAreArray(container.begin(), container.end());
 }
@@ -5073,15 +5073,15 @@ template <typename Tuple2Matcher, typename RhsContainer>
 inline internal::UnorderedElementsAreArrayMatcher<
     typename internal::BoundSecondMatcher<
         Tuple2Matcher,
-        typename internal::StlContainerView<
-            typename std::remove_const<RhsContainer>::type>::type::value_type>>
+        internal::ValueType<typename internal::StlContainerView<
+            typename std::remove_const<RhsContainer>::type>::type>>>
 UnorderedPointwise(const Tuple2Matcher& tuple2_matcher,
                    const RhsContainer& rhs_container) {
   // RhsView allows the same code to handle RhsContainer being a
   // STL-style container and it being a native C-style array.
   typedef typename internal::StlContainerView<RhsContainer> RhsView;
   typedef typename RhsView::type RhsStlContainer;
-  typedef typename RhsStlContainer::value_type Second;
+  typedef internal::ValueType<RhsStlContainer> Second;
   const RhsStlContainer& rhs_stl_container =
       RhsView::ConstReference(rhs_container);
 
@@ -5191,7 +5191,7 @@ inline internal::UnorderedElementsAreArrayMatcher<T> IsSupersetOf(
 
 template <typename Container>
 inline internal::UnorderedElementsAreArrayMatcher<
-    typename Container::value_type>
+    internal::ValueType<Container>>
 IsSupersetOf(const Container& container) {
   return IsSupersetOf(container.begin(), container.end());
 }
@@ -5248,7 +5248,7 @@ inline internal::UnorderedElementsAreArrayMatcher<T> IsSubsetOf(
 
 template <typename Container>
 inline internal::UnorderedElementsAreArrayMatcher<
-    typename Container::value_type>
+    internal::ValueType<Container>>
 IsSubsetOf(const Container& container) {
   return IsSubsetOf(container.begin(), container.end());
 }
@@ -5496,13 +5496,13 @@ inline internal::AllOfArrayMatcher<T> AllOfArray(const T (&array)[N]) {
 }
 
 template <typename Container>
-inline internal::AnyOfArrayMatcher<typename Container::value_type> AnyOfArray(
+inline internal::AnyOfArrayMatcher<internal::ValueType<Container>> AnyOfArray(
     const Container& container) {
   return AnyOfArray(container.begin(), container.end());
 }
 
 template <typename Container>
-inline internal::AllOfArrayMatcher<typename Container::value_type> AllOfArray(
+inline internal::AllOfArrayMatcher<internal::ValueType<Container>> AllOfArray(
     const Container& container) {
   return AllOfArray(container.begin(), container.end());
 }

--- a/googlemock/include/gmock/internal/gmock-internal-utils.h
+++ b/googlemock/include/gmock/internal/gmock-internal-utils.h
@@ -47,8 +47,13 @@
 #include <utility>
 #include <vector>
 
+
 #include "gmock/internal/gmock-port.h"
 #include "gtest/gtest.h"
+
+#if GTEST_INTERNAL_HAS_STD_RANGES
+#include <ranges>
+#endif
 
 namespace testing {
 
@@ -357,6 +362,45 @@ class [[nodiscard]] StlContainerView {
   static type Copy(const RawContainer& container) { return container; }
 };
 
+#if GTEST_INTERNAL_HAS_STD_RANGES
+
+// This specialization is used when RawContainer models a C++20 range view.
+template <std::ranges::view View>
+class [[nodiscard]] StlContainerView<View> {
+ public:
+  using type = View;
+
+#if GTEST_INTERNAL_HAS_STD_RANGES_AS_CONST
+
+  // Use std::ranges::views::as_const from C++23 if that's available.
+  using const_reference = decltype(std::ranges::views::as_const(std::declval<View&>()));
+
+  static const_reference ConstReference(View view) {
+    return std::ranges::views::as_const(view);
+  }
+
+#else
+
+  // Implement const conversion behavior using transform.
+  struct AsConst {
+    const auto& operator()(std::ranges::range_reference_t<View> elm) const {
+      return std::as_const(elm);
+    }
+  };
+
+  using const_reference = std::ranges::transform_view<View, AsConst>;
+
+  static const_reference ConstReference(View view) {
+    return std::ranges::views::transform(view, AsConst());
+  }
+
+#endif
+
+  static type Copy(View view) { return view; }
+};
+
+#endif
+
 // This specialization is used when RawContainer is a native array type.
 template <typename Element, size_t N>
 class [[nodiscard]] StlContainerView<Element[N]> {
@@ -479,6 +523,40 @@ template <size_t I, typename T>
 using TupleElement = typename std::tuple_element<I, T>::type;
 
 bool Base64Unescape(const std::string& encoded, std::string* decoded);
+
+#if GTEST_INTERNAL_HAS_STD_RANGES
+
+// This is a helper to cause substitution failure in `ValueType<T>`, consistent
+// with the original behavior.
+struct ValueTypeIllFormed {};
+
+// Modern implementation: Try several strategies to deduce the value type.
+//
+// 1) If `T` has a nested `value_type`, use that.
+// 2) If `T` satisfies `std::ranges::range`, use `std::ranges::range_value_t<T>`.
+// 3) Ill-formed otherwise.
+template <typename T>
+using ValueType = typename decltype([] {
+  if constexpr (requires { typename T::value_type; }) {
+    return std::type_identity<typename T::value_type>{};
+  } else if constexpr (std::ranges::range<T>) {
+    return std::type_identity<std::ranges::range_value_t<T>>{};
+  } else {
+    // Other branches returning `std::type_identity<...>` allows checking
+    // `[...]::type` on the return value, which in turn allows us to fallback to
+    // ill-formedness neatly in this branch since `ValueTypeIllFormed`
+    // doesn't have a member `type`.
+    return ValueTypeIllFormed{};
+  }
+}())::type;
+
+#else
+
+// Legacy implementation: Assume T has a nested `value_type`. Ill-formed otherwise.
+template <typename T>
+using ValueType = typename T::value_type;
+
+#endif
 
 GTEST_DISABLE_MSC_WARNINGS_POP_()  // 4100 4805
 

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -200,6 +200,10 @@
 //                                        is suppressed.
 //   GTEST_INTERNAL_HAS_STD_SPAN - for enabling UniversalPrinter<std::span>
 //                                 specializations. Always defined to 0 or 1
+//   GTEST_INTERNAL_HAS_STD_RANGES - for enabling std::ranges view support in matchers.
+//                                   Always defined to 0 or 1
+//   GTEST_INTERNAL_HAS_STD_RANGES_AS_CONST - for relying on std::views::as_const
+//                                            support. Always defined to 0 or 1
 //   GTEST_USE_OWN_FLAGFILE_FLAG_ - Always defined to 0 or 1.
 //   GTEST_HAS_CXXABI_H_ - Always defined to 0 or 1.
 //   GTEST_CAN_STREAM_RESULTS_ - Always defined to 0 or 1.
@@ -2336,6 +2340,18 @@ const char* StringFromGTestEnv(const char* flag, const char* default_val);
 
 #ifndef GTEST_INTERNAL_HAS_STD_SPAN
 #define GTEST_INTERNAL_HAS_STD_SPAN 0
+#endif
+
+#if defined(__cpp_lib_ranges) && __cpp_lib_ranges >= 201911L
+#define GTEST_INTERNAL_HAS_STD_RANGES 1
+#else
+#define GTEST_INTERNAL_HAS_STD_RANGES 0
+#endif
+
+#if defined(__cpp_lib_ranges_as_const) && __cpp_lib_ranges_as_const >= 202207L
+#define GTEST_INTERNAL_HAS_STD_RANGES_AS_CONST 1
+#else
+#define GTEST_INTERNAL_HAS_STD_RANGES_AS_CONST 0
 #endif
 
 #ifdef GTEST_HAS_ABSL


### PR DESCRIPTION
- Add feature flags for `std::ranges` and `std::views::as_const` detection.
- Extend `StlContainerView` with a `std::ranges::view` specialization.
- Introduce `internal::ValueType` to deduce element/value type for both STL containers and ranges, while keeping backward-compatibility for the existing behavior.
- Update container matchers to use `internal::ValueType` instead of assuming nested `value_type`.
- Add coverage for common matchers against `std::ranges` views (e.g. `ElementsAre`, `ElementsAreArray`, `Contains`, `Pointwise`, `UnorderedPointwise`, `Pointee`).
- Resolves #3403.
- Resolves #4512.
- Resolves #4534.

Tested: On x86_64-pc-linux-gnu, with gcc 15.2.1 and clang 21.1.6, with libstdc++ for both, with build types Debug and Release, with C++ standards 17, 20 and 23.

Ad-hoc test script is given below.

```bash
#!/bin/bash

set -o errexit
set -o nounset
set -o pipefail

function check() {
  local cc="$1"
  local cxx="$2"
  local build_type="$3"
  local std="$4"
  local build_dir="build_${cc}_${build_type}_${std}"
  echo -e "\033[1m"
  echo "=== Building with $cc/$cxx, type=$build_type, std=$std ==="
  echo -e "\033[0m"
  rm -rf "$build_dir"
  mkdir -p "$build_dir"
  CC="$cc" CXX="$cxx" \
    cmake \
      -S . \
      -B "$build_dir" \
      -G "Ninja" \
      -Dgtest_build_tests=ON \
      -Dgmock_build_tests=ON \
      -DCMAKE_BUILD_TYPE="$build_type" \
      -DCMAKE_CXX_STANDARD="$std" \
      -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
  cmake --build "$build_dir" -- -j$(nproc)
  cmake --build "$build_dir" --target test
}

check "gcc" "g++" "Debug" "17"
check "gcc" "g++" "Release" "17"
check "gcc" "g++" "Debug" "20"
check "gcc" "g++" "Release" "20"
check "gcc" "g++" "Debug" "23"
check "gcc" "g++" "Release" "23"

check "clang" "clang++" "Debug" "17"
check "clang" "clang++" "Release" "17"
check "clang" "clang++" "Debug" "20"
check "clang" "clang++" "Release" "20"
check "clang" "clang++" "Debug" "23"
check "clang" "clang++" "Release" "23"
```