### PR TITLE
Fix issue #5042: Don't override VC++ project C runtime library settings when googletest is used through cmake FetchContent or add_subdirectory

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -71,7 +71,8 @@ macro(config_compiler_and_linker)
     # as static libraries, as we don't have to rely on CRT DLLs being available.
     # CMake always defaults to using shared CRT libraries, so we override that
     # default here.
-    if (NOT BUILD_SHARED_LIBS AND NOT gtest_force_shared_crt AND NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
+    if (NOT BUILD_SHARED_LIBS AND NOT gtest_force_shared_crt AND NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY
+        AND CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
       set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     endif()
 


### PR DESCRIPTION
Check if googletest is top-level project before overriding VC++ CRT selection. This keeps the override for standalone library builds and allows googletest used through FetchContent and add_subdirectory in cmake projects to honor project defaults.

There is a more explicit check in cmake 3.21 than comparing project directory names - `PROJECT_IS_TOP_LEVEL` - it could be used if the minimum supported cmake version is bumped up from 3.16

Fixes issue #5042 