### PR TITLE
Register googlemock Python tests with CTest

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -202,6 +202,11 @@ if (gmock_build_tests)
   ############################################################
   # Python tests.
 
+  # Python is found in googletest's directory scope, which does not propagate
+  # to this parent scope, and the imported Python3::Interpreter target used by
+  # py_test() is directory-scoped as well, so the search is repeated here.
+  find_package(Python3 COMPONENTS Interpreter QUIET)
+
   cxx_executable(gmock_leak_test_ test gmock_main)
   py_test(gmock_leak_test)
 


### PR DESCRIPTION
Closes #5070

## What changed

`googlemock/CMakeLists.txt` now calls `find_package(Python3 COMPONENTS Interpreter QUIET)` inside `if (gmock_build_tests)`, before the Python tests section. One statement plus a comment; no other file is touched.

## Why

`py_test()` is defined in `googletest/cmake/internal_utils.cmake` and is global, but the `Python3_Interpreter_FOUND` variable and the imported `Python3::Interpreter` target it depends on are both directory-scoped. googlemock adds googletest as a subdirectory, so those live in a child scope and are not visible where `py_test()` is called from. Every call from googlemock took the early return, and `gmock_leak_test` and `gmock_output_test` were never registered with CTest.

This is a regression of #4124. fd36851c8d383a2b711905eb488692da1152a3d8 fixed it in February 2023 by marking the interpreter variables `CACHE INTERNAL`, which made them global. 812f35b26b88ab1607a806b87539175591bba8c2 later replaced that code with `find_package(Python3)` and dropped the cache variables, restoring the original problem. Re-adding `CACHE INTERNAL` alone would not be enough today, because `py_test()` now runs the interpreter through the imported target rather than through a path variable, and imported targets are directory-scoped as well. Performing the search in googlemock's own scope creates both the variable and the target where they are needed.

Because `find_package` is `QUIET` and `py_test()` returns silently, there was no diagnostic for this in the configure output.

## Verification

All commands run on Ubuntu 22.04.3 (WSL2), g++ 11.4.0, cmake 3.22.1, Python 3.10.12, against upstream/main at 0daf775f8c9324e7d42582a09de1240805f25a54.

Before the change:

```
$ cmake -S . -B build -Dgtest_build_tests=ON -Dgmock_build_tests=ON
$ ctest --test-dir build -N | tail -1
Total Tests: 63
$ ctest --test-dir build -N | grep -E "gmock_leak_test|gmock_output_test"
$ make -j8 && ctest
100% tests passed, 0 tests failed out of 63
```

After the change:

```
$ ctest --test-dir build -N | tail -1
Total Tests: 65
$ ctest --test-dir build -N | grep -E "gmock_leak_test|gmock_output_test"
  Test #19: gmock_leak_test
  Test #20: gmock_output_test
$ make -j8 && ctest
100% tests passed, 0 tests failed out of 65
```

The two tests are executed, not merely registered, and both pass.

The `-Dgmock_build_tests=ON` invocation suggested in `CONTRIBUTING.md` is also fixed by this: it went from 18 registered tests to 20.

No formatting tools were run: the change is confined to a CMake file, and `.clang-format` does not apply to it.

## Known limitation

This puts `gmock_leak_test` and `gmock_output_test` back into the CMake CI configurations, which run `-Dgtest_build_tests=ON -Dgmock_build_tests=ON` followed by `ctest` on both Linux and MSVC. `gmock_output_test` compares program output against a golden file and has been sensitive to MSVC output differences in the past: 0a3b403f fixed it for MSVC on the same day fd36851c first enabled these tests, and 097f64e9 reverted that fix a week later. I have only been able to verify Linux and cannot check the MSVC behaviour of the golden comparison.

If re-enabling the tests in CI is not wanted at this point, I am happy to replace this with a `message(STATUS ...)` diagnostic instead, so that the silent skip at least becomes visible without changing which tests run. Please let me know which you prefer.

## Environment

- Ubuntu 22.04.3 LTS under WSL2
- g++ (Ubuntu 11.4.0-1ubuntu1~22.04.3) 11.4.0
- cmake version 3.22.1
- Python 3.10.12
