### PR TITLE
Fix -Wunused-template warnings

### DIFF
--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -6028,8 +6028,8 @@ PolymorphicMatcher<internal::ExceptionMatcherImpl<Err>> ThrowsMessage(
     };                                                                         \
   };                                                                           \
   template <GMOCK_INTERNAL_MATCHER_TEMPLATE_PARAMS(args)>                      \
-  inline full_name<GMOCK_INTERNAL_MATCHER_TYPE_PARAMS(args)> name(             \
-      GMOCK_INTERNAL_MATCHER_FUNCTION_ARGS(args)) {                            \
+  [[maybe_unused]] inline full_name<GMOCK_INTERNAL_MATCHER_TYPE_PARAMS(args)>  \
+  name(GMOCK_INTERNAL_MATCHER_FUNCTION_ARGS(args)) {                           \
     return full_name<GMOCK_INTERNAL_MATCHER_TYPE_PARAMS(args)>(                \
         GMOCK_INTERNAL_MATCHER_ARGS_USAGE(args));                              \
   }                                                                            \

--- a/googlemock/test/gmock-matchers-arithmetic_test.cc
+++ b/googlemock/test/gmock-matchers-arithmetic_test.cc
@@ -1659,7 +1659,7 @@ MATCHER(M, "") {
 }
 
 template <typename T1, typename T2>
-bool AllOf(const T1& /*t1*/, const T2& /*t2*/) {
+[[maybe_unused]] bool AllOf(const T1& /*t1*/, const T2& /*t2*/) {
   return true;
 }
 
@@ -1669,7 +1669,7 @@ TEST(AllOfTest, DoesNotCallAllOfUnqualified) {
 }
 
 template <typename T1, typename T2>
-bool AnyOf(const T1&, const T2&) {
+[[maybe_unused]] bool AnyOf(const T1&, const T2&) {
   return true;
 }
 

--- a/googlemock/test/gmock-matchers-comparisons_test.cc
+++ b/googlemock/test/gmock-matchers-comparisons_test.cc
@@ -586,7 +586,7 @@ namespace convertible_from_any {
 struct ConvertibleFromAny {
   ConvertibleFromAny(int a_value) : value(a_value) {}
   template <typename T>
-  ConvertibleFromAny(const T& /*a_value*/) : value(-1) {
+  [[maybe_unused]] ConvertibleFromAny(const T& /*a_value*/) : value(-1) {
     ADD_FAILURE() << "Conversion constructor called";
   }
   int value;

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -330,7 +330,7 @@ inline void Shuffle(internal::Random* random, std::vector<E>* v) {
 // A function for deleting an object.  Handy for being used as a
 // functor.
 template <typename T>
-static void Delete(T* x) {
+inline void Delete(T* x) {
   delete x;
 }
 


### PR DESCRIPTION
Clang 23 turns on this warning under -Wall.
https://github.com/llvm/llvm-project/blob/release/23.x/clang/docs/ReleaseNotes.md?plain=1#L602