### PR TITLE
Register the fail_if_no_test_selected regression test in the Bazel build

### DIFF
--- a/googletest/test/BUILD.bazel
+++ b/googletest/test/BUILD.bazel
@@ -399,6 +399,17 @@ py_test(
     deps = [":gtest_test_utils"],
 )
 
+py_test(
+    name = "googletest-fail-if-no-test-selected-test",
+    size = "small",
+    srcs = ["googletest-fail-if-no-test-selected-test.py"],
+    data = [
+        ":googletest-fail-if-no-test-linked-test-with-disabled-test_",
+        ":googletest-fail-if-no-test-linked-test-with-enabled-test_",
+    ],
+    deps = [":gtest_test_utils"],
+)
+
 cc_binary(
     name = "googletest-shuffle-test_",
     srcs = ["googletest-shuffle-test_.cc"],


### PR DESCRIPTION
This adds the existing googletest-fail-if-no-test-selected-test.py to the Bazel test graph. The script was introduced together with the --gtest_fail_if_no_test_selected flag but was never registered, so the flag had no CI coverage. The new py_test reuses the same disabled/enabled helper binaries the linked-test already depends on, so no new C++ code is needed.

I ran the test locally against freshly built helper binaries and all three cases pass: success without the flag when only disabled tests exist, failure with the flag in that same scenario, and success with the flag when an enabled test runs.

CMake parity can be a follow-up -- neither this script nor the linked-test one is wired into CMakeLists.txt today.