### PR TITLE
fix: Python 3 crash in googletest-output-test.py debug mode

### DIFF
--- a/googletest/test/googletest-output-test.py
+++ b/googletest/test/googletest-output-test.py
@@ -349,14 +349,14 @@ class GTestOutputTest(gtest_test_utils.TestCase):
                 gtest_test_utils.GetSourceDir(),
                 '_googletest-output-test_normalized_actual.txt',
             ),
-            'wb',
+            'w',
         ).write(normalized_actual)
         open(
             os.path.join(
                 gtest_test_utils.GetSourceDir(),
                 '_googletest-output-test_normalized_golden.txt',
             ),
-            'wb',
+            'w',
         ).write(normalized_golden)
 
       self.assertEqual(normalized_golden, normalized_actual)


### PR DESCRIPTION
Fixes #3943

When `DEBUG_GTEST_OUTPUT_TEST` is set, the script crashes in Python 3 with 'a bytes-like object is required' because the debug output files are opened in binary mode ('wb') but the normalized strings are str objects, not bytes.

Changed both file open modes from 'wb' to 'w' (lines 352, 359).