### PR TITLE
fix: initialize cxx_strict_flags before compiler branches

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -70,6 +70,7 @@ macro(config_compiler_and_linker)
   endif()
 
   fix_default_compiler_settings_()
+  set(cxx_strict_flags "")
   if (MSVC)
     # Newlines inside flags variables break CMake's NMake generator.
     # TODO(vladl@google.com): Add -RTCs and -RTCu to debug builds.


### PR DESCRIPTION
cxx_strict_flags was omitted in several compiler conditional blocks (such as MSVC, SunPro, XL, and HP), leading to a CMake developer warning about an uninitialized variable when dev warnings are enabled.

Fixes #4071