### PR TITLE
gmock: Add `ignore` value to `--gmock_verbose` flag (#5047)

### DIFF
--- a/docs/gmock_cheat_sheet.md
+++ b/docs/gmock_cheat_sheet.md
@@ -238,4 +238,4 @@ it.
 | Flag                           | Description                               |
 | :----------------------------- | :---------------------------------------- |
 | `--gmock_catch_leaked_mocks=0` | Don't report leaked mock objects as failures. |
-| `--gmock_verbose=LEVEL` | Sets the default verbosity level (`info`, `warning`, or `error`) of Google Mock messages. |
+| `--gmock_verbose=LEVEL` | Sets the default verbosity level (`info`, `warning`, `error`, or `ignore`) of Google Mock messages. |

--- a/docs/gmock_cook_book.md
+++ b/docs/gmock_cook_book.md
@@ -3161,7 +3161,7 @@ observe every mock call that happens (including argument values, the return
 value, and the stack trace). Clearly, one size doesn't fit all.
 
 You can control how much gMock tells you using the `--gmock_verbose=LEVEL`
-command-line flag, where `LEVEL` is a string with three possible values:
+command-line flag, where `LEVEL` is a string with four possible values:
 
 *   `info`: gMock will print all informational messages, warnings, and errors
     (most verbose). At this setting, gMock will also log any calls to the
@@ -3170,6 +3170,7 @@ command-line flag, where `LEVEL` is a string with three possible values:
 *   `warning`: gMock will print both warnings and errors (less verbose); it will
     omit the stack traces in "uninteresting call" warnings. This is the default.
 *   `error`: gMock will print errors only (least verbose).
+*   `ignore`: gMock will suppress warnings (same as `error`).
 
 Alternatively, you can adjust the value of that flag from within your tests like
 so:

--- a/docs/gmock_faq.md
+++ b/docs/gmock_faq.md
@@ -265,7 +265,7 @@ using ::testing::_;
 
 This tells gMock that you do expect the calls and no warning should be printed.
 
-Also, you can control the verbosity by specifying `--gmock_verbose=error`. Other
+Also, you can control the verbosity by specifying `--gmock_verbose=error` or `--gmock_verbose=ignore`. Other
 values are `info` and `warning`. If you find the output too noisy when
 debugging, just choose a less verbose level.
 

--- a/googlemock/include/gmock/internal/gmock-internal-utils.h
+++ b/googlemock/include/gmock/internal/gmock-internal-utils.h
@@ -276,6 +276,8 @@ const char kInfoVerbosity[] = "info";
 const char kWarningVerbosity[] = "warning";
 // No logs are printed.
 const char kErrorVerbosity[] = "error";
+// No logs are printed.
+const char kIgnoreVerbosity[] = "ignore";
 
 // Returns true if and only if a log with the given severity is visible
 // according to the --gmock_verbose flag.

--- a/googlemock/src/gmock-internal-utils.cc
+++ b/googlemock/src/gmock-internal-utils.cc
@@ -134,8 +134,9 @@ GTEST_API_ bool LogIsVisible(LogSeverity severity) {
   if (GMOCK_FLAG_GET(verbose) == kInfoVerbosity) {
     // Always show the log if --gmock_verbose=info.
     return true;
-  } else if (GMOCK_FLAG_GET(verbose) == kErrorVerbosity) {
-    // Always hide it if --gmock_verbose=error.
+  } else if (GMOCK_FLAG_GET(verbose) == kErrorVerbosity ||
+             GMOCK_FLAG_GET(verbose) == kIgnoreVerbosity) {
+    // Always hide it if --gmock_verbose=error or --gmock_verbose=ignore.
     return false;
   } else {
     // If --gmock_verbose is neither "info" nor "error", we treat it

--- a/googlemock/src/gmock.cc
+++ b/googlemock/src/gmock.cc
@@ -42,7 +42,8 @@ GMOCK_DEFINE_string_(verbose, testing::internal::kWarningVerbosity,
                      "  Valid values:\n"
                      "  info    - prints all messages.\n"
                      "  warning - prints warnings and errors.\n"
-                     "  error   - prints errors only.");
+                     "  error   - prints errors only.\n"
+                     "  ignore  - prints no messages.");
 
 GMOCK_DEFINE_int32_(default_mock_behavior, 1,
                     "Controls the default behavior of mocks."

--- a/googlemock/test/gmock-internal-utils_test.cc
+++ b/googlemock/test/gmock-internal-utils_test.cc
@@ -495,6 +495,13 @@ TEST(LogTest, NoLogsArePrintedWhenVerbosityIsError) {
   TestLogWithSeverity(kErrorVerbosity, kWarning, false);
 }
 
+// Tests that no logs are printed when the value of the
+// --gmock_verbose flag is "ignore".
+TEST(LogTest, NoLogsArePrintedWhenVerbosityIsIgnore) {
+  TestLogWithSeverity(kIgnoreVerbosity, kInfo, false);
+  TestLogWithSeverity(kIgnoreVerbosity, kWarning, false);
+}
+
 // Tests that only warnings are printed when the value of the
 // --gmock_verbose flag is invalid.
 TEST(LogTest, OnlyWarningsArePrintedWhenVerbosityIsInvalid) {
@@ -543,6 +550,12 @@ TEST(ExpectCallTest, DoesNotLogWhenVerbosityIsError) {
   EXPECT_STREQ("", GrabOutput(ExpectCallLogger, kErrorVerbosity).c_str());
 }
 
+// Verifies that EXPECT_CALL doesn't log
+// if the --gmock_verbose flag is set to "ignore".
+TEST(ExpectCallTest, DoesNotLogWhenVerbosityIsIgnore) {
+  EXPECT_STREQ("", GrabOutput(ExpectCallLogger, kIgnoreVerbosity).c_str());
+}
+
 void OnCallLogger() {
   DummyMock mock;
   (void)ON_CALL(mock, TestMethod());
@@ -564,6 +577,12 @@ TEST(OnCallTest, DoesNotLogWhenVerbosityIsWarning) {
 // the --gmock_verbose flag is set to "error".
 TEST(OnCallTest, DoesNotLogWhenVerbosityIsError) {
   EXPECT_STREQ("", GrabOutput(OnCallLogger, kErrorVerbosity).c_str());
+}
+
+// Verifies that ON_CALL doesn't log if
+// the --gmock_verbose flag is set to "ignore".
+TEST(OnCallTest, DoesNotLogWhenVerbosityIsIgnore) {
+  EXPECT_STREQ("", GrabOutput(OnCallLogger, kIgnoreVerbosity).c_str());
 }
 
 void OnCallAnyArgumentLogger() {

--- a/googlemock/test/gmock-spec-builders_test.cc
+++ b/googlemock/test/gmock-spec-builders_test.cc
@@ -52,6 +52,7 @@ using ::testing::internal::FormatFileLocation;
 using ::testing::internal::kAllow;
 using ::testing::internal::kErrorVerbosity;
 using ::testing::internal::kFail;
+using ::testing::internal::kIgnoreVerbosity;
 using ::testing::internal::kInfoVerbosity;
 using ::testing::internal::kWarn;
 using ::testing::internal::kWarningVerbosity;
@@ -2091,10 +2092,18 @@ TEST_F(GMockVerboseFlagTest, Warning) {
   TestUninterestingCallOnNaggyMock(true);
 }
 
-// Tests that --gmock_verbose=warning causes neither expected nor
+// Tests that --gmock_verbose=error causes neither expected nor
 // uninteresting calls to be reported.
 TEST_F(GMockVerboseFlagTest, Error) {
   GMOCK_FLAG_SET(verbose, kErrorVerbosity);
+  TestExpectedCall(false);
+  TestUninterestingCallOnNaggyMock(false);
+}
+
+// Tests that --gmock_verbose=ignore causes neither expected nor
+// uninteresting calls to be reported.
+TEST_F(GMockVerboseFlagTest, Ignore) {
+  GMOCK_FLAG_SET(verbose, kIgnoreVerbosity);
   TestExpectedCall(false);
   TestUninterestingCallOnNaggyMock(false);
 }

--- a/googlemock/test/gmock_test.cc
+++ b/googlemock/test/gmock_test.cc
@@ -115,6 +115,14 @@ TEST(InitGoogleMockTest, ParsesGoogleMockFlagAndUnrecognizedFlag) {
   TestInitGoogleMock(argv, new_argv, "error");
 }
 
+TEST(InitGoogleMockTest, ParsesIgnoreVerboseFlag) {
+  const char* argv[] = {"foo.exe", "--gmock_verbose=ignore", nullptr};
+
+  const char* new_argv[] = {"foo.exe", nullptr};
+
+  TestInitGoogleMock(argv, new_argv, "ignore");
+}
+
 TEST(WideInitGoogleMockTest, ParsesInvalidCommandLine) {
   const wchar_t* argv[] = {nullptr};
 


### PR DESCRIPTION
### Summary of Changes

Adds `ignore` as a valid option for the `--gmock_verbose` command-line flag (e.g., `--gmock_verbose=ignore` or `::testing::FLAGS_gmock_verbose = "ignore"`). 

When set to `ignore`, GoogleMock suppresses informational messages and warnings (such as "Uninteresting mock function call"), behaving identically to `error`. This provides a cleaner test output when users are running repeated tests or inspecting custom log output without warning noise.

Fixes #5047.

### Key Changes
- **Core Implementation**: Added `kIgnoreVerbosity` constant in `googlemock/include/gmock/internal/gmock-internal-utils.h` and updated `LogIsVisible()` in `googlemock/src/gmock-internal-utils.cc` to evaluate `ignore`.
- **Flag Definition**: Updated `gmock_verbose` flag help string in `googlemock/src/gmock.cc`.
- **Tests**:
  - `googlemock/test/gmock-internal-utils_test.cc`: Added tests for `LogTest`, `ExpectCallTest`, and `OnCallTest` with `kIgnoreVerbosity`.
  - `googlemock/test/gmock-spec-builders_test.cc`: Added `GMockVerboseFlagTest.Ignore` test case.
  - `googlemock/test/gmock_test.cc`: Added CLI flag parsing unit test for `--gmock_verbose=ignore`.
- **Documentation**: Updated `gmock_cheat_sheet.md`, `gmock_cook_book.md`, and `gmock_faq.md`.

### CLA
I have signed the Google Contributor License Agreement (CLA).

### Verification
All unit tests have been added and structured to match existing `gmock_verbose` level tests. Code conforms to Google C++ Style Guide and formatting guidelines.