### PR TITLE
Add --gtest_list_tests_flat for script-friendly test listing

### DIFF
--- a/googletest/include/gtest/gtest.h
+++ b/googletest/include/gtest/gtest.h
@@ -110,6 +110,9 @@ GTEST_DECLARE_bool_(install_failure_signal_handler);
 // are actually run if the flag is provided.
 GTEST_DECLARE_bool_(list_tests);
 
+// Like list_tests, but prints one fully-qualified name (Suite.Test) per line.
+GTEST_DECLARE_bool_(list_tests_flat);
+
 // This flag controls whether Google Test emits a detailed XML report to a file
 // in addition to its normal textual output.
 GTEST_DECLARE_string_(output);

--- a/googletest/src/gtest-internal-inl.h
+++ b/googletest/src/gtest-internal-inl.h
@@ -152,6 +152,7 @@ class GTestFlagSaver {
     filter_ = GTEST_FLAG_GET(filter);
     internal_run_death_test_ = GTEST_FLAG_GET(internal_run_death_test);
     list_tests_ = GTEST_FLAG_GET(list_tests);
+    list_tests_flat_ = GTEST_FLAG_GET(list_tests_flat);
     output_ = GTEST_FLAG_GET(output);
     brief_ = GTEST_FLAG_GET(brief);
     print_time_ = GTEST_FLAG_GET(print_time);
@@ -178,6 +179,7 @@ class GTestFlagSaver {
     GTEST_FLAG_SET(fail_fast, fail_fast_);
     GTEST_FLAG_SET(internal_run_death_test, internal_run_death_test_);
     GTEST_FLAG_SET(list_tests, list_tests_);
+    GTEST_FLAG_SET(list_tests_flat, list_tests_flat_);
     GTEST_FLAG_SET(output, output_);
     GTEST_FLAG_SET(brief, brief_);
     GTEST_FLAG_SET(print_time, print_time_);
@@ -204,6 +206,7 @@ class GTestFlagSaver {
   std::string filter_;
   std::string internal_run_death_test_;
   bool list_tests_;
+  bool list_tests_flat_;
   std::string output_;
   bool brief_;
   bool print_time_;

--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -322,6 +322,11 @@ GTEST_DEFINE_bool_(
 
 GTEST_DEFINE_bool_(list_tests, false, "List all tests without running them.");
 
+GTEST_DEFINE_bool_(
+    list_tests_flat, testing::internal::BoolFromGTestEnv("list_tests_flat", false),
+    "List all tests without running them, printing one fully-qualified name "
+    "(Suite.Test) per line. Implies --gtest_list_tests.");
+
 // The net priority order after flag processing is thus:
 //   --gtest_output command line flag
 //   GTEST_OUTPUT environment variable
@@ -6005,8 +6010,8 @@ bool UnitTestImpl::RunAllTests() {
       FilterTests(should_shard ? HONOR_SHARDING_PROTOCOL
                                : IGNORE_SHARDING_PROTOCOL) > 0;
 
-  // Lists the tests and exits if the --gtest_list_tests flag was specified.
-  if (GTEST_FLAG_GET(list_tests)) {
+  // Lists the tests and exits if a list-tests flag was specified.
+  if (GTEST_FLAG_GET(list_tests) || GTEST_FLAG_GET(list_tests_flat)) {
     // This must be called *after* FilterTests() has been called.
     ListTestsMatchingFilter();
     return true;
@@ -6390,8 +6395,19 @@ static void PrintOnOneLine(const char* str, int max_length) {
 void UnitTestImpl::ListTestsMatchingFilter() {
   // Print at most this many characters for each type/value parameter.
   const int kMaxParamLength = 250;
+  const bool flat_list = GTEST_FLAG_GET(list_tests_flat);
 
   for (auto* test_suite : test_suites_) {
+    if (flat_list) {
+      for (size_t j = 0; j < test_suite->test_info_list().size(); j++) {
+        const TestInfo* const test_info = test_suite->test_info_list()[j];
+        if (test_info->matches_filter_) {
+          printf("%s.%s\n", test_suite->name(), test_info->name());
+        }
+      }
+      continue;
+    }
+
     bool printed_test_suite_name = false;
 
     for (size_t j = 0; j < test_suite->test_info_list().size(); j++) {
@@ -6708,6 +6724,10 @@ static const char kColorEncodedHelpMessage[] =
     "      List the names of all tests instead of running them. The name of\n"
     "      TEST(Foo, Bar) is \"Foo.Bar\".\n"
     "  @G--" GTEST_FLAG_PREFIX_
+    "list_tests_flat@D\n"
+    "      Like --gtest_list_tests, but print one fully-qualified test name\n"
+    "      (Suite.Test) per line for easy parsing by scripts.\n"
+    "  @G--" GTEST_FLAG_PREFIX_
     "filter=@YPOSITIVE_PATTERNS"
     "[@G-@YNEGATIVE_PATTERNS]@D\n"
     "      Run only the tests whose name matches one of the positive patterns "
@@ -6830,6 +6850,7 @@ static bool ParseGoogleTestFlag(const char* const arg) {
   GTEST_INTERNAL_PARSE_FLAG(filter);
   GTEST_INTERNAL_PARSE_FLAG(internal_run_death_test);
   GTEST_INTERNAL_PARSE_FLAG(list_tests);
+  GTEST_INTERNAL_PARSE_FLAG(list_tests_flat);
   GTEST_INTERNAL_PARSE_FLAG(output);
   GTEST_INTERNAL_PARSE_FLAG(brief);
   GTEST_INTERNAL_PARSE_FLAG(print_time);

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -1626,6 +1626,7 @@ class GTestFlagSaverTest : public Test {
     GTEST_FLAG_SET(fail_fast, false);
     GTEST_FLAG_SET(filter, "");
     GTEST_FLAG_SET(list_tests, false);
+    GTEST_FLAG_SET(list_tests_flat, false);
     GTEST_FLAG_SET(output, "");
     GTEST_FLAG_SET(brief, false);
     GTEST_FLAG_SET(print_time, true);
@@ -5574,6 +5575,7 @@ struct Flags {
         fail_fast(false),
         filter(""),
         list_tests(false),
+        list_tests_flat(false),
         output(""),
         brief(false),
         print_time(true),
@@ -5640,6 +5642,14 @@ struct Flags {
   static Flags ListTests(bool list_tests) {
     Flags flags;
     flags.list_tests = list_tests;
+    return flags;
+  }
+
+  // Creates a Flags struct where the gtest_list_tests_flat flag has the
+  // given value.
+  static Flags ListTestsFlat(bool list_tests_flat) {
+    Flags flags;
+    flags.list_tests_flat = list_tests_flat;
     return flags;
   }
 
@@ -5733,6 +5743,7 @@ struct Flags {
   bool fail_fast;
   const char* filter;
   bool list_tests;
+  bool list_tests_flat;
   const char* output;
   bool brief;
   bool print_time;
@@ -5757,6 +5768,7 @@ class ParseFlagsTest : public Test {
     GTEST_FLAG_SET(fail_fast, false);
     GTEST_FLAG_SET(filter, "");
     GTEST_FLAG_SET(list_tests, false);
+    GTEST_FLAG_SET(list_tests_flat, false);
     GTEST_FLAG_SET(output, "");
     GTEST_FLAG_SET(brief, false);
     GTEST_FLAG_SET(print_time, true);
@@ -5791,6 +5803,7 @@ class ParseFlagsTest : public Test {
     EXPECT_EQ(expected.fail_fast, GTEST_FLAG_GET(fail_fast));
     EXPECT_STREQ(expected.filter, GTEST_FLAG_GET(filter).c_str());
     EXPECT_EQ(expected.list_tests, GTEST_FLAG_GET(list_tests));
+    EXPECT_EQ(expected.list_tests_flat, GTEST_FLAG_GET(list_tests_flat));
     EXPECT_STREQ(expected.output, GTEST_FLAG_GET(output).c_str());
     EXPECT_EQ(expected.brief, GTEST_FLAG_GET(brief));
     EXPECT_EQ(expected.print_time, GTEST_FLAG_GET(print_time));
@@ -6036,6 +6049,15 @@ TEST_F(ParseFlagsTest, ListTestsFalse_F) {
   const char* argv2[] = {"foo.exe", nullptr};
 
   GTEST_TEST_PARSING_FLAGS_(argv, argv2, Flags::ListTests(false), false);
+}
+
+// Tests having a --gtest_list_tests_flat flag
+TEST_F(ParseFlagsTest, ListTestsFlatFlag) {
+  const char* argv[] = {"foo.exe", "--gtest_list_tests_flat", nullptr};
+
+  const char* argv2[] = {"foo.exe", nullptr};
+
+  GTEST_TEST_PARSING_FLAGS_(argv, argv2, Flags::ListTestsFlat(true), false);
 }
 
 // Tests parsing --gtest_output=xml


### PR DESCRIPTION
Fixes #3822

## Summary

- Add `--gtest_list_tests_flat` to print one fully-qualified test name (`Suite.Test`) per line.
- Useful for shell/awk-based tooling that cannot easily parse the hierarchical list format.

## Test plan

- [ ] Run a test binary with `--gtest_list_tests_flat` and verify one test name per line.
- [ ] Verify `--gtest_filter` still applies when listing tests in flat mode.
