### PR TITLE
Resolve warning about undefined TARGET_OS_IPHONE

### DIFF
--- a/googletest/include/gtest/internal/gtest-port-arch.h
+++ b/googletest/include/gtest/internal/gtest-port-arch.h
@@ -71,7 +71,7 @@
 #elif defined __APPLE__
 #define GTEST_OS_MAC 1
 #include <TargetConditionals.h>
-#if TARGET_OS_IPHONE
+#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
 #define GTEST_OS_IOS 1
 #endif
 #elif defined __DragonFly__


### PR DESCRIPTION
Check that `TARGET_OS_IPHONE` is defined before checking its value to determine iOS support. This causes a warning about undefined macros when building against old Mac OS X SDKs.