### PR TITLE
feat(printers): GTEST_MAX_NUM_ELEMENTS_TO_PRINT override (#4905)

### DIFF
--- a/googletest/include/gtest/gtest-printers.h
+++ b/googletest/include/gtest/gtest-printers.h
@@ -163,6 +163,9 @@ struct IsStdSpan<std::span<E>> {
 // the presence of const_iterator to avoid treating iterators as containers
 // because of iterator::iterator. Which means std::span satisfies the *intended*
 // condition of IsContainerTest.
+#ifndef GTEST_MAX_NUM_ELEMENTS_TO_PRINT
+#define GTEST_MAX_NUM_ELEMENTS_TO_PRINT 32
+#endif
 struct ContainerPrinter {
   template <typename T,
             typename = typename std::enable_if<
@@ -170,7 +173,8 @@ struct ContainerPrinter {
                  !IsRecursiveContainer<T>::value) ||
                 IsStdSpan<T>::value>::type>
   static void PrintValue(const T& container, std::ostream* os) {
-    const size_t kMaxCount = 32;  // The maximum number of elements to print.
+    const size_t kMaxCount =
+        static_cast<size_t>(GTEST_MAX_NUM_ELEMENTS_TO_PRINT);
     *os << '{';
     size_t count = 0;
     for (auto&& elem : container) {


### PR DESCRIPTION
## Summary
Allows overriding the container print limit via `GTEST_MAX_NUM_ELEMENTS_TO_PRINT` (default remains 32) as requested in #4905.

```cpp
#define GTEST_MAX_NUM_ELEMENTS_TO_PRINT 81
#include <gtest/gtest.h>
```

## Test plan
- [ ] Default build still truncates at 32 elements with `...`
- [ ] With a higher macro value, larger containers print fully

Closes #4905
