### PR TITLE
Preserve UTF-8 strings in JSON output

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -4648,7 +4648,7 @@ std::string JsonUnitTestResultPrinter::EscapeJson(const std::string& str) {
         m << "\\r";
         break;
       default:
-        if (ch < ' ') {
+        if (static_cast<unsigned char>(ch) < ' ') {
           m << "\\u00" << String::FormatByte(static_cast<unsigned char>(ch));
         } else {
           m << ch;

--- a/googletest/test/googletest-json-output-unittest.py
+++ b/googletest/test/googletest-json-output-unittest.py
@@ -336,7 +336,7 @@ EXPECTED_NON_EMPTY = {
                     'time': '*',
                     'timestamp': '*',
                     'classname': 'PropertyRecordingTest',
-                    'key_1': '1',
+                    'key_1': 'caf\u00e9 \u4e2d',
                 },
                 {
                     'name': 'IntValuedProperty',
@@ -878,7 +878,7 @@ class GTestJsonOutputUnitTest(gtest_test_utils.TestCase):
           'the expected exit code %s.'
           % (command, p.exit_code, expected_exit_code),
       )
-    with open(json_path) as f:
+    with open(json_path, encoding='utf-8') as f:
       actual = json.load(f)
     return actual
 

--- a/googletest/test/gtest_xml_output_unittest.py
+++ b/googletest/test/gtest_xml_output_unittest.py
@@ -144,7 +144,7 @@ It is good practice to tell why you skip a test.
     </properties>
     <testcase name="OneProperty" file="gtest_xml_output_unittest_.cc" line="125" status="run" result="completed" time="*" timestamp="*" classname="PropertyRecordingTest">
       <properties>
-        <property name="key_1" value="1"/>
+        <property name="key_1" value="caf\u00e9 \u4e2d"/>
       </properties>
     </testcase>
     <testcase name="IntValuedProperty" file="gtest_xml_output_unittest_.cc" line="129" status="run" result="completed" time="*" timestamp="*" classname="PropertyRecordingTest">

--- a/googletest/test/gtest_xml_output_unittest_.cc
+++ b/googletest/test/gtest_xml_output_unittest_.cc
@@ -123,7 +123,7 @@ class PropertyRecordingTest : public Test {
 };
 
 TEST_F(PropertyRecordingTest, OneProperty) {
-  RecordProperty("key_1", "1");
+  RecordProperty("key_1", "caf\xC3\xA9 \xE4\xB8\xAD");
 }
 
 TEST_F(PropertyRecordingTest, IntValuedProperty) {


### PR DESCRIPTION
Fixes #5081.

`JsonUnitTestResultPrinter::EscapeJson` compared each byte as a signed `char` when deciding whether it was a JSON control character. On signed-`char` platforms, UTF-8 bytes above `0x7f` were therefore escaped independently as `\u00XX`, corrupting the decoded text.

Compare the byte as unsigned so valid UTF-8 passes through consistently on signed- and unsigned-`char` platforms. Add an end-to-end UTF-8 property regression for JSON and XML output, and decode the JSON result explicitly as UTF-8 in the Python test harness.

Tests:

- `cmake --build build --parallel 4`
- `ctest --test-dir build --output-on-failure --parallel 4` (63/63 passed)
- JSON and XML output tests in a separate `-funsigned-char` build (2/2 passed)
