### PR TITLE
Don't set *_OUTPUT_DIRECTORY target properties

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -167,14 +167,6 @@ function(cxx_library_with_type name type cxx_flags)
   set_target_properties(${name}
     PROPERTIES
     COMPILE_FLAGS "${cxx_flags}")
-  # Set the output directory for build artifacts.
-  set_target_properties(${name}
-    PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-    COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
   # Make PDBs match library name.
   get_target_property(pdb_debug_postfix ${name} DEBUG_POSTFIX)
   set_target_properties(${name}


### PR DESCRIPTION
This PR removes a hunk of code from `cxx_library_with_type` responsible for setting various `*_OUTPUT_DIRECTORY` properties, instead falling back to either (a) the defaults or (b) user-provided `CMAKE_*_OUTPUT_DIRECTORY` variables.

The defaults match what was being set previously, and if a user is providing `CMAKE_*_OUTPUT_DIRECTORY` they expect it to be adhered to.

Closes #4957 