### PR TITLE
added find_package to CMake GoogleTest tutorial

### DIFF
--- a/docs/quickstart-cmake.md
+++ b/docs/quickstart-cmake.md
@@ -107,6 +107,9 @@ add_executable(
   hello_test
   hello_test.cc
 )
+
+find_package(GTest REQUIRED)
+
 target_link_libraries(
   hello_test
   GTest::gtest_main


### PR DESCRIPTION
Without adding this line, I got an error saying: CMake Error at CMakeLists.txt:23 (target_link_libraries):
  Target "hello_test" links to:

    GTest::gtest_main
      but the target was not found.  
      
     I got this after basically copy pasting the tutorial code aside from renaming the executable. After adding this line, I was able to build properly and get the test passing