### PR TITLE
Print char8_t/char16_t code units that aren't code points as code units

### DIFF
--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -524,17 +524,14 @@ inline void PrintTo(bool x, ::std::ostream* os) {
 GTEST_API_ void PrintTo(wchar_t wc, ::std::ostream* os);
 
 GTEST_API_ void PrintTo(char32_t c, ::std::ostream* os);
-inline void PrintTo(char16_t c, ::std::ostream* os) {
-  // TODO(b/418738869): Incorrect for values not representing valid codepoints.
-  // Also see https://github.com/google/googletest/issues/4762.
-  PrintTo(static_cast<char32_t>(c), os);
-}
+
+// Overloads for the UTF-8 and UTF-16 code unit types.  A code unit that
+// encodes a code point all by itself is printed with the U+XXXX notation;
+// one that does not (any non-ASCII char8_t, and the UTF-16 surrogates) is
+// printed as a code unit instead, the way wchar_t is.
+GTEST_API_ void PrintTo(char16_t c, ::std::ostream* os);
 #ifdef __cpp_lib_char8_t
-inline void PrintTo(char8_t c, ::std::ostream* os) {
-  // TODO(b/418738869): Incorrect for values not representing valid codepoints.
-  // Also see https://github.com/google/googletest/issues/4762.
-  PrintTo(static_cast<char32_t>(c), os);
-}
+GTEST_API_ void PrintTo(char8_t c, ::std::ostream* os);
 #endif
 
 // gcc/clang __{u,}int128_t

--- a/googletest/src/gtest-printers.cc
+++ b/googletest/src/gtest-printers.cc
@@ -285,6 +285,28 @@ void PrintTo(char32_t c, ::std::ostream* os) {
       << static_cast<uint32_t>(c);
 }
 
+// char8_t and char16_t hold code units, not code points, so the U+XXXX
+// notation only applies to the values that encode a code point on their own.
+// The rest -- non-ASCII char8_t, which are always part of a multi-unit UTF-8
+// sequence, and the UTF-16 surrogates -- are printed as code units.
+void PrintTo(char16_t c, ::std::ostream* os) {
+  if (c >= 0xD800 && c <= 0xDFFF) {
+    PrintCharAndCodeTo(c, os);
+  } else {
+    PrintTo(static_cast<char32_t>(c), os);
+  }
+}
+
+#ifdef __cpp_lib_char8_t
+void PrintTo(char8_t c, ::std::ostream* os) {
+  if (c >= 0x80) {
+    PrintCharAndCodeTo(c, os);
+  } else {
+    PrintTo(static_cast<char32_t>(c), os);
+  }
+}
+#endif
+
 // gcc/clang __{u,}int128_t
 #if defined(__SIZEOF_INT128__)
 void PrintTo(__uint128_t v, ::std::ostream* os) {

--- a/googletest/test/googletest-printers-test.cc
+++ b/googletest/test/googletest-printers-test.cc
@@ -395,12 +395,24 @@ TEST(PrintCharTest, UnsignedChar) {
   EXPECT_EQ("'b' (98, 0x62)", Print(static_cast<unsigned char>('b')));
 }
 
-TEST(PrintCharTest, Char16) { EXPECT_EQ("U+0041", Print(u'A')); }
+TEST(PrintCharTest, Char16) {
+  EXPECT_EQ("U+0041", Print(u'A'));
+  EXPECT_EQ("U+754C", Print(u'界'));
+  // Surrogates are not code points, so they are printed as code units.
+  EXPECT_EQ("u'\\xD800' (55296)", Print(static_cast<char16_t>(0xD800)));
+  EXPECT_EQ("u'\\xDFFF' (57343)", Print(static_cast<char16_t>(0xDFFF)));
+}
 
 TEST(PrintCharTest, Char32) { EXPECT_EQ("U+0041", Print(U'A')); }
 
 #ifdef __cpp_lib_char8_t
-TEST(PrintCharTest, Char8) { EXPECT_EQ("U+0041", Print(u8'A')); }
+TEST(PrintCharTest, Char8) {
+  EXPECT_EQ("U+0041", Print(u8'A'));
+  // Only ASCII code units encode a code point on their own; the rest are
+  // printed as code units.
+  EXPECT_EQ("u8'\\x80' (128)", Print(static_cast<char8_t>(0x80)));
+  EXPECT_EQ("u8'\\xFF' (255)", Print(static_cast<char8_t>(0xFF)));
+}
 #endif
 
 // Tests printing other simple, built-in types.
@@ -455,7 +467,7 @@ TEST(PrintBuiltInTypeTest, Integer) {
 #ifdef __cpp_lib_char8_t
   EXPECT_EQ("U+0000",
             Print(std::numeric_limits<char8_t>::min()));  // char8_t
-  EXPECT_EQ("U+00FF",
+  EXPECT_EQ("u8'\\xFF' (255)",
             Print(std::numeric_limits<char8_t>::max()));  // char8_t
 #endif
   EXPECT_EQ("U+0000",


### PR DESCRIPTION
Fixes #4762.

### Problem

`PrintTo(char8_t)` and `PrintTo(char16_t)` widen their argument to `char32_t` and print it with the `U+XXXX` notation:

```cpp
inline void PrintTo(char8_t c, ::std::ostream* os) {
  // TODO(b/418738869): Incorrect for values not representing valid codepoints.
  // Also see https://github.com/google/googletest/issues/4762.
  PrintTo(static_cast<char32_t>(c), os);
}
```

`U+XXXX` names a *code point*, but `char8_t` and `char16_t` hold *code units*, so the notation is wrong for every value that does not encode a code point on its own:

* any non-ASCII `char8_t` — those are always part of a multi-unit UTF-8 sequence, never a code point;
* the UTF-16 surrogates `D800`–`DFFF` — reserved, and not code points in isolation.

So `PrintTo(char8_t(0x80))` printed `U+0080`, the code point of a character that value cannot represent. ([compiler explorer repro from the issue](https://compiler-explorer.com/z/xE56jbK5M))

### Fix

@higher-performance asked in the issue whether there is a well-known notation for these. There is one already in this file: the escape-plus-code form `PrintCharAndCodeTo()` uses for `char`, `unsigned char` and `wchar_t`. `wchar_t` is the closest precedent — also a code unit type, also holds values that aren't code points, and it has always been printed this way. Reusing it means no new output format to specify, and no new code beyond the branch itself.

Values that *do* encode a code point keep the `U+XXXX` notation, so the common case is unchanged:

| value | before | after |
|---|---|---|
| `u8'A'` | `U+0041` | `U+0041` |
| `char8_t(0x80)` | `U+0080` | `u8'\x80' (128)` |
| `char8_t(0xFF)` | `U+00FF` | `u8'\xFF' (255)` |
| `u'A'` | `U+0041` | `U+0041` |
| `u'界'` | `U+754C` | `U+754C` |
| `char16_t(0xD800)` | `U+D800` | `u'\xD800' (55296)` |

`PrintTo(char32_t)` is left alone — this PR sticks to the two overloads the issue names.

The two overloads move from the header to `gtest-printers.cc` (as `GTEST_API_`, like the existing `PrintTo(char32_t)` and `PrintTo(unsigned char)`) so they can reach `PrintCharAndCodeTo()`.

### Testing

Extended `PrintCharTest.Char8` / `PrintCharTest.Char16` with the non-code-point values, and updated the one `PrintBuiltInTypeTest.Integer` expectation that covered `char8_t`'s max. Full `ctest` suite (62/62) passes at `-DCMAKE_CXX_STANDARD=20`, so the `__cpp_lib_char8_t` branch is exercised; also built at the default standard where that branch is compiled out.
