### PR TITLE
fix: GTEST_HAS_PTHREAD detection for pthread-enabled Emscripten

### DIFF
--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -593,7 +593,8 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
      defined(GTEST_OS_DRAGONFLY) || defined(GTEST_OS_GNU_KFREEBSD) || \
      defined(GTEST_OS_OPENBSD) || defined(GTEST_OS_HAIKU) ||          \
      defined(GTEST_OS_GNU_HURD) || defined(GTEST_OS_SOLARIS) ||       \
-     defined(GTEST_OS_AIX) || defined(GTEST_OS_ZOS))
+     defined(GTEST_OS_AIX) || defined(GTEST_OS_ZOS) ||                \
+     (defined(GTEST_OS_EMSCRIPTEN) && defined(__EMSCRIPTEN_PTHREADS__)))
 #define GTEST_HAS_PTHREAD 1
 #else
 #define GTEST_HAS_PTHREAD 0


### PR DESCRIPTION
## Summary

Fix inconsistent `GTEST_HAS_PTHREAD` detection on Emscripten when building with `-pthread`.

GoogleTest's CMake configuration correctly enables `GTEST_HAS_PTHREAD=1` for the library via `find_package(Threads)`. However, `gtest-port.h` does not recognize pthread-enabled Emscripten during header auto-detection, causing consumer translation units to use `GTEST_HAS_PTHREAD=0`.

This mismatch results in different implementations of `testing::internal::ThreadLocal<T>` (pthread-backed vs. single-threaded), leading to an ODR violation and runtime crashes in GMock (e.g., `EXPECT_CALL`).

## Changes

* Add `GTEST_OS_EMSCRIPTEN` with `__EMSCRIPTEN_PTHREADS__` to the platform list in `gtest-port.h`'s `GTEST_HAS_PTHREAD` auto-detection.
* Uses `GTEST_OS_EMSCRIPTEN` (already defined in `gtest-port-arch.h`) for consistency with existing code style.

## Why this approach?

* Uses the existing `GTEST_OS_EMSCRIPTEN` macro instead of raw `__EMSCRIPTEN__`, consistent with the rest of the codebase.
* `__EMSCRIPTEN_PTHREADS__` is defined by Emscripten only when compiled with `-pthread`, keeping behavior unchanged for non-pthread Emscripten builds.
* Header-based detection now matches the CMake `find_package(Threads)` behavior, eliminating the ODR violation.

## Testing

* Verified that existing tests (`gtest_unittest`, `gmock-actions_test`) pass on Linux.
* The fix only affects Emscripten builds; non-Emscripten behavior is unchanged.

Fixes #5015