### PR TITLE
[unittest] Use TempDir() in gtest death-test stream capture on Linux

### DIFF
--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -1146,7 +1146,7 @@ class CapturedStream {
     if (!EndsWithPathSeparator(name_template))
       name_template.push_back(GTEST_PATH_SEP_[0]);
 #else
-    name_template = "/tmp/";
+    name_template = TempDir();
 #endif
     name_template.append("gtest_captured_stream.XXXXXX");
 


### PR DESCRIPTION
gtest's CapturedStream on Linux hardcoded /tmp/ for its temp file
without consulting the environment, causing failures in sandboxed
environments where /tmp is read-only. Use TempDir() instead, which
checks TEST_TMPDIR then TMPDIR and falls back to /tmp/, matching the
behavior already present on Android and macOS/iOS.

Assisted-by: Claude Code