### PR TITLE
docs: document MOCK_METHOD argument limit

### DIFF
--- a/docs/gmock_cook_book.md
+++ b/docs/gmock_cook_book.md
@@ -15,6 +15,8 @@ brevity, but you should do it in your own code.
 Mock classes are defined as normal classes, using the `MOCK_METHOD` macro to
 generate mocked methods. The macro gets 3 or 4 parameters:
 
+Note that a mocked method can have at most 31 arguments.
+
 ```cpp
 class MyMock {
  public:

--- a/docs/reference/mocking.md
+++ b/docs/reference/mocking.md
@@ -16,6 +16,8 @@ GoogleTest defines the following macros for working with mocks.
 Defines a mock method *`method_name`* with arguments `(`*`args...`*`)` and
 return type *`return_type`* within a mock class.
 
+The number of arguments is limited to 31.
+
 The parameters of `MOCK_METHOD` mirror the method declaration. The optional
 fourth parameter *`specs...`* is a comma-separated list of qualifiers. The
 following qualifiers are accepted:


### PR DESCRIPTION
## Problem

Fixes #4608

MOCK_METHOD macro has a hard limit on the number of arguments it accepts (15 before commit `dc3c9ed`, now 31 after it doubled the limit), but this limit is nowhere documented. Users hit confusing compile errors when exceeding it.

## Solution

Document the 31-argument limit in both documentation locations that describe MOCK_METHOD:

- `docs/gmock_cook_book.md` — adds a note in the mock class definition section
- `docs/reference/mocking.md` — adds the note right after the MOCK_METHOD description where `args...` is defined

## Testing

Limit verified against upstream test added in dc3c9ed (gmock-function-mocker_test.cc defines 32 MOCK_METHODs covering 0-31 args). Documentation-only change; no code or tests modified.