### PR TITLE
Add ignore verbosity level to gMock

### DIFF
--- a/googlemock/include/gmock/internal/gmock-internal-utils.h
+++ b/googlemock/include/gmock/internal/gmock-internal-utils.h
@@ -276,6 +276,8 @@ const char kInfoVerbosity[] = "info";
 const char kWarningVerbosity[] = "warning";
 // No logs are printed.
 const char kErrorVerbosity[] = "error";
+// No logs are printed.
+const char kIgnoreVerbosity[] = "ignore";
 
 // Returns true if and only if a log with the given severity is visible
 // according to the --gmock_verbose flag.

--- a/googlemock/src/gmock-internal-utils.cc
+++ b/googlemock/src/gmock-internal-utils.cc
@@ -134,12 +134,13 @@ GTEST_API_ bool LogIsVisible(LogSeverity severity) {
   if (GMOCK_FLAG_GET(verbose) == kInfoVerbosity) {
     // Always show the log if --gmock_verbose=info.
     return true;
-  } else if (GMOCK_FLAG_GET(verbose) == kErrorVerbosity) {
-    // Always hide it if --gmock_verbose=error.
+  } else if (GMOCK_FLAG_GET(verbose) == kErrorVerbosity ||
+             GMOCK_FLAG_GET(verbose) == kIgnoreVerbosity) {
+    // Always hide it if --gmock_verbose=error or --gmock_verbose=ignore.
     return false;
   } else {
-    // If --gmock_verbose is neither "info" nor "error", we treat it
-    // as "warning" (its default value).
+    // If --gmock_verbose is neither "info", "error", nor "ignore",
+    // we treat it as "warning" (its default value).
     return severity == kWarning;
   }
 }


### PR DESCRIPTION
## Summary

Adds `ignore` as a valid option for the `--gmock_verbose` command-line flag.

When set to `ignore`, GoogleMock suppresses informational messages and warnings, behaving similarly to `error`. This provides a way to run tests without warning output such as uninteresting mock function call messages.

Fixes #5047.

## Changes

- Added `kIgnoreVerbosity` constant.
- Updated `LogIsVisible()` to recognize `--gmock_verbose=ignore`.
- `ignore` suppresses informational messages and warnings.

## Verification

All 62 GoogleTest/GoogleMock tests pass with:

```text
ctest -C Debug --output-on-failure