### PR TITLE
Fix clang-tidy warning for MATCHER_P macro

### DIFF
--- a/googlemock/include/gmock/gmock-matchers.h
+++ b/googlemock/include/gmock/gmock-matchers.h
@@ -6010,6 +6010,7 @@ PolymorphicMatcher<internal::ExceptionMatcherImpl<Err>> ThrowsMessage(
       void DescribeNegationTo(::std::ostream* gmock_os) const override {       \
         *gmock_os << FormatDescription(true);                                  \
       }                                                                        \
+      /* NOLINTNEXTLINE(misc-non-private-member-variables-in-classes) */       \
       GMOCK_INTERNAL_MATCHER_MEMBERS(args)                                     \
                                                                                \
      private:                                                                  \


### PR DESCRIPTION
For `MATCHER_P(IsExpectedLogMessage, expected, "")` `clang-tidy` complains this way:

```
warning: member variable 'expected' has public visibility
[misc-non-private-member-variables-in-classes]
```