### PR TITLE
Use ANSI colors for forced output without a Windows console

### DIFF
--- a/googletest/src/gtest.cc
+++ b/googletest/src/gtest.cc
@@ -3300,7 +3300,7 @@ static WORD GetNewColor(GTestColor color, WORD old_color_attrs) {
   return new_color;
 }
 
-#else
+#endif  // GTEST_OS_WINDOWS && !GTEST_OS_WINDOWS_MOBILE
 
 // Returns the ANSI color code for the given color. GTestColor::kDefault is
 // an invalid input.
@@ -3317,8 +3317,6 @@ static const char* GetAnsiColorCode(GTestColor color) {
       return "9";
   }
 }
-
-#endif  // GTEST_OS_WINDOWS && !GTEST_OS_WINDOWS_MOBILE
 
 // Returns true if and only if Google Test should use colors in the output.
 bool ShouldUseColor(bool stdout_is_tty) {
@@ -3358,10 +3356,9 @@ bool ShouldUseColor(bool stdout_is_tty) {
   // be conservative.
 }
 
-// Helpers for printing colored strings to stdout. Note that on Windows, we
-// cannot simply emit special characters and have the terminal change colors.
-// This routine must actually emit the characters rather than return a string
-// that would be colored when printed, as can be done on Linux.
+// Helpers for printing colored strings to stdout. On Windows, console
+// attributes are used when stdout is a console; ANSI escape sequences are
+// used when color is explicitly requested but stdout is redirected.
 
 GTEST_ATTRIBUTE_PRINTF_(2, 3)
 static void ColoredPrintf(GTestColor color, const char* fmt, ...) {
@@ -3388,7 +3385,16 @@ static void ColoredPrintf(GTestColor color, const char* fmt, ...) {
 
   // Gets the current text color.
   CONSOLE_SCREEN_BUFFER_INFO buffer_info;
-  GetConsoleScreenBufferInfo(stdout_handle, &buffer_info);
+  if (!GetConsoleScreenBufferInfo(stdout_handle, &buffer_info)) {
+    // When stdout is redirected, it may not have a console screen buffer. If
+    // color was explicitly requested, emit ANSI sequences instead.
+    const bool use_ansi_color = ShouldUseColor(false);
+    if (use_ansi_color) printf("\033[0;3%sm", GetAnsiColorCode(color));
+    vprintf(fmt, args);
+    if (use_ansi_color) printf("\033[m");
+    va_end(args);
+    return;
+  }
   const WORD old_color_attrs = buffer_info.wAttributes;
   const WORD new_color = GetNewColor(color, old_color_attrs);
 

--- a/googletest/test/googletest-output-test.py
+++ b/googletest/test/googletest-output-test.py
@@ -63,6 +63,7 @@ PROGRAM_PATH = gtest_test_utils.GetTestExecutablePath('googletest-output-test_')
 # 'internal_skip_environment_and_ad_hoc_tests' argument.
 COMMAND_LIST_TESTS = ({}, [PROGRAM_PATH, '--gtest_list_tests'])
 COMMAND_WITH_COLOR = ({}, [PROGRAM_PATH, '--gtest_color=yes'])
+COMMAND_WITH_COLOR_ENV = ({'GTEST_COLOR': 'yes'}, [PROGRAM_PATH])
 COMMAND_WITH_TIME = (
     {},
     [
@@ -282,6 +283,14 @@ CAN_GENERATE_GOLDEN_FILE = (
 
 
 class GTestOutputTest(gtest_test_utils.TestCase):
+
+  def testForcedColorWithCapturedStdout(self):
+    if not IS_WINDOWS:
+      return
+
+    for command in (COMMAND_WITH_COLOR, COMMAND_WITH_COLOR_ENV):
+      output = GetShellCommandOutput(command)
+      self.assertIn('\033[0;3', output)
 
   def RemoveUnsupportedTests(self, test_output):
     if not SUPPORTS_DEATH_TESTS:

--- a/googletest/test/googletest-output-test.py
+++ b/googletest/test/googletest-output-test.py
@@ -64,6 +64,8 @@ PROGRAM_PATH = gtest_test_utils.GetTestExecutablePath('googletest-output-test_')
 COMMAND_LIST_TESTS = ({}, [PROGRAM_PATH, '--gtest_list_tests'])
 COMMAND_WITH_COLOR = ({}, [PROGRAM_PATH, '--gtest_color=yes'])
 COMMAND_WITH_COLOR_ENV = ({'GTEST_COLOR': 'yes'}, [PROGRAM_PATH])
+COMMAND_WITH_AUTO_COLOR = ({}, [PROGRAM_PATH, '--gtest_color=auto'])
+COMMAND_WITH_NO_COLOR = ({}, [PROGRAM_PATH, '--gtest_color=no'])
 COMMAND_WITH_TIME = (
     {},
     [
@@ -291,6 +293,10 @@ class GTestOutputTest(gtest_test_utils.TestCase):
     for command in (COMMAND_WITH_COLOR, COMMAND_WITH_COLOR_ENV):
       output = GetShellCommandOutput(command)
       self.assertIn('\033[0;3', output)
+
+    for command in (COMMAND_WITH_AUTO_COLOR, COMMAND_WITH_NO_COLOR):
+      output = GetShellCommandOutput(command)
+      self.assertNotIn('\033[0;3', output)
 
   def RemoveUnsupportedTests(self, test_output):
     if not SUPPORTS_DEATH_TESTS:


### PR DESCRIPTION
Fixes #2930

## Summary

- Add a Windows regression test covering both `--gtest_color=yes` and `GTEST_COLOR=yes` when stdout is captured through a pipe.
- Fall back to ANSI color sequences only when color is explicitly forced and `GetConsoleScreenBufferInfo()` cannot use the stdout handle.
- Preserve the existing `auto` and `no` behavior and do not add a public `ansi` option.

## Validation

- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure` (45/45 passed on macOS)
- `git diff --check`
- Windows-specific regression is included for CI validation.

This change was prepared with AI assistance and reviewed against the repository contribution guidelines.