### PR TITLE
Fix Python3 TypeError in DEBUG_GTEST_OUTPUT_TEST mode

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,6 +5,7 @@
 
 Ajay Joshi <jaj@google.com>
 Balázs Dán <balazs.dan@gmail.com>
+Benjamin Siliezar <bsiliezar2@gmail.com>
 Benoit Sigoure <tsuna@google.com>
 Bharat Mediratta <bharat@menalto.com>
 Bogdan Piloca <boo@google.com>

--- a/googletest/test/googletest-output-test.py
+++ b/googletest/test/googletest-output-test.py
@@ -350,14 +350,14 @@ class GTestOutputTest(gtest_test_utils.TestCase):
                 '_googletest-output-test_normalized_actual.txt',
             ),
             'wb',
-        ).write(normalized_actual)
+        ).write(normalized_actual.encode())
         open(
             os.path.join(
                 gtest_test_utils.GetSourceDir(),
                 '_googletest-output-test_normalized_golden.txt',
             ),
             'wb',
-        ).write(normalized_golden)
+        ).write(normalized_golden.encode())
 
       self.assertEqual(normalized_golden, normalized_actual)
 


### PR DESCRIPTION
Description
When DEBUG_GTEST_OUTPUT_TEST is set, the script attempted to write 'str' to a file opened in binary mode (wb), causing a TypeError.  Fixed by encoding the strings before writing with `.encode()`.

Fixes #3943 