### PR TITLE
docs: add periods to README feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,35 +44,35 @@ More information about building GoogleTest can be found at
 
 *   xUnit test framework: \
     Googletest is based on the [xUnit](https://en.wikipedia.org/wiki/XUnit)
-    testing framework, a popular architecture for unit testing
+    testing framework, a popular architecture for unit testing.
 *   Test discovery: \
     Googletest automatically discovers and runs your tests, eliminating the need
-    to manually register your tests
+    to manually register your tests.
 *   Rich set of assertions: \
     Googletest provides a variety of assertions, such as equality, inequality,
-    exceptions, and more, making it easy to test your code
+    exceptions, and more, making it easy to test your code.
 *   User-defined assertions: \
     You can define your own assertions with Googletest, making it simple to
-    write tests that are specific to your code
+    write tests that are specific to your code.
 *   Death tests: \
     Googletest supports death tests, which verify that your code exits in a
-    certain way, making it useful for testing error-handling code
+    certain way, making it useful for testing error-handling code.
 *   Fatal and non-fatal failures: \
     You can specify whether a test failure should be treated as fatal or
     non-fatal with Googletest, allowing tests to continue running even if a
-    failure occurs
+    failure occurs.
 *   Value-parameterized tests: \
     Googletest supports value-parameterized tests, which run multiple times with
     different input values, making it useful for testing functions that take
-    different inputs
+    different inputs.
 *   Type-parameterized tests: \
     Googletest also supports type-parameterized tests, which run with different
     data types, making it useful for testing functions that work with different
-    data types
+    data types.
 *   Various options for running tests: \
     Googletest provides many options for running tests including running
     individual tests, running tests in a specific order and running tests in
-    parallel
+    parallel.
 
 ## Supported Platforms
 


### PR DESCRIPTION
## Problem
The README Features section has sentence-style descriptions, but the entries listed in #4974 do not consistently end with periods.

## Root cause
The feature descriptions were written as sentence fragments without final punctuation, while the rest of the README uses sentence punctuation.

## Solution
Add periods to each feature description in the README Features section without changing the wording.

## Tests run
- `git diff --check`

Fixes #4974