### PR TITLE
Add flags to suppress individual startup notes

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -2110,6 +2110,15 @@ By default, GoogleTest prints the time it takes to run each test. To disable
 that, run the test program with the `--gtest_print_time=0` command line flag, or
 set the GTEST_PRINT_TIME environment variable to `0`.
 
+#### Suppressing Test Execution Notes
+
+By default, GoogleTest prints note lines for non-universal test filters,
+active test shards, and shuffle seeds. To disable these notes independently,
+use `--gtest_print_test_filter=0`, `--gtest_print_test_shard_status=0`, or
+`--gtest_print_test_shuffle_seed=0`, or set the corresponding
+`GTEST_PRINT_TEST_FILTER`, `GTEST_PRINT_TEST_SHARD_STATUS`, or
+`GTEST_PRINT_TEST_SHUFFLE_SEED` environment variable to `0`.
+
 #### Suppressing UTF-8 Text Output
 
 In case of assertion failures, GoogleTest prints expected and actual values of

--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -121,6 +121,15 @@ GTEST_DECLARE_bool_(brief);
 // test.
 GTEST_DECLARE_bool_(print_time);
 
+// This flag controls whether Google Test prints the test filter.
+GTEST_DECLARE_bool_(print_test_filter);
+
+// This flag controls whether Google Test prints the test shard status.
+GTEST_DECLARE_bool_(print_test_shard_status);
+
+// This flag controls whether Google Test prints the test shuffle seed.
+GTEST_DECLARE_bool_(print_test_shuffle_seed);
+
 // This flags control whether Google Test prints UTF8 characters as text.
 GTEST_DECLARE_bool_(print_utf8);
 

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -155,6 +155,9 @@ class GTestFlagSaver {
     output_ = GTEST_FLAG_GET(output);
     brief_ = GTEST_FLAG_GET(brief);
     print_time_ = GTEST_FLAG_GET(print_time);
+    print_test_filter_ = GTEST_FLAG_GET(print_test_filter);
+    print_test_shard_status_ = GTEST_FLAG_GET(print_test_shard_status);
+    print_test_shuffle_seed_ = GTEST_FLAG_GET(print_test_shuffle_seed);
     print_utf8_ = GTEST_FLAG_GET(print_utf8);
     random_seed_ = GTEST_FLAG_GET(random_seed);
     repeat_ = GTEST_FLAG_GET(repeat);
@@ -181,6 +184,9 @@ class GTestFlagSaver {
     GTEST_FLAG_SET(output, output_);
     GTEST_FLAG_SET(brief, brief_);
     GTEST_FLAG_SET(print_time, print_time_);
+    GTEST_FLAG_SET(print_test_filter, print_test_filter_);
+    GTEST_FLAG_SET(print_test_shard_status, print_test_shard_status_);
+    GTEST_FLAG_SET(print_test_shuffle_seed, print_test_shuffle_seed_);
     GTEST_FLAG_SET(print_utf8, print_utf8_);
     GTEST_FLAG_SET(random_seed, random_seed_);
     GTEST_FLAG_SET(repeat, repeat_);
@@ -207,6 +213,9 @@ class GTestFlagSaver {
   std::string output_;
   bool brief_;
   bool print_time_;
+  bool print_test_filter_;
+  bool print_test_shard_status_;
+  bool print_test_shuffle_seed_;
   bool print_utf8_;
   int32_t random_seed_;
   int32_t repeat_;

--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -1379,15 +1379,18 @@ bool ParseInt32(const Message& src_text, const char* str, int32_t* value) {
 // Reads and returns the Boolean environment variable corresponding to
 // the given flag; if it's not set, returns default_value.
 //
-// The value is considered true if and only if it's not "0".
+// The value is considered true if and only if it does not start with '0', 'f',
+// or 'F'.
 bool BoolFromGTestEnv(const char* flag, bool default_value) {
 #if defined(GTEST_GET_BOOL_FROM_ENV_)
   return GTEST_GET_BOOL_FROM_ENV_(flag, default_value);
 #else
   const std::string env_var = FlagToEnvVar(flag);
   const char* const string_value = posix::GetEnv(env_var.c_str());
-  return string_value == nullptr ? default_value
-                                 : strcmp(string_value, "0") != 0;
+  return string_value == nullptr
+             ? default_value
+             : !(*string_value == '0' || *string_value == 'f' ||
+                 *string_value == 'F');
 #endif  // defined(GTEST_GET_BOOL_FROM_ENV_)
 }
 

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -349,6 +349,24 @@ GTEST_DEFINE_bool_(print_time,
                    "True if and only if " GTEST_NAME_
                    " should display elapsed time in text output.");
 
+GTEST_DEFINE_bool_(print_test_filter,
+                   testing::internal::BoolFromGTestEnv("print_test_filter",
+                                                       true),
+                   "True if and only if " GTEST_NAME_
+                   " should display the test filter in text output.");
+
+GTEST_DEFINE_bool_(print_test_shard_status,
+                   testing::internal::BoolFromGTestEnv(
+                       "print_test_shard_status", true),
+                   "True if and only if " GTEST_NAME_
+                   " should display the test shard status in text output.");
+
+GTEST_DEFINE_bool_(print_test_shuffle_seed,
+                   testing::internal::BoolFromGTestEnv(
+                       "print_test_shuffle_seed", true),
+                   "True if and only if " GTEST_NAME_
+                   " should display the test shuffle seed in text output.");
+
 GTEST_DEFINE_bool_(print_utf8,
                    testing::internal::BoolFromGTestEnv("print_utf8", true),
                    "True if and only if " GTEST_NAME_
@@ -3482,19 +3500,20 @@ void PrettyUnitTestResultPrinter::OnTestIterationStart(
 
   // Prints the filter if it's not *.  This reminds the user that some
   // tests may be skipped.
-  if (!String::CStringEquals(filter, kUniversalFilter)) {
+  if (!String::CStringEquals(filter, kUniversalFilter) &&
+      GTEST_FLAG_GET(print_test_filter)) {
     ColoredPrintf(GTestColor::kYellow, "Note: %s filter = %s\n", GTEST_NAME_,
                   filter);
   }
 
-  if (internal::ShouldShard(false)) {
+  if (internal::ShouldShard(false) && GTEST_FLAG_GET(print_test_shard_status)) {
     const int32_t shard_index = GTEST_FLAG_GET(shard_index);
     ColoredPrintf(GTestColor::kYellow, "Note: This is test shard %d of %d.\n",
                   static_cast<int>(shard_index) + 1,
                   GTEST_FLAG_GET(total_shards));
   }
 
-  if (GTEST_FLAG_GET(shuffle)) {
+  if (GTEST_FLAG_GET(shuffle) && GTEST_FLAG_GET(print_test_shuffle_seed)) {
     ColoredPrintf(GTestColor::kYellow,
                   "Note: Randomizing tests' orders with a seed of %d .\n",
                   unit_test.random_seed());
@@ -6744,6 +6763,15 @@ static const char kColorEncodedHelpMessage[] =
     "print_time=0@D\n"
     "      Don't print the elapsed time of each test.\n"
     "  @G--" GTEST_FLAG_PREFIX_
+    "print_test_filter=0@D\n"
+    "      Don't print the test filter.\n"
+    "  @G--" GTEST_FLAG_PREFIX_
+    "print_test_shard_status=0@D\n"
+    "      Don't print the test shard status.\n"
+    "  @G--" GTEST_FLAG_PREFIX_
+    "print_test_shuffle_seed=0@D\n"
+    "      Don't print the test shuffle seed.\n"
+    "  @G--" GTEST_FLAG_PREFIX_
     "output=@Y(@Gjson@Y|@Gxml@Y)[@G:@YDIRECTORY_PATH@G" GTEST_PATH_SEP_
     "@Y|@G:@YFILE_PATH]@D\n"
     "      Generate a JSON or XML report in the given directory or with the "
@@ -6816,6 +6844,9 @@ static bool ParseGoogleTestFlag(const char* const arg) {
   GTEST_INTERNAL_PARSE_FLAG(output);
   GTEST_INTERNAL_PARSE_FLAG(brief);
   GTEST_INTERNAL_PARSE_FLAG(print_time);
+  GTEST_INTERNAL_PARSE_FLAG(print_test_filter);
+  GTEST_INTERNAL_PARSE_FLAG(print_test_shard_status);
+  GTEST_INTERNAL_PARSE_FLAG(print_test_shuffle_seed);
   GTEST_INTERNAL_PARSE_FLAG(print_utf8);
   GTEST_INTERNAL_PARSE_FLAG(random_seed);
   GTEST_INTERNAL_PARSE_FLAG(repeat);

--- a/googletest/test/googletest-env-var-test.py
+++ b/googletest/test/googletest-env-var-test.py
@@ -68,12 +68,15 @@ def GetFlag(flag):
   return gtest_test_utils.Subprocess(args, env=environ).output
 
 
-def TestFlag(flag, test_val, default_val):
+def TestFlag(flag, test_val, default_val, expected_val=None):
   """Verifies that the given flag is affected by the corresponding env var."""
+
+  if expected_val is None:
+    expected_val = test_val
 
   env_var = 'GTEST_' + flag.upper()
   SetEnvVar(env_var, test_val)
-  AssertEq(test_val, GetFlag(flag))
+  AssertEq(expected_val, GetFlag(flag))
   SetEnvVar(env_var, None)
   AssertEq(default_val, GetFlag(flag))
 
@@ -92,6 +95,9 @@ class GTestEnvVarTest(gtest_test_utils.TestCase):
     TestFlag('output', 'xml:tmp/foo.xml', '')
     TestFlag('brief', '1', '0')
     TestFlag('print_time', '0', '1')
+    TestFlag('print_test_filter', 'false', '1', '0')
+    TestFlag('print_test_shard_status', 'false', '1', '0')
+    TestFlag('print_test_shuffle_seed', 'false', '1', '0')
     TestFlag('repeat', '999', '1')
     TestFlag('throw_on_failure', '1', '0')
     TestFlag('death_test_style', 'threadsafe', 'fast')

--- a/googletest/test/googletest-env-var-test_.cc
+++ b/googletest/test/googletest-env-var-test_.cc
@@ -95,6 +95,21 @@ void PrintFlag(const char* flag) {
     return;
   }
 
+  if (strcmp(flag, "print_test_filter") == 0) {
+    cout << GTEST_FLAG_GET(print_test_filter);
+    return;
+  }
+
+  if (strcmp(flag, "print_test_shard_status") == 0) {
+    cout << GTEST_FLAG_GET(print_test_shard_status);
+    return;
+  }
+
+  if (strcmp(flag, "print_test_shuffle_seed") == 0) {
+    cout << GTEST_FLAG_GET(print_test_shuffle_seed);
+    return;
+  }
+
   if (strcmp(flag, "repeat") == 0) {
     cout << GTEST_FLAG_GET(repeat);
     return;

--- a/googletest/test/googletest-output-test.py
+++ b/googletest/test/googletest-output-test.py
@@ -89,6 +89,20 @@ COMMAND_WITH_SHARDING = (
         '--gtest_filter=PassingTest.*',
     ],
 )
+COMMAND_WITH_SHUFFLE = (
+    {},
+    [
+        PROGRAM_PATH,
+        'internal_skip_environment_and_ad_hoc_tests',
+        '--gtest_filter=PassingTest.*',
+        '--gtest_shuffle',
+        '--gtest_random_seed=1',
+    ],
+)
+
+FILTER_NOTE = 'Note: Google Test filter = PassingTest.*'
+SHARD_NOTE = 'Note: This is test shard 2 of 2.'
+SHUFFLE_SEED_NOTE = "Note: Randomizing tests' orders with a seed of 1 ."
 
 GOLDEN_PATH = os.path.join(gtest_test_utils.GetSourceDir(), GOLDEN_NAME)
 
@@ -360,6 +374,46 @@ class GTestOutputTest(gtest_test_utils.TestCase):
         ).write(normalized_golden)
 
       self.assertEqual(normalized_golden, normalized_actual)
+
+  def testDefaultStartupNotesArePrinted(self):
+    sharding_output = GetCommandOutput(COMMAND_WITH_SHARDING)
+    self.assertIn(FILTER_NOTE, sharding_output)
+    self.assertIn(SHARD_NOTE, sharding_output)
+
+    shuffle_output = GetCommandOutput(COMMAND_WITH_SHUFFLE)
+    self.assertIn(FILTER_NOTE, shuffle_output)
+    self.assertIn(SHUFFLE_SEED_NOTE, shuffle_output)
+
+  def testPrintTestFilterFalseSuppressesOnlyFilterNote(self):
+    env, cmdline = COMMAND_WITH_SHUFFLE
+    output = GetCommandOutput(
+        (env, cmdline + ['--gtest_print_test_filter=false'])
+    )
+
+    self.assertNotIn(FILTER_NOTE, output)
+    self.assertIn(SHUFFLE_SEED_NOTE, output)
+    self.assertIn('[==========] Running 2 tests from 1 test suite.', output)
+    self.assertIn('[ RUN      ] PassingTest.PassingTest', output)
+
+  def testPrintTestShardStatusFalseSuppressesOnlyShardNote(self):
+    env, cmdline = COMMAND_WITH_SHARDING
+    output = GetCommandOutput(
+        (env, cmdline + ['--gtest_print_test_shard_status=false'])
+    )
+
+    self.assertIn(FILTER_NOTE, output)
+    self.assertNotIn(SHARD_NOTE, output)
+    self.assertIn('[ RUN      ] PassingTest.PassingTest2', output)
+
+  def testPrintTestShuffleSeedFalseSuppressesOnlyShuffleSeedNote(self):
+    env, cmdline = COMMAND_WITH_SHUFFLE
+    output = GetCommandOutput(
+        (env, cmdline + ['--gtest_print_test_shuffle_seed=false'])
+    )
+
+    self.assertIn(FILTER_NOTE, output)
+    self.assertNotIn(SHUFFLE_SEED_NOTE, output)
+    self.assertIn('[ RUN      ] PassingTest.PassingTest', output)
 
 
 if __name__ == '__main__':

--- a/googletest/test/googletest-shuffle-test.py
+++ b/googletest/test/googletest-shuffle-test.py
@@ -73,6 +73,10 @@ def RandomSeedFlag(n):
   return '--gtest_random_seed=%s' % (n,)
 
 
+def PrintTestShuffleSeedFlag(value):
+  return '--gtest_print_test_shuffle_seed=%s' % (value,)
+
+
 def RunAndReturnOutput(extra_env, args):
   """Runs the test program and returns its output."""
 
@@ -350,6 +354,17 @@ class GTestShuffleUnitTest(gtest_test_utils.TestCase):
     self.assertTrue(
         tests_in_iteration2 != tests_in_iteration3, tests_in_iteration2
     )
+
+  def testSuppressingShuffleSeedNoteDoesNotDisableShuffle(self):
+    shuffled_tests = GetTestsForAllIterations(
+        {}, [ShuffleFlag(), RandomSeedFlag(1)]
+    )[0]
+    shuffled_tests_without_note = GetTestsForAllIterations(
+        {}, [ShuffleFlag(), RandomSeedFlag(1), PrintTestShuffleSeedFlag('0')]
+    )[0]
+
+    self.assertEqual(shuffled_tests, shuffled_tests_without_note)
+    self.assertNotEqual(ACTIVE_TESTS, shuffled_tests_without_note)
 
   def testShuffleShardedTestsPreservesPartition(self):
     # If we run M tests on N shards, the same M tests should be run in

--- a/googletest/test/gtest_help_test.py
+++ b/googletest/test/gtest_help_test.py
@@ -96,6 +96,12 @@ HELP_REGEX = re.compile(
     + FLAG_PREFIX
     + r'print_time.*'
     + FLAG_PREFIX
+    + r'print_test_filter.*'
+    + FLAG_PREFIX
+    + r'print_test_shard_status.*'
+    + FLAG_PREFIX
+    + r'print_test_shuffle_seed.*'
+    + FLAG_PREFIX
     + r'output=.*'
     + FLAG_PREFIX
     + r'break_on_failure.*'

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -43,7 +43,9 @@ TEST(CommandLineFlagsTest, CanBeAccessedInCodeOnceGTestHIsIncluded) {
       GTEST_FLAG_GET(color) != "unknown" || GTEST_FLAG_GET(fail_fast) ||
       GTEST_FLAG_GET(filter) != "unknown" || GTEST_FLAG_GET(list_tests) ||
       GTEST_FLAG_GET(output) != "unknown" || GTEST_FLAG_GET(brief) ||
-      GTEST_FLAG_GET(print_time) || GTEST_FLAG_GET(random_seed) ||
+      GTEST_FLAG_GET(print_time) || GTEST_FLAG_GET(print_test_filter) ||
+      GTEST_FLAG_GET(print_test_shard_status) ||
+      GTEST_FLAG_GET(print_test_shuffle_seed) || GTEST_FLAG_GET(random_seed) ||
       GTEST_FLAG_GET(repeat) > 0 ||
       GTEST_FLAG_GET(recreate_environments_when_repeating) ||
       GTEST_FLAG_GET(show_internal_stack_frames) || GTEST_FLAG_GET(shuffle) ||
@@ -1613,6 +1615,9 @@ class GTestFlagSaverTest : public Test {
     GTEST_FLAG_SET(output, "");
     GTEST_FLAG_SET(brief, false);
     GTEST_FLAG_SET(print_time, true);
+    GTEST_FLAG_SET(print_test_filter, true);
+    GTEST_FLAG_SET(print_test_shard_status, true);
+    GTEST_FLAG_SET(print_test_shuffle_seed, true);
     GTEST_FLAG_SET(random_seed, 0);
     GTEST_FLAG_SET(repeat, 1);
     GTEST_FLAG_SET(recreate_environments_when_repeating, true);
@@ -1643,6 +1648,9 @@ class GTestFlagSaverTest : public Test {
     EXPECT_STREQ("", GTEST_FLAG_GET(output).c_str());
     EXPECT_FALSE(GTEST_FLAG_GET(brief));
     EXPECT_TRUE(GTEST_FLAG_GET(print_time));
+    EXPECT_TRUE(GTEST_FLAG_GET(print_test_filter));
+    EXPECT_TRUE(GTEST_FLAG_GET(print_test_shard_status));
+    EXPECT_TRUE(GTEST_FLAG_GET(print_test_shuffle_seed));
     EXPECT_EQ(0, GTEST_FLAG_GET(random_seed));
     EXPECT_EQ(1, GTEST_FLAG_GET(repeat));
     EXPECT_TRUE(GTEST_FLAG_GET(recreate_environments_when_repeating));
@@ -1662,6 +1670,9 @@ class GTestFlagSaverTest : public Test {
     GTEST_FLAG_SET(output, "xml:foo.xml");
     GTEST_FLAG_SET(brief, true);
     GTEST_FLAG_SET(print_time, false);
+    GTEST_FLAG_SET(print_test_filter, false);
+    GTEST_FLAG_SET(print_test_shard_status, false);
+    GTEST_FLAG_SET(print_test_shuffle_seed, false);
     GTEST_FLAG_SET(random_seed, 1);
     GTEST_FLAG_SET(repeat, 100);
     GTEST_FLAG_SET(recreate_environments_when_repeating, false);
@@ -5525,6 +5536,9 @@ struct Flags {
         output(""),
         brief(false),
         print_time(true),
+        print_test_filter(true),
+        print_test_shard_status(true),
+        print_test_shuffle_seed(true),
         random_seed(0),
         repeat(1),
         recreate_environments_when_repeating(true),
@@ -5615,6 +5629,30 @@ struct Flags {
     return flags;
   }
 
+  // Creates a Flags struct where the gtest_print_test_filter flag has the
+  // given value.
+  static Flags PrintTestFilter(bool print_test_filter) {
+    Flags flags;
+    flags.print_test_filter = print_test_filter;
+    return flags;
+  }
+
+  // Creates a Flags struct where the gtest_print_test_shard_status flag has
+  // the given value.
+  static Flags PrintTestShardStatus(bool print_test_shard_status) {
+    Flags flags;
+    flags.print_test_shard_status = print_test_shard_status;
+    return flags;
+  }
+
+  // Creates a Flags struct where the gtest_print_test_shuffle_seed flag has
+  // the given value.
+  static Flags PrintTestShuffleSeed(bool print_test_shuffle_seed) {
+    Flags flags;
+    flags.print_test_shuffle_seed = print_test_shuffle_seed;
+    return flags;
+  }
+
   // Creates a Flags struct where the gtest_random_seed flag has the given
   // value.
   static Flags RandomSeed(int32_t random_seed) {
@@ -5684,6 +5722,9 @@ struct Flags {
   const char* output;
   bool brief;
   bool print_time;
+  bool print_test_filter;
+  bool print_test_shard_status;
+  bool print_test_shuffle_seed;
   int32_t random_seed;
   int32_t repeat;
   bool recreate_environments_when_repeating;
@@ -5708,6 +5749,9 @@ class ParseFlagsTest : public Test {
     GTEST_FLAG_SET(output, "");
     GTEST_FLAG_SET(brief, false);
     GTEST_FLAG_SET(print_time, true);
+    GTEST_FLAG_SET(print_test_filter, true);
+    GTEST_FLAG_SET(print_test_shard_status, true);
+    GTEST_FLAG_SET(print_test_shuffle_seed, true);
     GTEST_FLAG_SET(random_seed, 0);
     GTEST_FLAG_SET(repeat, 1);
     GTEST_FLAG_SET(recreate_environments_when_repeating, true);
@@ -5742,6 +5786,11 @@ class ParseFlagsTest : public Test {
     EXPECT_STREQ(expected.output, GTEST_FLAG_GET(output).c_str());
     EXPECT_EQ(expected.brief, GTEST_FLAG_GET(brief));
     EXPECT_EQ(expected.print_time, GTEST_FLAG_GET(print_time));
+    EXPECT_EQ(expected.print_test_filter, GTEST_FLAG_GET(print_test_filter));
+    EXPECT_EQ(expected.print_test_shard_status,
+              GTEST_FLAG_GET(print_test_shard_status));
+    EXPECT_EQ(expected.print_test_shuffle_seed,
+              GTEST_FLAG_GET(print_test_shuffle_seed));
     EXPECT_EQ(expected.random_seed, GTEST_FLAG_GET(random_seed));
     EXPECT_EQ(expected.repeat, GTEST_FLAG_GET(repeat));
     EXPECT_EQ(expected.recreate_environments_when_repeating,
@@ -6086,6 +6135,37 @@ TEST_F(ParseFlagsTest, PrintTimeFalse_F) {
   const char* argv2[] = {"foo.exe", nullptr};
 
   GTEST_TEST_PARSING_FLAGS_(argv, argv2, Flags::PrintTime(false), false);
+}
+
+// Tests parsing --gtest_print_test_filter=0.
+TEST_F(ParseFlagsTest, PrintTestFilterFalse) {
+  const char* argv[] = {"foo.exe", "--gtest_print_test_filter=0", nullptr};
+
+  const char* argv2[] = {"foo.exe", nullptr};
+
+  GTEST_TEST_PARSING_FLAGS_(argv, argv2, Flags::PrintTestFilter(false), false);
+}
+
+// Tests parsing --gtest_print_test_shard_status=0.
+TEST_F(ParseFlagsTest, PrintTestShardStatusFalse) {
+  const char* argv[] = {"foo.exe", "--gtest_print_test_shard_status=0",
+                        nullptr};
+
+  const char* argv2[] = {"foo.exe", nullptr};
+
+  GTEST_TEST_PARSING_FLAGS_(argv, argv2,
+                            Flags::PrintTestShardStatus(false), false);
+}
+
+// Tests parsing --gtest_print_test_shuffle_seed=0.
+TEST_F(ParseFlagsTest, PrintTestShuffleSeedFalse) {
+  const char* argv[] = {"foo.exe", "--gtest_print_test_shuffle_seed=0",
+                        nullptr};
+
+  const char* argv2[] = {"foo.exe", nullptr};
+
+  GTEST_TEST_PARSING_FLAGS_(argv, argv2,
+                            Flags::PrintTestShuffleSeed(false), false);
 }
 
 // Tests parsing --gtest_random_seed=number


### PR DESCRIPTION
Fixes #4981.

## Problem

`PrettyUnitTestResultPrinter::OnTestIterationStart` prints several startup `Note:` lines, including the active test filter, shard status, and shuffle seed. Very long filter strings can make console output hard to read, but GoogleTest did not provide a way to suppress these notes individually.

## Root cause

The note lines were tied directly to their execution conditions:
- non-universal `--gtest_filter`
- active sharding
- enabled `--gtest_shuffle`

There was no separate output-level flag for each note.

## Solution

Add three boolean GoogleTest flags, all defaulting to `true`:

- `print_test_filter`
- `print_test_shard_status`
- `print_test_shuffle_seed`

These independently suppress only their matching startup note while preserving default output and leaving filtering, sharding, shuffling, and random seed behavior unchanged.

Supported usage includes:

- `GTEST_FLAG_SET(print_test_filter, false)`
- `--gtest_print_test_filter=false`
- `GTEST_PRINT_TEST_FILTER=false`

The same pattern applies to `print_test_shard_status` and `print_test_shuffle_seed`.

This also aligns boolean environment-variable parsing with command-line boolean parsing, so values starting with `0`, `f`, or `F` are treated as false.

## Tests

- `cmake -Dgtest_build_tests=ON -Dgmock_build_tests=ON ..`
- `make`
- `ctest -R googletest-env-var-test --output-on-failure`
- `make test`

Full CTest result: 63/63 tests passed.