### PR TITLE
Fix CMake 3.22 crash in find_package(Python3) when Python is absent

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -255,7 +255,12 @@ function(cxx_executable name dir libs)
 endfunction()
 
 if(gtest_build_tests)
-  find_package(Python3)
+  # Only the interpreter is needed for Python tests. Specifying the component
+  # explicitly avoids a crash in CMake <= 3.23's FindPython3 module when no
+  # Python installation is present (the module calls list(GET) on an empty
+  # list).  QUIET lets the build continue without Python tests instead of
+  # failing outright.
+  find_package(Python3 COMPONENTS Interpreter QUIET)
 endif()
 
 # cxx_test_with_flags(name cxx_flags libs srcs...)


### PR DESCRIPTION
Fixes #4847

On CMake <= 3.23, `find_package(Python3)` without explicit components can crash with `list GET given empty list` in CMake's internal `FindPython/Support.cmake` when no Python installation is present on the system (e.g. macOS without a system Python).

This changes the call to:
```cmake
find_package(Python3 COMPONENTS Interpreter QUIET)
```

- `COMPONENTS Interpreter`: only the interpreter is needed for the Python-based tests, and specifying it explicitly avoids the buggy code path in older FindPython3 modules.
- `QUIET`: allows the build to continue gracefully without Python tests when Python is not found, instead of erroring out.

The existing guard at line 285 (`if (NOT Python3_Interpreter_FOUND)`) already handles the case where Python is missing, so this change is fully backward-compatible.

Steps to reproduce (before fix):
1. Use CMake 3.22 on macOS without a system Python
2. Configure with `cmake -Dgtest_build_tests=ON <path-to-googletest>`
3. Observe: `CMake Error ... list GET given empty list`

After fix:
1. Same configuration succeeds; Python tests are silently skipped if Python is not found.

Tested: full build and all 63 tests pass on Ubuntu with CMake 3.28 / GCC 13 / Python 3.12.