### PR TITLE
Strip --help during GoogleTest flag parsing

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -6868,9 +6868,12 @@ void ParseGoogleTestFlagsOnlyImpl(int* argc, CharType** argv) {
       LoadFlagsFromFile(flagfile_value);
       remove_flag = true;
 #endif  // GTEST_USE_OWN_FLAGFILE_FLAG_ && GTEST_HAS_FILE_SYSTEM
-    } else if (arg_string == "--help" || HasGoogleTestFlagPrefix(arg)) {
-      // Both help flag and unrecognized Google Test flags (excluding
-      // internal ones) trigger help display.
+    } else if (arg_string == "--help") {
+      g_help_flag = true;
+      remove_flag = true;
+    } else if (HasGoogleTestFlagPrefix(arg)) {
+      // Unrecognized Google Test flags (excluding internal ones) trigger help
+      // display, but remain available for other flag parsers.
       g_help_flag = true;
     }
 

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -5942,6 +5942,15 @@ TEST_F(ParseFlagsTest, UnrecognizedFlag) {
   GTEST_TEST_PARSING_FLAGS_(argv, argv2, flags, false);
 }
 
+// Tests having a --help flag on the command line.
+TEST_F(ParseFlagsTest, HelpFlag) {
+  const char* argv[] = {"foo.exe", "--help", "bar", nullptr};
+
+  const char* argv2[] = {"foo.exe", "bar", nullptr};
+
+  GTEST_TEST_PARSING_FLAGS_(argv, argv2, Flags(), true);
+}
+
 // Tests having a --gtest_list_tests flag
 TEST_F(ParseFlagsTest, ListTestsFlag) {
   const char* argv[] = {"foo.exe", "--gtest_list_tests", nullptr};


### PR DESCRIPTION
Problem
- Fixes google/googletest#4831: `InitGoogleTest` sets the help flag for `--help`, but leaves `--help` in `argv` after parsing.

Root cause
- `--help` shared the same branch as unrecognized GoogleTest-prefixed flags. That path intentionally keeps unknown `--gtest_*` arguments available for other parsers, so `--help` was also preserved.

Solution
- Handle `--help` separately: set the help flag and remove the argument from `argv`.
- Keep the existing behavior for unrecognized `--gtest_*` arguments.
- Add parser coverage for `--help` to ensure it is stripped while help output remains enabled.

Tests run
- `cmake --build build --target gtest_unittest --config Debug`
- `build\googletest\Debug\gtest_unittest.exe --gtest_filter=ParseFlagsTest.HelpFlag`
- `build\googletest\Debug\gtest_unittest.exe --gtest_filter=ParseFlagsTest.*`
- `git diff --check`