### PR TITLE
Default GTEST_HAS_ABSL=1 since abseil is an unconditional dep (fixes #4953)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -73,9 +73,22 @@ config_setting(
 )
 
 config_setting(
-    name = "has_absl",
-    values = {"define": "absl=1"},
+    name = "absl_disabled",
+    values = {"define": "absl=0"},
 )
+
+_ABSL_DEPS = [
+    "@abseil-cpp//absl/container:flat_hash_set",
+    "@abseil-cpp//absl/debugging:failure_signal_handler",
+    "@abseil-cpp//absl/debugging:stacktrace",
+    "@abseil-cpp//absl/debugging:symbolize",
+    "@abseil-cpp//absl/flags:flag",
+    "@abseil-cpp//absl/flags:parse",
+    "@abseil-cpp//absl/flags:reflection",
+    "@abseil-cpp//absl/flags:usage",
+    "@abseil-cpp//absl/strings",
+    "@re2",
+]
 
 # Library that defines the FRIEND_TEST macro.
 cc_library(
@@ -116,8 +129,8 @@ cc_library(
         "//conditions:default": ["-pthread"],
     }),
     defines = select({
-        ":has_absl": ["GTEST_HAS_ABSL=1"],
-        "//conditions:default": [],
+        ":absl_disabled": [],
+        "//conditions:default": ["GTEST_HAS_ABSL=1"],
     }),
     features = select({
         ":windows": ["windows_export_all_symbols"],
@@ -143,19 +156,8 @@ cc_library(
         "//conditions:default": ["-pthread"],
     }),
     deps = select({
-        ":has_absl": [
-            "@abseil-cpp//absl/container:flat_hash_set",
-            "@abseil-cpp//absl/debugging:failure_signal_handler",
-            "@abseil-cpp//absl/debugging:stacktrace",
-            "@abseil-cpp//absl/debugging:symbolize",
-            "@abseil-cpp//absl/flags:flag",
-            "@abseil-cpp//absl/flags:parse",
-            "@abseil-cpp//absl/flags:reflection",
-            "@abseil-cpp//absl/flags:usage",
-            "@abseil-cpp//absl/strings",
-            "@re2",
-        ],
-        "//conditions:default": [],
+        ":absl_disabled": [],
+        "//conditions:default": _ABSL_DEPS,
     }) + select({
         # `gtest-death-test.cc` has `EXPECT_DEATH` that spawns a process,
         # expects it to crash and inspects its logs with the given matcher,


### PR DESCRIPTION
## Summary

Fixes #4953.

`abseil-cpp` is loaded unconditionally both under bzlmod (via `bazel_dep` in `MODULE.bazel`) and under WORKSPACE (via `googletest_deps()` in `googletest_deps.bzl`), but `GTEST_HAS_ABSL` was only defined when the user passed `--define absl=1`. As a result, features gated on the macro — `AbslStringify` support in `gtest-message.h` / `gtest-printers.h`, abseil-based flag parsing, the failure-signal handler — silently stayed off even though the abseil dependency was already in the build graph.

This flips the default: abseil integration is enabled by default; users can opt out with `--define absl=0`.

## Changes (single file: `BUILD.bazel`)

- Replace `config_setting(name = "has_absl", values = {"define": "absl=1"})` with `config_setting(name = "absl_disabled", values = {"define": "absl=0"})`.
- Invert the two `select()` callsites so `GTEST_HAS_ABSL=1` and the abseil deps are the default branch and the empty list is selected only when `absl=0`.
- Extract the abseil deps list into a top-level `_ABSL_DEPS` variable.

## Backward compatibility

- `--define absl=1` continues to be accepted (silent no-op now, since absl is enabled by default).
- `--define absl=0` is a new explicit opt-out for users who don't want the abseil integration even though the dependency is loaded.
- No new `bazel_dep` is introduced. `MODULE.bazel` and `googletest_deps.bzl` are untouched.

## Validation

Tested locally on Windows / MSVC 14.44 with bazelisk + Bazel 9.1.0:

1. `bazelisk build //:gtest` → success, abseil headers in inputs of `gtest` compile actions.
2. Probe with `#error` if `GTEST_HAS_ABSL != 1`: compiles by default → macro is set as expected.
3. Probe with `#error` if `GTEST_HAS_ABSL == 1`: compiles only with `--define absl=0` → opt-out works.

(Probe targets were used during validation only and are not part of this diff.)