### PR TITLE
docs: update CMake version requirement in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ and their own tests from a git checkout, which has further requirements:
 
 *   [Python](https://www.python.org/) v3.6 or newer (for running some of the
     tests and re-generating certain source files from templates)
-*   [CMake](https://cmake.org/) v2.8.12 or newer
+*   [CMake](https://cmake.org/) v3.16 or newer
 
 ## Developing Google Test and Google Mock
 


### PR DESCRIPTION
CMakeLists.txt requires CMake 3.16 but CONTRIBUTING.md still says v2.8.12. Update to match the actual minimum version.

Fixes #4698