### PR TITLE
Add StringView ctor to Matcher<std::string> for lifetime-safe Property() / Field() use

### DIFF
--- a/googlemock/test/gmock-matchers-comparisons_test.cc
+++ b/googlemock/test/gmock-matchers-comparisons_test.cc
@@ -272,6 +272,40 @@ TEST(StringViewMatcherTest, CanBeImplicitlyConstructedFromStringView) {
   EXPECT_TRUE(m2.Matches("cats"));
   EXPECT_FALSE(m2.Matches("dogs"));
 }
+
+// Tests that a StringView object can be implicitly converted to a
+// Matcher<std::string> or Matcher<const std::string&>. This is the symmetric
+// counterpart of CanBeImplicitlyConstructedFromString above; without these
+// constructors, a StringView falls through to a polymorphic Eq matcher that
+// stores the view by value and dangles past the constructing call.
+TEST(StringMatcherTest, CanBeImplicitlyConstructedFromStringView) {
+  Matcher<std::string> m1 = internal::StringView("cats");
+  EXPECT_TRUE(m1.Matches("cats"));
+  EXPECT_FALSE(m1.Matches("dogs"));
+
+  Matcher<const std::string&> m2 = internal::StringView("cats");
+  EXPECT_TRUE(m2.Matches("cats"));
+  EXPECT_FALSE(m2.Matches("dogs"));
+}
+
+// Tests that the matcher copies the string data and is safe to use after the
+// underlying buffer the StringView was constructed from is destroyed.
+TEST(StringMatcherTest, StringViewCtorIsLifetimeSafe) {
+  Matcher<std::string> m1;
+  Matcher<const std::string&> m2;
+  {
+    std::string buffer = "cats";
+    m1 = internal::StringView(buffer);
+    m2 = internal::StringView(buffer);
+    // Mutate buffer and let it go out of scope to ensure the matcher does not
+    // alias |buffer|'s storage.
+    buffer = "dogs";
+  }
+  EXPECT_TRUE(m1.Matches("cats"));
+  EXPECT_FALSE(m1.Matches("dogs"));
+  EXPECT_TRUE(m2.Matches("cats"));
+  EXPECT_FALSE(m2.Matches("dogs"));
+}
 #endif  // GTEST_INTERNAL_HAS_STRING_VIEW
 
 // Tests that a std::reference_wrapper<std::string> object can be implicitly

--- a/googletest/include/gtest/gtest-matchers.h
+++ b/googletest/include/gtest/gtest-matchers.h
@@ -520,6 +520,13 @@ Matcher<const std::string&> : public internal::MatcherBase<const std::string&> {
 
   // Allows the user to write "foo" instead of Eq("foo") sometimes.
   Matcher(const char* s);  // NOLINT
+
+#if GTEST_INTERNAL_HAS_STRING_VIEW
+  // Allows the user to pass absl::string_views or std::string_views directly.
+  // Copies into a std::string so the matcher owns its data and does not alias
+  // a (possibly temporary) buffer in the caller.
+  Matcher(internal::StringView s);  // NOLINT
+#endif
 };
 
 template <>
@@ -544,6 +551,13 @@ Matcher<std::string> : public internal::MatcherBase<std::string> {
 
   // Allows the user to write "foo" instead of Eq("foo") sometimes.
   Matcher(const char* s);  // NOLINT
+
+#if GTEST_INTERNAL_HAS_STRING_VIEW
+  // Allows the user to pass absl::string_views or std::string_views directly.
+  // Copies into a std::string so the matcher owns its data and does not alias
+  // a (possibly temporary) buffer in the caller.
+  Matcher(internal::StringView s);  // NOLINT
+#endif
 };
 
 #if GTEST_INTERNAL_HAS_STRING_VIEW

--- a/googletest/src/gtest-matchers.cc
+++ b/googletest/src/gtest-matchers.cc
@@ -93,6 +93,18 @@ Matcher<internal::StringView>::Matcher(const char* s) {
 Matcher<internal::StringView>::Matcher(internal::StringView s) {
   *this = Eq(std::string(s));
 }
+
+// Constructs a matcher that matches a const std::string& whose value is
+// equal to s. Copies into a std::string so the matcher owns its data.
+Matcher<const std::string&>::Matcher(internal::StringView s) {
+  *this = Eq(std::string(s));
+}
+
+// Constructs a matcher that matches a std::string whose value is equal to s.
+// Copies into a std::string so the matcher owns its data.
+Matcher<std::string>::Matcher(internal::StringView s) {
+  *this = Eq(std::string(s));
+}
 #endif  // GTEST_INTERNAL_HAS_STRING_VIEW
 
 }  // namespace testing


### PR DESCRIPTION
## Summary

Adds `Matcher<std::string>::Matcher(StringView)` and `Matcher<const std::string&>::Matcher(StringView)`, mirroring the existing `Matcher<StringView>::Matcher(StringView)` implementation. The new constructors copy into a `std::string` via `Eq(std::string(s))` so the matcher owns its data.

## Motivation

Today, `Matcher<StringView>` has an explicit constructor that copies into a `std::string`:

```cpp
Matcher<internal::StringView>::Matcher(internal::StringView s) {
  *this = Eq(std::string(s));
}
```

…but the symmetric `Matcher<std::string>` / `Matcher<const std::string&>` do not. That asymmetric gap silently miscompiles when callers pass a `string_view` temporary into a matcher whose target type is `std::string` — most commonly via `Property` / `Field`:

```cpp
EXPECT_CALL(mock, Method(_, Property(&Proto::string_field,
                                     std::format("{},{}", subkey, topic))));
```

`Property` builds `Matcher<const std::string&>` from the value. With no `StringView` ctor available for that target, the `string_view` falls through to `MatcherCastImpl` and ends up wrapped by polymorphic `Eq(string_view)` → `EqMatcher<string_view>` stores the view by value. The matcher persists until the test fixture is destroyed; the `std::format` temporary it points to is destroyed at the end of the `EXPECT_CALL` statement. The matcher dangles.

Allocator reuse in optimized builds reliably exposes this: subsequent `std::format` calls in the same scope reuse the same heap slot, so multiple stored matchers all end up pointing into the same recycled buffer holding the last-written contents. We hit it in production code where six `EXPECT_CALL`s with `Property(&Proto::sub_key, std::format(...))` collapsed to all matching the same garbled string in `-c opt` (but passing in fastbuild).

## Change

- New `Matcher(StringView)` constructor on `Matcher<std::string>` and `Matcher<const std::string&>`, guarded by `GTEST_INTERNAL_HAS_STRING_VIEW`.
- Implementations in `gtest-matchers.cc` that delegate to `Eq(std::string(s))`, exactly mirroring the existing `Matcher<StringView>(StringView)` impl.

The change is purely additive — there is no new behavior for code that doesn't currently dangle, and the new path makes a previously-undefined-behavior case well-defined.

## Tests

- `StringMatcherTest.CanBeImplicitlyConstructedFromStringView` — symmetric counterpart of the existing `StringViewMatcherTest.CanBeImplicitlyConstructedFromString`.
- `StringMatcherTest.StringViewCtorIsLifetimeSafe` — regression test that constructs the matcher from a `StringView` of a `std::string` buffer, then mutates and destroys the buffer before invoking `Matches()`. Without this patch the matcher would hold a dangling view; with the patch it holds an owned copy.

Both pass under cmake locally (`gmock-matchers-comparisons_test`).

## Test plan
- [x] New tests pass
- [x] Existing `StringViewMatcherTest.*` and `StringMatcherTest.*` still pass
- [x] Full `gmock-matchers-comparisons_test` builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)