### PR TITLE
Fix null pointer crash in ScopedPrematureExitFile when file creation fails

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -5146,8 +5146,10 @@ class ScopedPrematureExitFile {
       // errors are ignored as there's nothing better we can do and we
       // don't want to fail the test because of this.
       FILE* pfile = posix::FOpen(premature_exit_filepath_.c_str(), "w");
-      fwrite("0", 1, 1, pfile);
-      fclose(pfile);
+      if (pfile != nullptr) {
+        fwrite("0", 1, 1, pfile);
+        fclose(pfile);
+      }
     }
   }
 


### PR DESCRIPTION
  ## Summary

  - Add null check before `fwrite` and `fclose` in
  `ScopedPrematureExitFile`
  - Prevents crash when `TEST_PREMATURE_EXIT_FILE` points to invalid
   path

  ## Related Issue

  Fixes #4909