### PR TITLE
Avoid shadowing parameter in INSTANTIATE_TEST_SUITE_P

### DIFF
--- a/googletest/include/gtest/gtest-param-test.h
+++ b/googletest/include/gtest/gtest-param-test.h
@@ -556,7 +556,8 @@ auto ConvertGenerator(Gen&& gen, Func&& f) {
     return GTEST_EXPAND_(GTEST_GET_FIRST_(__VA_ARGS__, DUMMY_PARAM_));        \
   }                                                                           \
   static ::std::string gtest_##prefix##test_suite_name##_EvalGenerateName_(   \
-      const ::testing::TestParamInfo<test_suite_name::ParamType>& info) {     \
+      const ::testing::TestParamInfo<test_suite_name::ParamType>&             \
+          test_param_info) {                                                  \
     if (::testing::internal::AlwaysFalse()) {                                 \
       ::testing::internal::TestNotEmpty(GTEST_EXPAND_(GTEST_GET_SECOND_(      \
           __VA_ARGS__,                                                        \
@@ -569,7 +570,7 @@ auto ConvertGenerator(Gen&& gen, Func&& f) {
     return ((GTEST_EXPAND_(GTEST_GET_SECOND_(                                 \
         __VA_ARGS__,                                                          \
         ::testing::internal::DefaultParamName<test_suite_name::ParamType>,    \
-        DUMMY_PARAM_))))(info);                                               \
+        DUMMY_PARAM_))))(test_param_info);                                     \
   }                                                                           \
   [[maybe_unused]] static int gtest_##prefix##test_suite_name##_dummy_ =      \
       ::testing::UnitTest::GetInstance()                                      \

--- a/googletest/test/googletest-param-test-test.cc
+++ b/googletest/test/googletest-param-test-test.cc
@@ -1020,8 +1020,8 @@ TEST_P(CustomLambdaNamingTest, CustomTestNames) {}
 
 INSTANTIATE_TEST_SUITE_P(CustomParamNameLambda, CustomLambdaNamingTest,
                          Values(std::string("LambdaName")),
-                         [](const ::testing::TestParamInfo<std::string>& inf) {
-                           return inf.param;
+                         [](const ::testing::TestParamInfo<std::string>& info) {
+                           return info.param;
                          });
 
 TEST(CustomNamingTest, CheckNameRegistry) {


### PR DESCRIPTION
Fixes #4776\n\nWhen INSTANTIATE_TEST_SUITE_P expands a custom name generator, the generated EvalGenerateName_ function previously used the parameter name info. A name-generator lambda commonly uses info too, and GCC -Wshadow=compatible-local diagnoses the nested lambda parameter.\n\nRename the generated parameter to test_param_info and update the call site. This does not change the public API or runtime behavior.\n\nTests:\n- cmake --build build -j2\n- ctest --test-dir build --output-on-failure (63/63 passed)\n- Minimal custom-name-generator example compiled with Clang -Wshadow -Werror=shadow\n\nThe exact GCC diagnostic was not available locally because the installed g++ is Apple Clang.