### PR TITLE
Fix -Wdeprecated-declarations warning from clang

### DIFF
--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -52,7 +52,16 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#ifdef __clang__
+#pragma clang diagnostic push 
+// Disable the deprecated-declarations warning before the clang bug
+// (https://github.com/llvm/llvm-project/issues/76515) has been fixed
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
 #include <memory>
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #include <ostream>
 #include <set>
 #include <sstream>


### PR DESCRIPTION
Hi all,

This PR disable the `-Wdeprecated-declarations` compiler warning for clang explicitly. The issue detail shows in #4935 

Why not add "-Wno-deprecated-declarations" to makefile to disable the compiler waning? Because OpenJDK will include the whole gtest source and build the gtest with their makefile, disable the compiler warning in source will avoid these project do this disable work again.