### PR TITLE
cmake: bundle gmock/gtest sources into gmock_main for Clang MSVC ABI

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -82,7 +82,7 @@ include_directories(${gmock_build_include_dirs})
 # Google Mock libraries. We build them using more strict warnings than what
 # are used for other targets, to ensure that Google Mock can be compiled by
 # a user aggressive about warnings.
-if (MSVC)
+if (MSVC OR CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")
   cxx_library(gmock
               "${cxx_strict}"
               "${gtest_dir}/src/gtest-all.cc"
@@ -165,7 +165,7 @@ if (gmock_build_tests)
   ############################################################
   # C++ tests built with non-standard compiler flags.
 
-  if (MSVC)
+  if (MSVC OR CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")
     cxx_library(gmock_main_no_exception "${cxx_no_exception}"
       "${gtest_dir}/src/gtest-all.cc" src/gmock-all.cc src/gmock_main.cc)
 


### PR DESCRIPTION
Fixes #4813

### Description
When compiling GoogleTest with `BUILD_SHARED_LIBS=ON` on Windows using Clang (`clang++`) targeting MSVC (`-target x86_64-pc-windows-msvc`), `gmock_main.dll` fails to link with:
```
lld-link: error: undefined symbol: class testing::internal::Mutex testing::internal::g_gmock_mutex
```

### Root Cause
CMake's `MSVC` variable is only set to true when the compiler frontend is MSVC-compatible (`cl.exe` or `clang-cl.exe`). When invoking `clang++` directly on Windows, `CMAKE_CXX_SIMULATE_ID` is set to `"MSVC"`, but `MSVC` is false.
As a result, CMake selected the `else()` branch in `googlemock/CMakeLists.txt`, which only compiles `src/gmock_main.cc` into `gmock_main.dll`. Because `gmock_main` is built as its own DLL, `GTEST_API_` expands to `__declspec(dllexport)` in `gmock_main.cc.obj`, causing `lld-link` to report an undefined export for `g_gmock_mutex`.

### Solution
Updated the conditions in `googlemock/CMakeLists.txt` to `if (MSVC OR CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")`, ensuring that Clang targeting the MSVC ABI bundles `gmock-all.cc` and `gtest-all.cc` into `gmock_main` consistently with MSVC and `clang-cl`.
