### PR TITLE
fix: detect pthread-enabled Emscripten in GTEST_HAS_PTHREAD

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -593,7 +593,8 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
      defined(GTEST_OS_DRAGONFLY) || defined(GTEST_OS_GNU_KFREEBSD) || \
      defined(GTEST_OS_OPENBSD) || defined(GTEST_OS_HAIKU) ||          \
      defined(GTEST_OS_GNU_HURD) || defined(GTEST_OS_SOLARIS) ||       \
-     defined(GTEST_OS_AIX) || defined(GTEST_OS_ZOS))
+     defined(GTEST_OS_AIX) || defined(GTEST_OS_ZOS) ||                \
+     (defined(GTEST_OS_EMSCRIPTEN) && defined(__EMSCRIPTEN_PTHREADS__)))
 #define GTEST_HAS_PTHREAD 1
 #else
 #define GTEST_HAS_PTHREAD 0


### PR DESCRIPTION
## Summary

Fix inconsistent `GTEST_HAS_PTHREAD` detection on Emscripten when building with `-pthread`.

GoogleTest's CMake configuration correctly enables `GTEST_HAS_PTHREAD=1` for the library when pthreads are available. However, `gtest-port.h` does not recognize pthread-enabled Emscripten during header auto-detection, causing consumer translation units to use `GTEST_HAS_PTHREAD=0`.

This mismatch results in different implementations of internal synchronization types such as `ThreadLocal<T>`, leading to an ODR violation and runtime crashes in GMock (for example, `EXPECT_CALL`).

## Changes

* Update `gtest-port.h` to treat Emscripten as pthread-capable only when `__EMSCRIPTEN_PTHREADS__` is defined.
* Keep behavior unchanged for all other platforms.

## Why this fix?

`__EMSCRIPTEN_PTHREADS__` is defined only when Emscripten is compiled with `-pthread`, making it the correct indicator for enabling pthread support. This keeps header-based detection consistent with the build configuration while avoiding any impact on non-pthread Emscripten builds.

Fixes #5015.
