### PR TITLE
Prefer -pthread flag on CMake

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -63,6 +63,7 @@ macro(config_compiler_and_linker)
   unset(GTEST_HAS_PTHREAD)
   if (NOT gtest_disable_pthreads AND NOT MINGW)
     # Defines CMAKE_USE_PTHREADS_INIT and CMAKE_THREAD_LIBS_INIT.
+    set(THREADS_PREFER_PTHREAD_FLAG TRUE)
     find_package(Threads)
     if (CMAKE_USE_PTHREADS_INIT)
       set(GTEST_HAS_PTHREAD ON)


### PR DESCRIPTION
In the past, GoogleTest could not set this flag unconditionally as it would break CUDA on CMake versions older than 3.13. As the project now requires at least CMake 3.16, it's safe to enable and finally prefer -pthread to -lpthread.

This does not make any difference on systems with glibc 2.34 as newer, as libpthread is part of libc now.

Properly fixes #2482

Cc: @higher-performance 