### PR TITLE
fix: only use __cpp_lib_three_way_comparison for <compare> detection

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -2411,9 +2411,7 @@ using StringView = ::std::string_view;
 #define GTEST_INTERNAL_HAS_STRING_VIEW 0
 #endif
 
-#if (defined(__cpp_lib_three_way_comparison) || \
-     (GTEST_INTERNAL_HAS_INCLUDE(<compare>) &&  \
-      GTEST_INTERNAL_CPLUSPLUS_LANG >= 201907L))
+#if defined(__cpp_lib_three_way_comparison)
 #define GTEST_INTERNAL_HAS_COMPARE_LIB 1
 #else
 #define GTEST_INTERNAL_HAS_COMPARE_LIB 0


### PR DESCRIPTION
The fallback check `GTEST_INTERNAL_HAS_INCLUDE(<compare>) && C++20` causes build failures on Android NDK 24 which has the header but lacks the full comparison operators needed by PrintTo. The feature test macro `__cpp_lib_three_way_comparison` is the reliable indicator.

Fixes #4933