### PR TITLE
fix: add missing EXPECT_CALL before mock invocations in gmock tests

### DIFF
--- a/googlemock/test/gmock-actions_test.cc
+++ b/googlemock/test/gmock-actions_test.cc
@@ -1859,6 +1859,7 @@ TEST(MockMethodTest, CanReturnMoveOnlyValue_Invoke) {
   // Check default value
   DefaultValue<std::unique_ptr<int>>::SetFactory(
       [] { return std::make_unique<int>(42); });
+  EXPECT_CALL(mock, MakeUnique()).WillOnce(DoDefault());
   EXPECT_EQ(42, *mock.MakeUnique());
 
   EXPECT_CALL(mock, MakeUnique()).WillRepeatedly(UniquePtrSource);

--- a/googlemock/test/gmock-matchers-arithmetic_test.cc
+++ b/googlemock/test/gmock-matchers-arithmetic_test.cc
@@ -1182,6 +1182,10 @@ TEST(AllArgsTest, WorksWithoutMatchers) {
   ON_CALL(helper, OneArg).WillByDefault(Return(20));
   ON_CALL(helper, TwoArgs).WillByDefault(Return(30));
 
+  EXPECT_CALL(helper, NoArgs);
+  EXPECT_CALL(helper, OneArg);
+  EXPECT_CALL(helper, TwoArgs);
+
   EXPECT_EQ(10, helper.NoArgs());
   EXPECT_EQ(20, helper.OneArg(1));
   EXPECT_EQ(30, helper.TwoArgs('\1', 2));


### PR DESCRIPTION
Fixes #4846

gmock's own tests invoke UB by calling mock methods without EXPECT_CALL. This PR adds the missing expectations:

- gmock-actions_test.cc: Add EXPECT_CALL before DefaultValue::SetFactory check that invoked mock without expectation
- gmock-matchers-arithmetic_test.cc: Add bare EXPECT_CALLs in AllArgsTest before mock methods called without expectations

Note: The third UB case in gmock-spec-builders_test.cc (lines 301,309) was intentionally left as-is — those calls are inside EXPECT_NONFATAL_FAILURE blocks that test the .With() clause error, and the subsequent unguarded calls are part of the test's design.