### PR TITLE
Reject empty values for integer flags

### DIFF
--- a/googletest/src/gtest-port.cc
+++ b/googletest/src/gtest-port.cc
@@ -1360,9 +1360,11 @@ bool ParseInt32(const Message& src_text, const char* str, int32_t* value) {
   char* end = nullptr;
   const long long_value = strtol(str, &end, 10);  // NOLINT
 
-  // Has strtol() consumed all characters in the string?
-  if (*end != '\0') {
-    // No - an invalid character was encountered.
+  // Has strtol() consumed at least one character and all characters in the
+  // string?
+  if (end == str || *end != '\0') {
+    // No - either no characters were consumed or an invalid character was
+    // encountered.
     Message msg;
     msg << "WARNING: " << src_text
         << " is expected to be a 32-bit integer, but actually"

--- a/googletest/test/gtest_unittest.cc
+++ b/googletest/test/gtest_unittest.cc
@@ -1773,10 +1773,12 @@ TEST(ParseInt32FlagTest, ReturnsDefaultWhenValueOverflows) {
   printf("(expecting 2 warnings)\n");
 
   int32_t value = 123;
-  EXPECT_FALSE(ParseFlag("--abc=12345678987654321", "abc", &value));
+  EXPECT_FALSE(ParseFlag("--" GTEST_FLAG_PREFIX_ "abc=12345678987654321", "abc",
+                         &value));
   EXPECT_EQ(123, value);
 
-  EXPECT_FALSE(ParseFlag("--abc=-12345678987654321", "abc", &value));
+  EXPECT_FALSE(ParseFlag("--" GTEST_FLAG_PREFIX_ "abc=-12345678987654321",
+                         "abc", &value));
   EXPECT_EQ(123, value);
 }
 
@@ -1787,10 +1789,20 @@ TEST(ParseInt32FlagTest, ReturnsDefaultWhenValueIsInvalid) {
   printf("(expecting 2 warnings)\n");
 
   int32_t value = 123;
-  EXPECT_FALSE(ParseFlag("--abc=A1", "abc", &value));
+  EXPECT_FALSE(ParseFlag("--" GTEST_FLAG_PREFIX_ "abc=A1", "abc", &value));
   EXPECT_EQ(123, value);
 
-  EXPECT_FALSE(ParseFlag("--abc=12X", "abc", &value));
+  EXPECT_FALSE(ParseFlag("--" GTEST_FLAG_PREFIX_ "abc=12X", "abc", &value));
+  EXPECT_EQ(123, value);
+}
+
+// Tests that ParseInt32Flag() rejects an empty value and doesn't change the
+// output value.
+TEST(ParseInt32FlagTest, RejectsEmptyValue) {
+  printf("(expecting 1 warning)\n");
+
+  int32_t value = 123;
+  EXPECT_FALSE(ParseFlag("--" GTEST_FLAG_PREFIX_ "abc=", "abc", &value));
   EXPECT_EQ(123, value);
 }
 


### PR DESCRIPTION
Fixes #5086.

`ParseInt32` checked whether `strtol` consumed the entire input, but not whether it consumed any input. As a result, empty integer flag values were accepted as zero. In the case of `--gtest_repeat=`, this silently caused the test executable to run zero iterations and exit successfully.

Require `strtol` to consume at least one character before accepting the conversion. Explicit zero values such as `--gtest_repeat=0` remain valid.

The existing overflow and invalid-value `ParseFlag` tests used `--abc=...` instead of the required `--gtest_abc=...`, so they returned before reaching `ParseInt32`. Correct those inputs and add a regression that verifies an empty value is rejected without changing the destination.

Tests:

- `cmake -S . -B build -Dgtest_build_tests=ON -Dgmock_build_tests=ON`
- `cmake --build build --parallel 4`
- `./build/googletest/gtest_unittest '--gtest_filter=ParseInt32FlagTest.*' --gtest_color=no` (5/5 passed)
- `ctest --test-dir build --output-on-failure --parallel 4` (63/63 passed)
- Empty `GTEST_REPEAT` end-to-end smoke test: warning emitted, default value 1 used, and the test ran successfully
- Targeted `clang-format --dry-run --Werror` checks for both modified regions
