### PR TITLE
Support pthread-enabled Emscripten in GTEST_HAS_PTHREAD

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -593,7 +593,8 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
      defined(GTEST_OS_DRAGONFLY) || defined(GTEST_OS_GNU_KFREEBSD) || \
      defined(GTEST_OS_OPENBSD) || defined(GTEST_OS_HAIKU) ||          \
      defined(GTEST_OS_GNU_HURD) || defined(GTEST_OS_SOLARIS) ||       \
-     defined(GTEST_OS_AIX) || defined(GTEST_OS_ZOS))
+     defined(GTEST_OS_AIX) || defined(GTEST_OS_ZOS) ||                \
+     (defined(__EMSCRIPTEN__) && defined(__EMSCRIPTEN_PTHREADS__)))
 #define GTEST_HAS_PTHREAD 1
 #else
 #define GTEST_HAS_PTHREAD 0


### PR DESCRIPTION
## Summary

Enable `GTEST_HAS_PTHREAD` when compiling with Emscripten pthreads.

Currently, GoogleTest's CMake configuration enables pthread support when building with `-pthread` under Emscripten, while `gtest-port.h` defaults `GTEST_HAS_PTHREAD` to `0` because Emscripten is not included in the platform detection.

This causes GoogleTest and consumer translation units to disagree on the value of `GTEST_HAS_PTHREAD`, leading to an ODR violation and crashes when using Google Mock.

This change adds:

```cpp
(defined(__EMSCRIPTEN__) && defined(__EMSCRIPTEN_PTHREADS__))
```

Fixes https://github.com/google/googletest/issues/5015