### PR TITLE
Add missing public flags to --help output

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -6732,6 +6732,12 @@ static const char kColorEncodedHelpMessage[] =
     "recreate_environments_when_repeating@D\n"
     "      Sets up and tears down the global test environment on each repeat\n"
     "      of the test.\n"
+    "  @G--" GTEST_FLAG_PREFIX_
+    "fail_fast@D\n"
+    "      Stop running tests after the first failure.\n"
+    "  @G--" GTEST_FLAG_PREFIX_
+    "fail_if_no_test_linked@D\n"
+    "      Fail if no test is linked into the test program.\n"
     "\n"
     "Test Output:\n"
     "  @G--" GTEST_FLAG_PREFIX_
@@ -6743,6 +6749,9 @@ static const char kColorEncodedHelpMessage[] =
     "  @G--" GTEST_FLAG_PREFIX_
     "print_time=0@D\n"
     "      Don't print the elapsed time of each test.\n"
+    "  @G--" GTEST_FLAG_PREFIX_
+    "print_utf8=0@D\n"
+    "      Don't print UTF-8 characters as text.\n"
     "  @G--" GTEST_FLAG_PREFIX_
     "output=@Y(@Gjson@Y|@Gxml@Y)[@G:@YDIRECTORY_PATH@G" GTEST_PATH_SEP_
     "@Y|@G:@YFILE_PATH]@D\n"
@@ -6760,6 +6769,9 @@ static const char kColorEncodedHelpMessage[] =
     "  @G--" GTEST_FLAG_PREFIX_
     "death_test_style=@Y(@Gfast@Y|@Gthreadsafe@Y)@D\n"
     "      Set the default death test style.\n"
+    "  @G--" GTEST_FLAG_PREFIX_
+    "death_test_use_fork@D\n"
+    "      Use fork() instead of clone() to spawn death test child processes.\n"
 #endif  // GTEST_HAS_DEATH_TEST && !GTEST_OS_WINDOWS
     "  @G--" GTEST_FLAG_PREFIX_
     "break_on_failure@D\n"
@@ -6772,6 +6784,9 @@ static const char kColorEncodedHelpMessage[] =
     "catch_exceptions=0@D\n"
     "      Do not report exceptions as test failures. Instead, allow them\n"
     "      to crash the program or throw a pop-up (on Windows).\n"
+    "  @G--" GTEST_FLAG_PREFIX_
+    "stack_trace_depth=@Y[NUMBER]@D\n"
+    "      Maximum number of stack frames to print when an assertion fails.\n"
     "\n"
     "Except for @G--" GTEST_FLAG_PREFIX_
     "list_tests@D, you can alternatively set "

--- a/googletest/test/gtest_help_test.py
+++ b/googletest/test/gtest_help_test.py
@@ -64,6 +64,7 @@ IS_WINDOWS = os.name == 'nt'
 PROGRAM_PATH = gtest_test_utils.GetTestExecutablePath('gtest_help_test_')
 FLAG_PREFIX = '--gtest_'
 DEATH_TEST_STYLE_FLAG = FLAG_PREFIX + 'death_test_style'
+DEATH_TEST_USE_FORK_FLAG = FLAG_PREFIX + 'death_test_use_fork'
 STREAM_RESULT_TO_FLAG = FLAG_PREFIX + 'stream_result_to'
 LIST_TESTS_FLAG = FLAG_PREFIX + 'list_tests'
 INTERNAL_FLAG_FOR_TESTING = FLAG_PREFIX + 'internal_flag_for_testing'
@@ -90,11 +91,17 @@ HELP_REGEX = re.compile(
     + FLAG_PREFIX
     + r'random_seed=.*'
     + FLAG_PREFIX
+    + r'fail_fast.*'
+    + FLAG_PREFIX
+    + r'fail_if_no_test_linked.*'
+    + FLAG_PREFIX
     + r'color=.*'
     + FLAG_PREFIX
     + r'brief.*'
     + FLAG_PREFIX
     + r'print_time.*'
+    + FLAG_PREFIX
+    + r'print_utf8.*'
     + FLAG_PREFIX
     + r'output=.*'
     + FLAG_PREFIX
@@ -102,7 +109,9 @@ HELP_REGEX = re.compile(
     + FLAG_PREFIX
     + r'throw_on_failure.*'
     + FLAG_PREFIX
-    + r'catch_exceptions=0.*',
+    + r'catch_exceptions=0.*'
+    + FLAG_PREFIX
+    + r'stack_trace_depth=.*',
     re.DOTALL,
 )
 
@@ -151,8 +160,10 @@ class GTestHelpTest(gtest_test_utils.TestCase):
 
     if SUPPORTS_DEATH_TESTS and not IS_WINDOWS:
       self.assertIn(DEATH_TEST_STYLE_FLAG, output)
+      self.assertIn(DEATH_TEST_USE_FORK_FLAG, output)
     else:
       self.assertNotIn(DEATH_TEST_STYLE_FLAG, output)
+      self.assertNotIn(DEATH_TEST_USE_FORK_FLAG, output)
 
   def test_runs_tests_without_help_flag(self):
     """Verifies correct behavior when no help flag is specified.


### PR DESCRIPTION
## Summary

This PR adds several public GoogleTest command-line flags to the standard `--help` output.

These flags were already supported by the command-line parser but were not documented in the help message shown to users. This change improves discoverability of existing functionality without changing runtime behavior.

## Changes

- Added `--gtest_fail_fast` to the help output.
- Added `--gtest_fail_if_no_test_linked` to the help output.
- Added `--gtest_print_utf8` to the help output.
- Added `--gtest_stack_trace_depth` to the help output.
- Added `--gtest_death_test_use_fork` to the help output where applicable.
- Updated `googletest/test/gtest_help_test.py` to verify the new help output.

## Testing

- Built GoogleTest locally.
- Verified the updated `--help` output using a sample GoogleTest executable.
- Updated the existing help output test to reflect the newly documented flags.

##Screenshots
Before:
<img width="743" height="811" alt="image" src="https://github.com/user-attachments/assets/276597ef-4b57-4b06-84eb-0ebe8b8f8e33" />
After:
<img width="717" height="930" alt="image" src="https://github.com/user-attachments/assets/983168e2-1282-4532-92a9-009e5adbccfc" />

Fixes #4802