### PR TITLE
docs: remove redundant RetiresOnSaturation from InSequence example

### DIFF
--- a/docs/gmock_for_dummies.md
+++ b/docs/gmock_for_dummies.md
@@ -679,8 +679,7 @@ using ::testing::Return;
 
   for (int i = 1; i <= n; i++) {
     EXPECT_CALL(turtle, GetX())
-        .WillOnce(Return(10*i))
-        .RetiresOnSaturation();
+        .WillOnce(Return(10*i));
   }
 }
 ```


### PR DESCRIPTION
InSequence automatically retires expectations after they are used, so RetiresOnSaturation() in the example is redundant and may mislead readers into thinking it is required.

Fixes #4733