### PR TITLE
Add --gtest_list_tests_brief to omit GetParam/TypeParam annotations

### DIFF
--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -110,6 +110,10 @@ GTEST_DECLARE_bool_(install_failure_signal_handler);
 // are actually run if the flag is provided.
 GTEST_DECLARE_bool_(list_tests);
 
+// This flag suppresses the "# GetParam() = ..." and "# TypeParam = ..."
+// annotations when listing tests with --gtest_list_tests.
+GTEST_DECLARE_bool_(list_tests_brief);
+
 // This flag controls whether Google Test emits a detailed XML report to a file
 // in addition to its normal textual output.
 GTEST_DECLARE_string_(output);

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -322,6 +322,12 @@ GTEST_DEFINE_bool_(
 
 GTEST_DEFINE_bool_(list_tests, false, "List all tests without running them.");
 
+GTEST_DEFINE_bool_(
+    list_tests_brief,
+    testing::internal::BoolFromGTestEnv("list_tests_brief", false),
+    "True if --gtest_list_tests should omit the per-test "
+    "\"# GetParam() = ...\" and \"# TypeParam = ...\" annotations.");
+
 // The net priority order after flag processing is thus:
 //   --gtest_output command line flag
 //   GTEST_OUTPUT environment variable
@@ -6388,6 +6394,7 @@ static void PrintOnOneLine(const char* str, int max_length) {
 void UnitTestImpl::ListTestsMatchingFilter() {
   // Print at most this many characters for each type/value parameter.
   const int kMaxParamLength = 250;
+  const bool brief = GTEST_FLAG_GET(list_tests_brief);
 
   for (auto* test_suite : test_suites_) {
     bool printed_test_suite_name = false;
@@ -6398,7 +6405,7 @@ void UnitTestImpl::ListTestsMatchingFilter() {
         if (!printed_test_suite_name) {
           printed_test_suite_name = true;
           printf("%s.", test_suite->name());
-          if (test_suite->type_param() != nullptr) {
+          if (!brief && test_suite->type_param() != nullptr) {
             printf("  # %s = ", kTypeParamLabel);
             // We print the type parameter on a single line to make
             // the output easy to parse by a program.
@@ -6407,7 +6414,7 @@ void UnitTestImpl::ListTestsMatchingFilter() {
           printf("\n");
         }
         printf("  %s", test_info->name());
-        if (test_info->value_param() != nullptr) {
+        if (!brief && test_info->value_param() != nullptr) {
           printf("  # %s = ", kValueParamLabel);
           // We print the value parameter on a single line to make the
           // output easy to parse by a program.
@@ -6706,6 +6713,10 @@ static const char kColorEncodedHelpMessage[] =
     "      List the names of all tests instead of running them. The name of\n"
     "      TEST(Foo, Bar) is \"Foo.Bar\".\n"
     "  @G--" GTEST_FLAG_PREFIX_
+    "list_tests_brief@D\n"
+    "      When listing tests, omit the \"# GetParam() = ...\" and\n"
+    "      \"# TypeParam = ...\" annotations.\n"
+    "  @G--" GTEST_FLAG_PREFIX_
     "filter=@YPOSITIVE_PATTERNS"
     "[@G-@YNEGATIVE_PATTERNS]@D\n"
     "      Run only the tests whose name matches one of the positive patterns "
@@ -6813,6 +6824,7 @@ static bool ParseGoogleTestFlag(const char* const arg) {
   GTEST_INTERNAL_PARSE_FLAG(filter);
   GTEST_INTERNAL_PARSE_FLAG(internal_run_death_test);
   GTEST_INTERNAL_PARSE_FLAG(list_tests);
+  GTEST_INTERNAL_PARSE_FLAG(list_tests_brief);
   GTEST_INTERNAL_PARSE_FLAG(output);
   GTEST_INTERNAL_PARSE_FLAG(brief);
   GTEST_INTERNAL_PARSE_FLAG(print_time);

--- a/googletest/test/googletest-list-tests-unittest.py
+++ b/googletest/test/googletest-list-tests-unittest.py
@@ -97,6 +97,53 @@ MyInstantiation/ValueParamTest\.
 )
 
 # The expected output when running googletest-list-tests-unittest_ with
+# --gtest_list_tests and --gtest_list_tests_brief.  The "# TypeParam = ..."
+# and "# GetParam() = ..." annotations must be omitted.
+EXPECTED_OUTPUT_BRIEF_RE = re.compile(
+    r"""FooDeathTest\.
+  Test1
+Foo\.
+  Bar1
+  Bar2
+  DISABLED_Bar3
+Abc\.
+  Xyz
+  Def
+FooBar\.
+  Baz
+FooTest\.
+  Test1
+  DISABLED_Test2
+  Test3
+TypedTest/0\.
+  TestA
+  TestB
+TypedTest/1\.
+  TestA
+  TestB
+TypedTest/2\.
+  TestA
+  TestB
+My/TypeParamTest/0\.
+  TestA
+  TestB
+My/TypeParamTest/1\.
+  TestA
+  TestB
+My/TypeParamTest/2\.
+  TestA
+  TestB
+MyInstantiation/ValueParamTest\.
+  TestA/0
+  TestA/1
+  TestA/2
+  TestB/0
+  TestB/1
+  TestB/2
+"""
+)
+
+# The expected output when running googletest-list-tests-unittest_ with
 # --gtest_list_tests and --gtest_filter=Foo*.
 EXPECTED_OUTPUT_FILTER_FOO_RE = re.compile(
     r"""FooDeathTest\.
@@ -219,6 +266,19 @@ class GTestListTestsUnitTest(gtest_test_utils.TestCase):
         expected_output_re=EXPECTED_OUTPUT_FILTER_FOO_RE,
         other_flag='--gtest_filter=Foo*',
     )
+
+  def testListTestsBriefOmitsParamAnnotations(self):
+    """--gtest_list_tests_brief omits "# GetParam() =" and "# TypeParam ="."""
+
+    output = Run(['--gtest_list_tests', '--gtest_list_tests_brief'])
+    self.assertTrue(
+        EXPECTED_OUTPUT_BRIEF_RE.match(output),
+        'output of "--gtest_list_tests --gtest_list_tests_brief" is "%s",\n'
+        'which does not match regex "%s"'
+        % (output, EXPECTED_OUTPUT_BRIEF_RE.pattern),
+    )
+    self.assertNotIn('GetParam()', output)
+    self.assertNotIn('TypeParam =', output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Adds a new boolean flag `--gtest_list_tests_brief` (and matching `GTEST_LIST_TESTS_BRIEF` env var) that suppresses `# GetParam() = ...` and `# TypeParam = ...` annotations when listing tests via `--gtest_list_tests`.
- Default is `false`, so existing behavior is preserved.
- Motivation (from #4937): users who already provide a custom test-name generator as the 4th argument of `INSTANTIATE_TEST_SUITE_P` find the trailing annotation redundant; for large/binary parameter values it dominates the output and makes listings hard to read or pipe.

## Why a flag and not a `PrintTo` workaround
The reporter of #4937 already tried supplying a `PrintTo` that returns an empty string. googletest still emits the literal prefix `  # GetParam() = ` before calling into the printer, so the noise can only be suppressed at the listing layer.

## Test plan
- [x] Extended `googletest/test/googletest-list-tests-unittest.py` with `testListTestsBriefOmitsParamAnnotations`, asserting both regex match and absence of `GetParam()` / `TypeParam =` strings.
- [x] Full `ctest` suite: 45/45 tests pass on Windows / MinGW (gcc 13.2).
- [x] Manual verification: `--help` shows the new flag; flag works via both CLI and env var.

Fixes #4937