### PR TITLE
Register fail_if_no_test_selected and linked tests in CMake and Bazel

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -315,4 +315,20 @@ if (gtest_build_tests)
   cxx_executable(gtest_xml_output_unittest_ test gtest)
   py_test(gtest_xml_output_unittest --no_stacktrace_support)
   py_test(googletest-json-output-unittest --no_stacktrace_support)
+
+  cxx_executable_with_flags(
+    googletest-fail-if-no-test-linked-test-without-test_
+    "${cxx_default}"
+    gtest_main
+    src/gtest_main.cc)
+  cxx_executable(
+    googletest-fail-if-no-test-linked-test-with-disabled-test_
+    test
+    gtest_main)
+  cxx_executable(
+    googletest-fail-if-no-test-linked-test-with-enabled-test_
+    test
+    gtest_main)
+  py_test(googletest-fail-if-no-test-linked-test)
+  py_test(googletest-fail-if-no-test-selected-test)
 endif()

--- a/googletest/test/BUILD.bazel
+++ b/googletest/test/BUILD.bazel
@@ -399,6 +399,17 @@ py_test(
     deps = [":gtest_test_utils"],
 )
 
+py_test(
+    name = "googletest-fail-if-no-test-selected-test",
+    size = "small",
+    srcs = ["googletest-fail-if-no-test-selected-test.py"],
+    data = [
+        ":googletest-fail-if-no-test-linked-test-with-disabled-test_",
+        ":googletest-fail-if-no-test-linked-test-with-enabled-test_",
+    ],
+    deps = [":gtest_test_utils"],
+)
+
 cc_binary(
     name = "googletest-shuffle-test_",
     srcs = ["googletest-shuffle-test_.cc"],


### PR DESCRIPTION
Fixes #5078

### Description
The test `googletest-fail-if-no-test-selected-test.py` was introduced to test the behavior when no tests are selected, but was not registered in either the Bazel test graph or CMake. Additionally, CMake was missing the registration for the helper executables and `googletest-fail-if-no-test-linked-test`.

### Changes
1. **`googletest/test/BUILD.bazel`**: Registered `googletest-fail-if-no-test-selected-test` as `py_test` using `gtest_test_utils` and referencing its helper binaries.
2. **`googletest/CMakeLists.txt`**: Registered helper executables (`googletest-fail-if-no-test-linked-test-without-test_`, `googletest-fail-if-no-test-linked-test-with-disabled-test_`, and `googletest-fail-if-no-test-linked-test-with-enabled-test_`) and registered both `googletest-fail-if-no-test-linked-test` and `googletest-fail-if-no-test-selected-test` under `gtest_build_tests`.
