### PR TITLE
Fix GetTestSuite(i) ignoring shuffle order

### DIFF
--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -587,7 +587,7 @@ class GTEST_API_ UnitTestImpl {
   // total_test_suite_count() - 1. If i is not in that range, returns NULL.
   const TestSuite* GetTestSuite(int i) const {
     const int index = GetElementOr(test_suite_indices_, i, -1);
-    return index < 0 ? nullptr : test_suites_[static_cast<size_t>(i)];
+    return index < 0 ? nullptr : test_suites_[static_cast<size_t>(index)];
   }
 
   //  Legacy API is deprecated but still available


### PR DESCRIPTION
## Summary

Fixes #5040

`UnitTestImpl::GetTestSuite(int i)` computes the shuffled index from `test_suite_indices_` but accesses `test_suites_` using the raw parameter `i` instead of the computed `index`. This causes `UnitTest::GetTestSuite(i)` to return suites in original registration order rather than the active shuffle order during execution.

## Changes

One-character fix: `test_suites_[static_cast<size_t>(i)]` → `test_suites_[static_cast<size_t>(index)]`

This matches the correct behavior in the mutable variant `GetMutableSuiteCase(i)` directly below it, and `TestSuite::GetTestInfo(i)` which also uses `index`.

## Testing

- Verified the fix resolves the mismatch between execution order and `GetTestSuite(i)` return value when `--gtest_shuffle` is active
- `gtest_unittest` tests pass
- `googletest-shuffle-test_` binary works correctly
