### PR TITLE
cmake: Fix PDB output dir for install of static and shared lib

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -320,11 +320,15 @@ function(install_project)
       foreach(t ${ARGN})
         get_target_property(t_pdb_name ${t} COMPILE_PDB_NAME)
         get_target_property(t_pdb_name_debug ${t} COMPILE_PDB_NAME_DEBUG)
-        get_target_property(t_pdb_output_directory ${t} PDB_OUTPUT_DIRECTORY)
+        get_target_property(t_pdb_output_directory ${t} COMPILE_PDB_OUTPUT_DIRECTORY)
+        get_target_property(t_shared_pdb_name ${t} PDB_NAME)
+        get_target_property(t_shared_pdb_name_debug ${t} PDB_NAME_DEBUG)
+        get_target_property(t_shared_pdb_output_directory ${t} PDB_OUTPUT_DIRECTORY)
         install(FILES
-          "${t_pdb_output_directory}/\${CMAKE_INSTALL_CONFIG_NAME}/$<$<CONFIG:Debug>:${t_pdb_name_debug}>$<$<NOT:$<CONFIG:Debug>>:${t_pdb_name}>.pdb"
+          "$<$<STREQUAL:$<TARGET_PROPERTY:${t},TYPE>,STATIC_LIBRARY>:${t_pdb_output_directory}/\${CMAKE_INSTALL_CONFIG_NAME}/$<IF:$<CONFIG:Debug>,${t_pdb_name_debug},${t_pdb_name}>.pdb>"
+          "$<$<STREQUAL:$<TARGET_PROPERTY:${t},TYPE>,SHARED_LIBRARY>:${t_shared_pdb_output_directory}/\${CMAKE_INSTALL_CONFIG_NAME}/$<IF:$<CONFIG:Debug>,${t_shared_pdb_name_debug},${t_shared_pdb_name}>.pdb"
           COMPONENT "${PROJECT_NAME}"
-          DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          DESTINATION $<IF:$<STREQUAL:$<TARGET_PROPERTY:${t},TYPE>,STATIC_LIBRARY>,${CMAKE_INSTALL_LIBDIR},${CMAKE_INSTALL_BINDIR}>
           OPTIONAL)
       endforeach()
     endif()


### PR DESCRIPTION

PR https://github.com/google/googletest/pull/3940 added ``COMPILE_PDB_OUTPUT_DIRECTORY`` property usage without updating the install command to accommodate the two PDB properties.
``COMPILE_PDB_*`` and ``PDB_*`` properties are two distinct properties that affect static (``COMPILE_PDB_*``) and shared (``PDB_*``) libs separately.
This commit adds cmake install rule for both types (optionally) to install when available.

The install function already uses the ``OPTIONAL`` argument for PDB ``install(FILES)`` command, so both static and shared pdb's are added to the install rule, and no warning/error is thrown if one or both arent available at install

Snippets of install output for both shared and static lib

Debug static
```
"C:\Program Files\CMake\bin\cmake.exe" -DBUILD_GMOCK=OFF -DINSTALL_GTEST=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_DEBUG_POSTFIX=d -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_INSTALL_PREFIX=C:/install -DCMAKE_BUILD_TYPE=Debug -DCMAKE_SYSTEM_VERSION=10.0.26200 -DCMAKE_SYSTEM_NAME=Windows "-GVisual Studio 17 2022" -Ax64 -S C:/source/googletest -B C:/source/googletest/build-gtest
<snip>
    -- Installing: C:/install/include/gtest/internal/gtest-type-uti
  l.h
    -- Installing: C:/install/lib/gtestd.lib
    -- Installing: C:/install/lib/gtest_maind.lib
    -- Installing: C:/install/lib/gtestd.pdb
    -- Installing: C:/install/lib/gtest_maind.pdb
    -- Installing: C:/install/lib/pkgconfig/gtest.pc
    -- Installing: C:/install/lib/pkgconfig/gtest_main.pc
```

Release static
```
"C:\Program Files\CMake\bin\cmake.exe" -DBUILD_GMOCK=OFF -DINSTALL_GTEST=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_DEBUG_POSTFIX=d -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_INSTALL_PREFIX=C:/install -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_VERSION=10.0.26200 -DCMAKE_SYSTEM_NAME=Windows "-GVisual Studio 17 2022" -Ax64 -S C:/source/googletest -B C:/source/googletest/build-gtest
<snip>
    -- Installing: C:/install/include/gtest/internal/gtest-string.h
    -- Installing: C:/install/include/gtest/internal/gtest-type-uti
  l.h
    -- Installing: C:/install/lib/gtest.lib
    -- Installing: C:/install/lib/gtest_main.lib
    -- Installing: C:/install/lib/gtest.pdb
    -- Installing: C:/install/lib/gtest_main.pdb
    -- Installing: C:/installlib/pkgconfig/gtest.pc
    -- Installing: C:/install/lib/pkgconfig/gtest_main.pc
```

Release Shared
```
"C:\Program Files\CMake\bin\cmake.exe" -DBUILD_GMOCK=OFF -DINSTALL_GTEST=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_DEBUG_POSTFIX=d -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_INSTALL_PREFIX=C:/install -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_VERSION=10.0.26200 -DCMAKE_SYSTEM_NAME=Windows "-GVisual Studio 17 2022" -Ax64 -S C:/source/googletest -B C:/source/googletest/build-gtest
<snip>
    -- Installing: C:/install/lib/gtest.lib
    -- Installing: C:/install/bin/gtest.dll
    -- Installing: C:/install/lib/gtest_main.lib
    -- Installing: C:/install/bin/gtest_main.dll
    -- Installing: C:/install/bin/gtest.pdb
    -- Installing: C:/install/bin/gtest_main.pdb
    -- Installing: C:/install/lib/pkgconfig/gtest.pc
    -- Installing: C:/install/lib/pkgconfig/gtest_main.pc
```

Fixes #4599
