### PR TITLE
cmake: Centralize MinGW/Cygwin -Wa,-mbig-obj test workaround

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -131,10 +131,6 @@ if (gmock_build_tests)
   # 'make test' or ctest.
   enable_testing()
 
-  if (MINGW OR CYGWIN)
-    add_compile_options("-Wa,-mbig-obj")
-  endif()
-
   ############################################################
   # C++ tests built with standard compiler flags.
 

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -237,6 +237,13 @@ function(cxx_executable_with_flags name cxx_flags libs)
   if (MSVC)
     # BigObj required for tests.
     set(cxx_flags "${cxx_flags} -bigobj")
+  elseif (MINGW OR CYGWIN)
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
+        CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      # MinGW and Cygwin use the GNU assembler, which has a 2^16 section limit.
+      # Large generated test executables exceed this limit, so raise it.
+      set(cxx_flags "${cxx_flags} -Wa,-mbig-obj")
+    endif()
   endif()
   if (cxx_flags)
     set_target_properties(${name}


### PR DESCRIPTION
While reviewing the build files, I noticed googlemock already worked around MinGW/Cygwin assembler section limits with -Wa,-mbig-obj, but googletest was missing the same fix. 

This patch centralizes that workaround in cxx_executable_with_flags, removes the duplicate from googlemock, and only affects test-related targets. All 62 tests pass.

