### PR TITLE
Fix: InitGoogleTest now consumes and removes the --help flag

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -6868,12 +6868,13 @@ void ParseGoogleTestFlagsOnlyImpl(int* argc, CharType** argv) {
       LoadFlagsFromFile(flagfile_value);
       remove_flag = true;
 #endif  // GTEST_USE_OWN_FLAGFILE_FLAG_ && GTEST_HAS_FILE_SYSTEM
-    } else if (arg_string == "--help" || HasGoogleTestFlagPrefix(arg)) {
+   } else if (arg_string == "--help" || HasGoogleTestFlagPrefix(arg)) {
       // Both help flag and unrecognized Google Test flags (excluding
       // internal ones) trigger help display.
       g_help_flag = true;
+      remove_flag = true; // Ensure --help flag is consumed and removed from argv
     }
-
+    
     if (remove_flag) {
       // Shift the remainder of the argv list left by one.
       for (int j = i + 1; j < *argc; ++j) {


### PR DESCRIPTION
### Description
Currently, when `--help` is passed to a GoogleTest binary, `InitGoogleTest` sets the internal help flag but does not remove the flag from `argv`. This prevents downstream argument parsers from knowing that the flag has already been handled.

### Changes
- Updated `ParseGoogleTestFlagsOnlyImpl` in `gtest.cc` to set `remove_flag = true` when `--help` or other unrecognized GTest flags are encountered.
- This ensures `argc` is decremented and the help flag is removed from the arguments list after initialization.

### Verification
Reproduced the issue with a manual test runner. 
- **Before fix:** `argc` remained 2 after `InitGoogleTest` when passing `--help`.
- **After fix:** `argc` correctly becomes 1.