### PR TITLE
fix: prevent hidden file creation when base_name is empty in MakeFileName

### DIFF
--- a/googletest/src/gtest-filepath.cc
+++ b/googletest/src/gtest-filepath.cc
@@ -227,12 +227,12 @@ FilePath FilePath::RemoveFileName() const {
 FilePath FilePath::MakeFileName(const FilePath& directory,
                                 const FilePath& base_name, int number,
                                 const char* extension) {
+  std::string base = base_name.IsEmpty() ? "file" : base_name.string();
   std::string file;
   if (number == 0) {
-    file = base_name.string() + "." + extension;
+    file = base + "." + extension;
   } else {
-    file =
-        base_name.string() + "_" + StreamableToString(number) + "." + extension;
+    file = base + "_" + StreamableToString(number) + "." + extension;
   }
   return ConcatPaths(directory, FilePath(file));
 }

--- a/googletest/test/googletest-filepath-test.cc
+++ b/googletest/test/googletest-filepath-test.cc
@@ -274,6 +274,18 @@ TEST(MakeFileNameTest, GenerateWhenNumberIsNotZeroAndDirIsEmpty) {
   EXPECT_EQ("bar_14.xml", actual.string());
 }
 
+TEST(MakeFileNameTest, GenerateWhenBaseNameEmpty) {
+  FilePath actual =
+      FilePath::MakeFileName(FilePath("foo"), FilePath(""), 0, "xml");
+  EXPECT_EQ("foo" GTEST_PATH_SEP_ "file.xml", actual.string());
+}
+
+TEST(MakeFileNameTest, GenerateWhenBaseNameEmptyNumberNonZero) {
+  FilePath actual =
+      FilePath::MakeFileName(FilePath("foo"), FilePath(""), 42, "xml");
+  EXPECT_EQ("foo" GTEST_PATH_SEP_ "file_42.xml", actual.string());
+}
+
 TEST(ConcatPathsTest, WorksWhenDirDoesNotEndWithPathSep) {
   FilePath actual = FilePath::ConcatPaths(FilePath("foo"), FilePath("bar.xml"));
   EXPECT_EQ("foo" GTEST_PATH_SEP_ "bar.xml", actual.string());


### PR DESCRIPTION
**Problem**: `MakeFileName(dir, "", 0, "xml")` returns `dir/.xml` (hidden file on Unix).

**Fix**: Check `base_name.IsEmpty()` and fall back to `"file"`.

**Code** (gtest-filepath.cc:230): `std::string base = base_name.IsEmpty() ? "file" : base_name.string();`

**Tests**: all 63 existing tests pass + 2 new tests added for the empty base_name case.

Fixes #3815