### PR TITLE
Update main branch version to 1.17.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(googletest-distribution)
-set(GOOGLETEST_VERSION 1.16.0)
+set(GOOGLETEST_VERSION 1.17.0)
 
 if(NOT CYGWIN AND NOT MSYS AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL QNX)
   set(CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
The main branch currently reports GoogleTest version 1.16.0 during CMake configuration. This PR updates the version metadata so that main reflects the next development version. This change is limited to version information only and does not affect APIs or test behavior.
Fixes #4844.