### PR TITLE
chore: bump main branch version to 1.18.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(googletest-distribution)
-set(GOOGLETEST_VERSION 1.16.0)
+set(GOOGLETEST_VERSION 1.18.0)
 
 if(NOT CYGWIN AND NOT MSYS AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL QNX)
   set(CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
The latest release is v1.17.0, but the main branch still reports version 1.16.0. Bump to 1.18.0 to reflect that main is the development branch for the next release after 1.17.

Closes #4844