### PR TITLE
Add default case to death test AssumeRole() switch

### DIFF
--- a/googletest/include/gtest/internal/gtest-death-test-internal.h
+++ b/googletest/include/gtest/internal/gtest-death-test-internal.h
@@ -244,6 +244,8 @@ GTEST_API_ bool ExitedUnsuccessfully(int exit_status);
           gtest_dt->Abort(::testing::internal::DeathTest::TEST_DID_NOT_DIE);   \
           break;                                                               \
         }                                                                      \
+        default:                                                               \
+          GTEST_LOG_(FATAL) << "Unexpected AssumeRole() return value.";        \
       }                                                                        \
     }                                                                          \
   } else                                                                       \


### PR DESCRIPTION
Meta has `-Wswitch-default` enabled for large parts of its repository. This warning requires a `default` case to cover non-exhaustive enumeration handling in `switch` statements.

The `switch (gtest_dt->AssumeRole())` statement in `gtest-death-test-internal.h` does not currently have a `default` case, which triggers this warning. This diff provides one, logging a fatal error for any unexpected `AssumeRole()` return value.

I expect this is better than alternatives such as error suppression at the build or file level because it will be cross-compatible with every compiler.