### PR TITLE
[FR]: Make default mock behavior a CMake option

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -10,6 +10,9 @@
 
 option(gmock_build_tests "Build all of Google Mock's own tests." OFF)
 
+set(gmock_default_mock_behavior "1" CACHE STRING
+    "Controls default mock behavior (0=Nice, 1=Naggy, 2=Strict).")
+
 # A directory to find Google Test sources.
 if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/gtest/CMakeLists.txt")
   set(gtest_dir gtest)
@@ -101,6 +104,9 @@ else()
   target_link_libraries(gmock_main PUBLIC gmock)
   set_target_properties(gmock_main PROPERTIES VERSION ${GOOGLETEST_VERSION})
 endif()
+
+target_compile_definitions(gmock PRIVATE
+    GMOCK_DEFAULT_MOCK_BEHAVIOR=${gmock_default_mock_behavior})
 
 string(REPLACE ";" "$<SEMICOLON>" dirs "${gmock_build_include_dirs}")
 target_include_directories(gmock SYSTEM INTERFACE

--- a/googlemock/include/gmock/gmock-nice-strict.h
+++ b/googlemock/include/gmock/gmock-nice-strict.h
@@ -38,10 +38,11 @@
 // uninteresting calls as errors.
 //
 // Currently a mock is naggy by default, so MockFoo and
-// NaggyMock<MockFoo> behave like the same.  However, we will soon
-// switch the default behavior of mocks to be nice, as that in general
-// leads to more maintainable tests.  When that happens, MockFoo will
-// stop behaving like NaggyMock<MockFoo> and start behaving like
+// NaggyMock<MockFoo> behave like the same.  The default can be
+// overridden at build time via the GMOCK_DEFAULT_MOCK_BEHAVIOR
+// CMake option, or at runtime via the --gmock_default_mock_behavior
+// flag.  If the default is set to NiceMock, MockFoo will stop
+// behaving like NaggyMock<MockFoo> and start behaving like
 // NiceMock<MockFoo>.
 //
 // NiceMock, NaggyMock, and StrictMock "inherit" the constructors of

--- a/googlemock/src/gmock.cc
+++ b/googlemock/src/gmock.cc
@@ -44,7 +44,7 @@ GMOCK_DEFINE_string_(verbose, testing::internal::kWarningVerbosity,
                      "  warning - prints warnings and errors.\n"
                      "  error   - prints errors only.");
 
-GMOCK_DEFINE_int32_(default_mock_behavior, 1,
+GMOCK_DEFINE_int32_(default_mock_behavior, GMOCK_DEFAULT_MOCK_BEHAVIOR,
                     "Controls the default behavior of mocks."
                     "  Valid values:\n"
                     "  0 - by default, mocks act as NiceMocks.\n"


### PR DESCRIPTION
Closes #4996

Changes:
- Added `gmock_default_mock_behavior` CMake option (0=Nice, 1=Naggy, 2=Strict, default=1)
- Replaced hardcoded default in gmock.cc with `GMOCK_DEFAULT_MOCK_BEHAVIOR` macro
- Updated comment in gmock-nice-strict.h to reflect configurable default

Usage: `cmake -Dgmock_default_mock_behavior=0` to default to NiceMock.