### PR TITLE
test: register fail-if-no-test-selected regression

### DIFF
--- a/googletest/test/BUILD.bazel
+++ b/googletest/test/BUILD.bazel
@@ -399,6 +399,17 @@ py_test(
     deps = [":gtest_test_utils"],
 )
 
+py_test(
+    name = "googletest-fail-if-no-test-selected-test",
+    size = "small",
+    srcs = ["googletest-fail-if-no-test-selected-test.py"],
+    data = [
+        ":googletest-fail-if-no-test-linked-test-with-disabled-test_",
+        ":googletest-fail-if-no-test-linked-test-with-enabled-test_",
+    ],
+    deps = [":gtest_test_utils"],
+)
+
 cc_binary(
     name = "googletest-shuffle-test_",
     srcs = ["googletest-shuffle-test_.cc"],


### PR DESCRIPTION
## Summary

Registers the existing `googletest-fail-if-no-test-selected-test.py` regression script in the Bazel test graph.

The target reuses the existing enabled- and disabled-test helper binaries already used by the related linked-test regression.

Related to #5078. This intentionally covers the Bazel registration only; it does not change CMake registration.

## Validation

- `python -m py_compile googletest/test/googletest-fail-if-no-test-selected-test.py`
- Verified the new target names the existing script and both existing helper binaries.
- `git diff --check`

Bazel is not installed on the validation host, so `bazel test //googletest/test:googletest-fail-if-no-test-selected-test` could not be run locally.