### PR TITLE
cmake: specify Interpreter component in find_package(Python3)

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -255,7 +255,7 @@ function(cxx_executable name dir libs)
 endfunction()
 
 if(gtest_build_tests)
-  find_package(Python3)
+  find_package(Python3 COMPONENTS Interpreter)
 endif()
 
 # cxx_test_with_flags(name cxx_flags libs srcs...)


### PR DESCRIPTION
Fixes #4847

`find_package(Python3)` without specifying `COMPONENTS` may look for development libraries in addition to the interpreter. This fails on cross-compilation setups (e.g. Android NDK's bundled CMake 3.22) where only the interpreter is needed to run Python tests.

Specifying `COMPONENTS Interpreter` ensures only the interpreter is looked for, matching the usage in `py_test()` which only needs `Python3::Interpreter`.

- One-line fix in `internal_utils.cmake`
- Tests pass (built and verified)