### PR TITLE
[Bug #4953] Enable GTEST_HAS_ABSL by default when using bzlmod

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -77,6 +77,12 @@ config_setting(
     values = {"define": "absl=1"},
 )
 
+config_setting(
+    name = "bzlmod_enabled",
+    flag_values = {"//command_line_option:enable_bzlmod": "true"},
+)
+
+
 # Library that defines the FRIEND_TEST macro.
 cc_library(
     name = "gtest_prod",
@@ -115,8 +121,9 @@ cc_library(
         ":windows": [],
         "//conditions:default": ["-pthread"],
     }),
-    defines = select({
+defines = select({
         ":has_absl": ["GTEST_HAS_ABSL=1"],
+        ":bzlmod_enabled": ["GTEST_HAS_ABSL=1"],
         "//conditions:default": [],
     }),
     features = select({
@@ -142,8 +149,20 @@ cc_library(
         ],
         "//conditions:default": ["-pthread"],
     }),
-    deps = select({
+deps = select({
         ":has_absl": [
+            "@abseil-cpp//absl/container:flat_hash_set",
+            "@abseil-cpp//absl/debugging:failure_signal_handler",
+            "@abseil-cpp//absl/debugging:stacktrace",
+            "@abseil-cpp//absl/debugging:symbolize",
+            "@abseil-cpp//absl/flags:flag",
+            "@abseil-cpp//absl/flags:parse",
+            "@abseil-cpp//absl/flags:reflection",
+            "@abseil-cpp//absl/flags:usage",
+            "@abseil-cpp//absl/strings",
+            "@re2",
+        ],
+        ":bzlmod_enabled": [
             "@abseil-cpp//absl/container:flat_hash_set",
             "@abseil-cpp//absl/debugging:failure_signal_handler",
             "@abseil-cpp//absl/debugging:stacktrace",

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,10 @@
+# TODO: Fix has_absl default to true for bzlmod
+
+## Remaining Steps:
+1. [x] Edit BUILD.bazel: Add bzlmod_enabled config_setting and update gtest defines/deps selects.
+2. [x] Edit docs/quickstart-bazel.md: Add note about default Abseil support with bzlmod.
+3. [x] Test changes: bazel test //... --enable_bzlmod=true succeeded.
+4. attempt_completion.
+
+Progress will be updated as steps complete.
+

--- a/docs/quickstart-bazel.md
+++ b/docs/quickstart-bazel.md
@@ -51,6 +51,8 @@ with the following content:
 bazel_dep(name = "googletest", version = "1.17.0")
 ```
 
+**Note:** When using bzlmod/BCR, Abseil support (including AbslStringify for custom printers) is enabled by default since Abseil is an unconditional dependency.
+
 Now you're ready to build C++ code that uses GoogleTest.
 
 ## Create and run a binary


### PR DESCRIPTION
## Summary

Enable `GTEST_HAS_ABSL` by default when using bzlmod/BCR.

## Problem

When using bzlmod, `abseil-cpp` is an unconditional dependency, but `GTEST_HAS_ABSL` defaults to off.
This causes features like `AbslStringify` to fail, print incorrect values, or cause compilation errors.

## Solution

- Added a new `config_setting` named `bzlmod_enabled` triggered by `--enable_bzlmod=true`.
- Updated `//:gtest` `defines` and `deps` `select()` statements to enable `GTEST_HAS_ABSL=1` and link Abseil if either:
  - `--define absl=1` (`:has_absl`)
  - bzlmod is enabled (`:bzlmod_enabled`)
- Updated docs/quickstart-bazel.md to note that Abseil support is enabled by default with bzlmod/BCR.

## Backward Compatibility

- WORKSPACE users still need `--define absl=1` to enable Abseil support.
- Behavior for existing workflows remains unchanged.

## Testing

```bash
bazel test //... --enable_bzlmod=true