### PR TITLE
gtest.cc: declare fail_if_no_test_linked flag

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -263,6 +263,7 @@ GTEST_DEFINE_bool_(
                                         testing::GetDefaultFailFast()),
     "True if and only if a test failure should stop further test execution.");
 
+GTEST_DECLARE_bool_(fail_if_no_test_linked);
 GTEST_DEFINE_bool_(
     fail_if_no_test_linked,
     testing::internal::BoolFromGTestEnv("fail_if_no_test_linked", false),


### PR DESCRIPTION
Clang's `-Wmissing-variable-declarations` flag flags this as an issue since the flag is only used in `gtest.cc`. Declare the flag beforehand in `gtest.cc` to tell the compiler that the variable scope is limited to `gtest.cc`.

Closes: #4897 