### PR TITLE
[Bug]: IsEmpty matcher doesn't work with C-style wide strings

### DIFF
--- a/googlemock/include/gmock/gmock-more-matchers.h
+++ b/googlemock/include/gmock/gmock-more-matchers.h
@@ -79,6 +79,12 @@ class [[nodiscard]] IsEmptyMatcher {
     return MatchAndExplain(std::string(s), listener);
   }
 
+  // Matches C-style wide strings.
+  bool MatchAndExplain(const wchar_t* s,
+                       MatchResultListener* listener) const {
+    return MatchAndExplain(std::wstring(s), listener);
+  }
+
   // Describes what this matcher matches.
   void DescribeTo(std::ostream* os) const { *os << "is empty"; }
 


### PR DESCRIPTION
Closes #4857

Added `const wchar_t*` overload to `IsEmptyMatcher::MatchAndExplain` in `gmock-more-matchers.h`, delegates to `std::wstring` version.