### PR TITLE
fix: resolve -Wmissing-declarations warning

### DIFF
--- a/googlemock/src/gmock-spec-builders.cc
+++ b/googlemock/src/gmock-spec-builders.cc
@@ -442,13 +442,15 @@ bool UntypedFunctionMockerBase::VerifyAndClearExpectationsLocked()
 
   return expectations_met;
 }
-
-static CallReaction intToCallReaction(int mock_behavior) {
+namespace{ 
+ CallReaction intToCallReaction(int mock_behavior) {
   if (mock_behavior >= kAllow && mock_behavior <= kFail) {
     return static_cast<internal::CallReaction>(mock_behavior);
   }
   return kWarn;
 }
+
+} 
 
 }  // namespace internal
 


### PR DESCRIPTION
Wrapped `intToCallReaction` in an anonymous namespace to prevent it from leaking into the global scope. This resolves the missing declaration compiler warning.

Fixes #3909