### PR TITLE
Initialize `match` variable in `MatchAndExplain`'s loop

### DIFF
--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -3696,7 +3696,7 @@ class [[nodiscard]] ElementsAreMatcherImpl
     // the end of either the elements or the matchers, or until we find a
     // mismatch.
     for (; it != stl_container.end() && exam_pos != count(); ++it, ++exam_pos) {
-      bool match;  // Does the current element match the current matcher?
+      bool match = false;  // Does the current element match the current matcher?
       if (listener_interested) {
         StringMatchResultListener s;
         match = matchers_[exam_pos].MatchAndExplain(*it, &s);


### PR DESCRIPTION
This prevents the warning of `variable 'match' is not initialized [cppcoreguidelines-init-variables]`.

Testing: The warning is gone with `clang-tidy`.

```
googlemock/include/gmock/gmock-matchers.h:3617:12: warning: variable 'match' is not initialized [cppcoreguidelines-init-variables]
 3617 |       bool match;  // Does the current element match the current matcher?
      |            ^    
      |                  = false
```