### PR TITLE
docs: clarify meaning of 'test crashes' in primer

### DIFF
--- a/docs/primer.md
+++ b/docs/primer.md
@@ -83,8 +83,10 @@ that check whether a condition is true. An assertion's result can be *success*,
 *nonfatal failure*, or *fatal failure*. If a fatal failure occurs, it aborts the
 current function; otherwise the program continues normally.
 
-*Tests* use assertions to verify the tested code's behavior. If a test crashes
-or has a failed assertion, then it *fails*; otherwise it *succeeds*.
+*Tests* use assertions to verify the tested code's behavior. If a test terminates
+abnormally (for example due to an uncaught exception, segmentation fault, or
+other runtime error) or has a failed assertion, then it *fails*; otherwise it
+*succeeds*.
 
 A *test suite* contains one or many tests. You should group your tests into test
 suites that reflect the structure of the tested code. When multiple tests in a


### PR DESCRIPTION
Clarify the meaning of "test crashes" in the Primer documentation.

The previous wording stated:
"If a test crashes or has a failed assertion, then it fails."

This change replaces the ambiguous term "crashes" with
"terminates abnormally (for example due to an uncaught exception,
segmentation fault, or other runtime error)" to make the behavior
clearer to readers.

Fixes #4790