### PR TITLE
feat(macros): discard [[nodiscard]] in EXPECT/ASSERT_THROW (#4679)

### DIFF
--- a/googletest/include/gtest/internal/gtest-internal.h
+++ b/googletest/include/gtest/internal/gtest-internal.h
@@ -1373,7 +1373,9 @@ class [[nodiscard]] NeverThrown {
   if (::testing::internal::TrueWithString gtest_msg{}) {                    \
     bool gtest_caught_expected = false;                                     \
     try {                                                                   \
-      GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement);            \
+      /* Discard [[nodiscard]] results: return value is unused if thrown. */ \
+      GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(                       \
+          static_cast<void>(statement));                                    \
     } catch (expected_exception const&) {                                   \
       gtest_caught_expected = true;                                         \
     }                                                                       \
@@ -1435,7 +1437,8 @@ class [[nodiscard]] NeverThrown {
   if (::testing::internal::AlwaysTrue()) {                           \
     bool gtest_caught_any = false;                                   \
     try {                                                            \
-      GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement);     \
+      GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(                \
+          static_cast<void>(statement));                             \
     } catch (...) {                                                  \
       gtest_caught_any = true;                                       \
     }                                                                \


### PR DESCRIPTION
## Summary
Makes `EXPECT_THROW` / `ASSERT_THROW` / `EXPECT_ANY_THROW` / `ASSERT_ANY_THROW` discard `[[nodiscard]]` return values (#4679).

Only the `*_THROW` / `*_ANY_THROW` paths use `static_cast<void>(statement)`. `*_NO_THROW` is unchanged so nodiscard warnings remain visible when the call is expected to return.

## Test plan
- [ ] `ASSERT_THROW(nodiscard_fn(), Ex)` compiles without nodiscard warnings
- [ ] `ASSERT_NO_THROW(nodiscard_fn())` still warns without an explicit discard
- [ ] Existing throw assertion tests pass

Closes #4679
