### PR TITLE
Run global environments when only disabled tests are selected

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -6002,6 +6002,8 @@ bool UnitTestImpl::RunAllTests() {
   const bool has_tests_to_run =
       FilterTests(should_shard ? HONOR_SHARDING_PROTOCOL
                                : IGNORE_SHARDING_PROTOCOL) > 0;
+  const bool has_tests_selected =
+      has_tests_to_run || reportable_disabled_test_count() > 0;
 
   // Lists the tests and exits if the --gtest_list_tests flag was specified.
   if (GTEST_FLAG_GET(list_tests)) {
@@ -6056,8 +6058,11 @@ bool UnitTestImpl::RunAllTests() {
     // Tells the unit test event listeners that the tests are about to start.
     repeater->OnTestIterationStart(*parent_, i);
 
-    // Runs each test suite if there is at least one test to run.
-    if (has_tests_to_run) {
+    // Sets up and tears down environments if there is at least one test to run,
+    // or if the selected tests are all disabled. The disabled tests still do
+    // not run, but global tear-down can clean resources created before
+    // RUN_ALL_TESTS().
+    if (has_tests_selected) {
       // Sets up all environments beforehand. If test environments aren't
       // recreated for each iteration, only do so on the first iteration.
       if (i == 0 || recreate_environments_when_repeating) {

--- a/googletest/test/gtest_environment_test.cc
+++ b/googletest/test/gtest_environment_test.cc
@@ -86,6 +86,8 @@ class MyEnvironment : public testing::Environment {
 // was run.
 TEST(FooTest, Bar) { test_was_run = true; }
 
+TEST(FooTest, DISABLED_Baz) { test_was_run = true; }
+
 // Prints the message and aborts the program if condition is false.
 void Check(bool condition, const char* msg) {
   if (!condition) {
@@ -172,6 +174,21 @@ void TestNoTestsSkipsSetUp() {
         "as the global set-up was not run.");
 }
 
+// Verifies that RUN_ALL_TESTS() still runs environment tear-down when the
+// selected tests are disabled.
+void TestDisabledTestsRunEnvironmentTearDown() {
+  MyEnvironment* const env = RegisterTestEnv();
+  GTEST_FLAG_SET(filter, "FooTest.DISABLED_Baz");
+  Check(RunAllTests(env, NO_FAILURE) != 0,
+        "RUN_ALL_TESTS() should return non-zero, as the global tear-down "
+        "should generate a failure.");
+  Check(!test_was_run, "The disabled test body should not run.");
+  Check(set_up_was_run,
+        "The global set-up should run, as a disabled test was selected.");
+  Check(tear_down_was_run,
+        "The global tear-down should run, as the global set-up was run.");
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -181,6 +198,7 @@ int main(int argc, char** argv) {
   TestTestsRun();
   TestNoTestsRunSetUpFailure();
   TestNoTestsSkipsSetUp();
+  TestDisabledTestsRunEnvironmentTearDown();
 
   printf("PASS\n");
   return 0;


### PR DESCRIPTION
Problem
- Closes #4966.
- When a filter selects only disabled tests, GoogleTest reports those disabled tests but skips the global test environment lifecycle. That means cleanup in `Environment::TearDown()` is not reached.

Root cause
- `UnitTestImpl::RunAllTests()` gated environment setup and teardown on `has_tests_to_run`, which only counts tests that will execute. Disabled tests that match the filter are reportable, but they do not make `has_tests_to_run` true.

Solution
- Treat reportable disabled tests as selected for the global environment lifecycle.
- Keep the disabled test bodies unexecuted.
- Add regression coverage in `gtest_environment_test` for a filter that selects only a disabled test.

Tests run
- `cmake --build build --target gtest_environment_test --config Debug`
- `build\\googletest\\Debug\\gtest_environment_test.exe`
- `cmake --build build --target gtest_unittest --config Debug`
- `build\\googletest\\Debug\\gtest_unittest.exe`
- `ctest -C Debug -R "gtest_environment_test|gtest_unittest" --output-on-failure`
- `git diff --check`