### PR TITLE
Include ad hoc failures in XML/JSON report counts

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -4281,7 +4281,7 @@ void XmlUnitTestResultPrinter::OutputXmlTestSuiteForTestResult(
   OutputXmlAttribute(
       stream, "testsuite", "timestamp",
       FormatEpochTimeInMillisAsIso8601(result.start_timestamp()));
-  *stream << ">";
+  *stream << ">\n";
 
   OutputXmlTestCaseForTestResult(stream, result);
 
@@ -4405,13 +4405,18 @@ void XmlUnitTestResultPrinter::OutputXmlTestResult(::std::ostream* stream,
 void XmlUnitTestResultPrinter::PrintXmlTestSuite(std::ostream* stream,
                                                  const TestSuite& test_suite) {
   const std::string kTestsuite = "testsuite";
+  // A failed ad hoc test result (e.g. a failure in SetUpTestSuite) is output
+  // as an extra test case below, so include it in the counts.
+  const int ad_hoc_failure = test_suite.ad_hoc_test_result().Failed() ? 1 : 0;
   *stream << "  <" << kTestsuite;
   OutputXmlAttribute(stream, kTestsuite, "name", test_suite.name());
-  OutputXmlAttribute(stream, kTestsuite, "tests",
-                     StreamableToString(test_suite.reportable_test_count()));
+  OutputXmlAttribute(
+      stream, kTestsuite, "tests",
+      StreamableToString(test_suite.reportable_test_count() + ad_hoc_failure));
   if (!GTEST_FLAG_GET(list_tests)) {
-    OutputXmlAttribute(stream, kTestsuite, "failures",
-                       StreamableToString(test_suite.failed_test_count()));
+    OutputXmlAttribute(
+        stream, kTestsuite, "failures",
+        StreamableToString(test_suite.failed_test_count() + ad_hoc_failure));
     OutputXmlAttribute(
         stream, kTestsuite, "disabled",
         StreamableToString(test_suite.reportable_disabled_test_count()));
@@ -4440,18 +4445,38 @@ void XmlUnitTestResultPrinter::PrintXmlTestSuite(std::ostream* stream,
   *stream << "  </" << kTestsuite << ">\n";
 }
 
+// Counts the synthetic test cases that are output for failures recorded
+// outside of individual tests (e.g. in SetUpTestSuite or a global test
+// environment), so that they can be included in the aggregate counts.
+static int AdHocTestFailureCount(const UnitTest& unit_test) {
+  int count = unit_test.ad_hoc_test_result().Failed() ? 1 : 0;
+  for (int i = 0; i < unit_test.total_test_suite_count(); ++i) {
+    const TestSuite& test_suite = *unit_test.GetTestSuite(i);
+    if (test_suite.reportable_test_count() > 0 &&
+        test_suite.ad_hoc_test_result().Failed()) {
+      ++count;
+    }
+  }
+  return count;
+}
+
 // Prints an XML summary of unit_test to output stream out.
 void XmlUnitTestResultPrinter::PrintXmlUnitTest(std::ostream* stream,
                                                 const UnitTest& unit_test) {
   const std::string kTestsuites = "testsuites";
+  // Failures outside of individual tests are output as synthetic test cases,
+  // so include them in the counts.
+  const int ad_hoc_failures = AdHocTestFailureCount(unit_test);
 
   *stream << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
   *stream << "<" << kTestsuites;
 
-  OutputXmlAttribute(stream, kTestsuites, "tests",
-                     StreamableToString(unit_test.reportable_test_count()));
-  OutputXmlAttribute(stream, kTestsuites, "failures",
-                     StreamableToString(unit_test.failed_test_count()));
+  OutputXmlAttribute(
+      stream, kTestsuites, "tests",
+      StreamableToString(unit_test.reportable_test_count() + ad_hoc_failures));
+  OutputXmlAttribute(
+      stream, kTestsuites, "failures",
+      StreamableToString(unit_test.failed_test_count() + ad_hoc_failures));
   OutputXmlAttribute(
       stream, kTestsuites, "disabled",
       StreamableToString(unit_test.reportable_disabled_test_count()));
@@ -4874,14 +4899,17 @@ void JsonUnitTestResultPrinter::PrintJsonTestSuite(
     std::ostream* stream, const TestSuite& test_suite) {
   const std::string kTestsuite = "testsuite";
   const std::string kIndent = Indent(6);
+  // A failed ad hoc test result (e.g. a failure in SetUpTestSuite) is output
+  // as an extra test case below, so include it in the counts.
+  const int ad_hoc_failure = test_suite.ad_hoc_test_result().Failed() ? 1 : 0;
 
   *stream << Indent(4) << "{\n";
   OutputJsonKey(stream, kTestsuite, "name", test_suite.name(), kIndent);
-  OutputJsonKey(stream, kTestsuite, "tests", test_suite.reportable_test_count(),
-                kIndent);
+  OutputJsonKey(stream, kTestsuite, "tests",
+                test_suite.reportable_test_count() + ad_hoc_failure, kIndent);
   if (!GTEST_FLAG_GET(list_tests)) {
     OutputJsonKey(stream, kTestsuite, "failures",
-                  test_suite.failed_test_count(), kIndent);
+                  test_suite.failed_test_count() + ad_hoc_failure, kIndent);
     OutputJsonKey(stream, kTestsuite, "disabled",
                   test_suite.reportable_disabled_test_count(), kIndent);
     OutputJsonKey(stream, kTestsuite, "errors", 0, kIndent);
@@ -4927,12 +4955,15 @@ void JsonUnitTestResultPrinter::PrintJsonUnitTest(std::ostream* stream,
                                                   const UnitTest& unit_test) {
   const std::string kTestsuites = "testsuites";
   const std::string kIndent = Indent(2);
+  // Failures outside of individual tests are output as synthetic test cases,
+  // so include them in the counts.
+  const int ad_hoc_failures = AdHocTestFailureCount(unit_test);
   *stream << "{\n";
 
-  OutputJsonKey(stream, kTestsuites, "tests", unit_test.reportable_test_count(),
-                kIndent);
-  OutputJsonKey(stream, kTestsuites, "failures", unit_test.failed_test_count(),
-                kIndent);
+  OutputJsonKey(stream, kTestsuites, "tests",
+                unit_test.reportable_test_count() + ad_hoc_failures, kIndent);
+  OutputJsonKey(stream, kTestsuites, "failures",
+                unit_test.failed_test_count() + ad_hoc_failures, kIndent);
   OutputJsonKey(stream, kTestsuites, "disabled",
                 unit_test.reportable_disabled_test_count(), kIndent);
   OutputJsonKey(stream, kTestsuites, "errors", 0, kIndent);

--- a/googletest/test/googletest-json-output-unittest.py
+++ b/googletest/test/googletest-json-output-unittest.py
@@ -57,8 +57,8 @@ else:
   STACK_TRACE_TEMPLATE = '\n'
 
 EXPECTED_NON_EMPTY = {
-    'tests': 28,
-    'failures': 5,
+    'tests': 30,
+    'failures': 7,
     'disabled': 2,
     'errors': 0,
     'timestamp': '*',
@@ -423,8 +423,8 @@ EXPECTED_NON_EMPTY = {
         },
         {
             'name': 'SetupFailTest',
-            'tests': 1,
-            'failures': 0,
+            'tests': 2,
+            'failures': 1,
             'disabled': 0,
             'errors': 0,
             'time': '*',
@@ -463,8 +463,8 @@ EXPECTED_NON_EMPTY = {
         },
         {
             'name': 'TearDownFailTest',
-            'tests': 1,
-            'failures': 0,
+            'tests': 2,
+            'failures': 1,
             'disabled': 0,
             'errors': 0,
             'timestamp': '*',
@@ -667,8 +667,8 @@ EXPECTED_FILTERED = {
 }
 
 EXPECTED_NO_TEST = {
-    'tests': 0,
-    'failures': 0,
+    'tests': 1,
+    'failures': 1,
     'disabled': 0,
     'errors': 0,
     'time': '*',

--- a/googletest/test/gtest_xml_output_unittest.py
+++ b/googletest/test/gtest_xml_output_unittest.py
@@ -67,7 +67,7 @@ else:
   sys.argv.remove(NO_STACKTRACE_SUPPORT_FLAG)
 
 EXPECTED_NON_EMPTY_XML = """<?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="28" failures="5" disabled="2" errors="0" time="*" timestamp="*" name="AllTests">
+<testsuites tests="30" failures="7" disabled="2" errors="0" time="*" timestamp="*" name="AllTests">
   <properties>
     <property name="ad_hoc_property" value="42"/>
   </properties>
@@ -182,7 +182,7 @@ It is good practice to tell why you skip a test.
        </properties>
      </testcase>
   </testsuite>
-  <testsuite name="SetupFailTest" tests="1" failures="0" disabled="0" skipped="1" errors="0" time="*" timestamp="*">
+  <testsuite name="SetupFailTest" tests="2" failures="1" disabled="0" skipped="1" errors="0" time="*" timestamp="*">
     <testcase name="NoopPassingTest" file="gtest_xml_output_unittest_.cc" line="172" status="run" result="skipped" time="*" timestamp="*" classname="SetupFailTest">
       <skipped message="gtest_xml_output_unittest_.cc:*&#x0A;"><![CDATA[gtest_xml_output_unittest_.cc:*
 ]]></skipped>
@@ -194,7 +194,7 @@ Expected equality of these values:
   2%(stack)s]]></failure>
     </testcase>
   </testsuite>
-  <testsuite name="TearDownFailTest" tests="1" failures="0" disabled="0" skipped="0" errors="0" time="*" timestamp="*">
+  <testsuite name="TearDownFailTest" tests="2" failures="1" disabled="0" skipped="0" errors="0" time="*" timestamp="*">
     <testcase name="NoopPassingTest" file="gtest_xml_output_unittest_.cc" line="179" status="run" result="completed" time="*" timestamp="*" classname="TearDownFailTest"/>
     <testcase name="" status="run" result="completed" classname="" time="*" timestamp="*">
       <failure message="gtest_xml_output_unittest_.cc:*&#x0A;Expected equality of these values:&#x0A;  1&#x0A;  2%(stack_entity)s" type=""><![CDATA[gtest_xml_output_unittest_.cc:*
@@ -264,7 +264,7 @@ EXPECTED_SHARDED_TEST_XML = """<?xml version="1.0" encoding="UTF-8"?>
 </testsuites>"""
 
 EXPECTED_NO_TEST_XML = """<?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="0" failures="0" disabled="0" errors="0" time="*"
+<testsuites tests="1" failures="1" disabled="0" errors="0" time="*"
             timestamp="*" name="AllTests">
   <testsuite name="NonTestSuiteFailure" tests="1" failures="1" disabled="0" skipped="0" errors="0" time="*" timestamp="*">
     <testcase name="" status="run" result="completed" time="*" timestamp="*" classname="">


### PR DESCRIPTION
Fixes #4911

## Problem

Failures recorded outside of individual tests — in `SetUpTestSuite`, `TearDownTestSuite`, or a global test `Environment` — are already emitted in the XML/JSON reports as synthetic test cases (the `NonTestSuiteFailure` test suite, and extra unnamed test cases inside real suites). However, the aggregate `tests` and `failures` counts did not include them.

For the environment-failure example from #4911, the report produced by current `main` is:

```xml
<testsuites tests="1" failures="0" ...>
  <testsuite name="MyTest" tests="1" failures="0" ...>
    <testcase name="MyTestCase" ... result="skipped" .../>
  </testsuite>
  <testsuite name="NonTestSuiteFailure" tests="1" failures="1" ...>
    <testcase ...>
      <failure ...>PSEnvironment::SetUp fail</failure>
    </testcase>
  </testsuite>
</testsuites>
```

The binary exits non-zero and the report body contains a `<failure>`, yet the root element claims `failures="0"` — so any tool that reads the aggregate counts (which is the reliable way to parse these reports, per #4911) concludes the run passed. The same holds for JSON output, and for the per-suite counts when `SetUpTestSuite`/`TearDownTestSuite` fail: the suite gains a failing `<testcase>` but still reports `failures="0"` and a `tests` count one lower than the number of test cases it contains.

## Fix

Count the synthetic entries where they are emitted:

- `<testsuite>` `tests`/`failures` include the extra test case emitted for the suite's failed ad hoc result.
- `<testsuites>` `tests`/`failures` include all synthetic test cases, so the root totals equal the sum of the per-suite totals.
- Same for the JSON printer, which mirrors the XML structure.

Also adds a missing newline after the opening `<testsuite>` tag of the synthetic `NonTestSuiteFailure` suite, which was previously printed on the same line as its child `<testcase>`.

The existing golden files in `gtest_xml_output_unittest.py` and `googletest-json-output-unittest.py` are updated accordingly (`SetupFailTest`/`TearDownFailTest` now report `tests="2" failures="1"`, and the root counts follow).

Public API semantics (`UnitTest::failed_test_count()` etc.) are unchanged; only the report output is affected.

## Verification

- `gtest_xml_output_unittest`, `googletest-json-output-unittest`, and the full 45-test ctest suite pass (MSVC 19.51, Debug).
- Manually verified both scenarios (global environment `SetUp` failure, and `SetUpTestSuite` failure) produce reports where root totals equal the per-suite sums and `failures` is non-zero exactly when the binary exits non-zero.
