### PR TITLE
Let `PrintValue(container, os)` support GTEST_MAX_NUM_ELEMENTS_TO_PRINT

### DIFF
--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -170,7 +170,14 @@ struct ContainerPrinter {
                  !IsRecursiveContainer<T>::value) ||
                 IsStdSpan<T>::value>::type>
   static void PrintValue(const T& container, std::ostream* os) {
-    const size_t kMaxCount = 32;  // The maximum number of elements to print.
+
+// The maximum number of elements to print.
+#ifdef GTEST_MAX_NUM_ELEMENTS_TO_PRINT
+    const size_t kMaxCount = GTEST_MAX_NUM_ELEMENTS_TO_PRINT;
+#else
+    const size_t kMaxCount = 32;
+#endif
+
     *os << '{';
     size_t count = 0;
     for (auto&& elem : container) {


### PR DESCRIPTION
- Allowed the user to specify the maximum number of elements to print, as request by FR issue #4905.